### PR TITLE
docs: add CodeSignal Interview research

### DIFF
--- a/docs/竞品分析/codesignal-interview.md
+++ b/docs/竞品分析/codesignal-interview.md
@@ -1,0 +1,254 @@
+# CodeSignal Interview 云 IDE 与 Coding Replay 调研
+
+调研日期：2026-05-22
+
+## 一、结论摘要
+
+CodeSignal Interview 是面向远程技术面试的云 IDE 平台，核心体验是候选人和面试官在同一个浏览器 IDE 中实时写代码、运行、测试、调试、通话和协作。它的 coding replay 会记录候选人在直播面试中的键盘输入和 IDE 活动；如果面试中使用 Terminal，terminal session 也会随 coding session 一起进入回放。官方明确说明，CodeSignal 内置音视频聊天不会被 coding replay 捕获。
+
+对 code-tape 来说，CodeSignal 最值得借鉴的不是完整招聘流程，而是三件事：
+
+1. 代码编辑事件、运行/终端事件和评审上下文应分层建模。
+2. 回放默认可以跳过候选人未活跃编码的片段，说明“活动索引”比单纯线性时间轴更适合复盘。
+3. replay 的分享和权限控制属于 P1 回放中心能力，不应压进 P0。
+
+建议本项目 P0 不录制终端事件。P0 应先稳定完成编辑器内容、光标选区、鼠标、快捷键、音视频和运行结果快照；终端事件会把事件模型扩大到命令输入、stdout/stderr 流、文件系统同步、进程状态和安全边界，适合在 P1 结合 WebContainers 或后端沙箱再做。
+
+## 二、官方资料
+
+- CodeSignal Interview 产品页（Issue 原链接会重定向到当前页面）：https://codesignal.com/live-tech-interviews/
+- Searching, reviewing, and sharing a candidate's interview coding replay：https://support.codesignal.com/hc/en-us/articles/360045986373-Searching-reviewing-and-sharing-a-candidate-s-interview-coding-replay
+- Using Terminal in your interview session：https://support.codesignal.com/hc/en-us/articles/360052367154-Using-Terminal-in-your-interview-session
+- Quick Start Guide: Interview：https://support.codesignal.com/hc/en-us/articles/22112352841879-Quick-Start-Guide-Interview
+- Conducting an interview in CodeSignal：https://support.codesignal.com/hc/en-us/articles/360045985453-Conducting-an-interview-in-CodeSignal
+- Being Interviewed in CodeSignal：https://support.codesignal.com/hc/en-us/articles/360045986753-Being-Interviewed-in-CodeSignal
+- Which question types are supported in CodeSignal Interview：https://support.codesignal.com/hc/en-us/articles/360045427374-Which-question-types-are-supported-in-CodeSignal-Interview
+- What languages are supported in CodeSignal Interview：https://support.codesignal.com/hc/en-us/articles/360061267734-What-languages-are-supported-in-CodeSignal-Interview
+- What is the CodeSignal Cloud IDE / Coding Environment：https://support.codesignal.com/hc/en-us/articles/360039872914-What-is-the-CodeSignal-Cloud-IDE-Coding-Environment
+- Creating a progressive free coding question：https://support.codesignal.com/hc/en-us/articles/8057191163287-Creating-a-progressive-free-coding-question
+
+## 三、产品定位、目标用户和核心流程
+
+### 产品定位
+
+CodeSignal Interview 定位为远程技术面试平台。官方产品页强调它是一个带云 IDE、视频、音频、聊天、白板、题库和模板的协作式 live tech interview 工具；Quick Start 文档则强调候选人写的是可编译的真实代码，并且可以展示 Linux 命令行、源码管理等更贴近真实开发的能力。
+
+### 目标用户
+
+- 招聘团队和面试官：用结构化模板、题库、云 IDE 和回放复盘候选人表现。
+- 候选人：在浏览器中完成真实编码、运行、调试和沟通。
+- Hiring manager / 评审同事：在面试结束后通过 replay、报告、反馈和分享链接复核面试。
+- 内容维护者：创建题目、模板、progressive questions、free-coding 或 advanced assessment 问题。
+
+### 核心面试流程
+
+1. 招聘方创建 interview session 或使用 interview template。
+2. 候选人通过链接进入，会选择 candidate / interviewer 身份并进入面试。
+3. 面试官选择题目，候选人在云 IDE 中写代码、运行、测试、调试。
+4. 如题型支持，候选人和面试官可以使用 Terminal、文件系统、前端预览或高级框架环境。
+5. 面试结束后点击 finish interview，系统生成详细 interview report 和每道题的 coding replay。
+6. 有权限的同事可以搜索、查看、分享 replay，并结合 feedback 完成人工评审。
+
+## 四、云 IDE 能力
+
+| 能力 | CodeSignal 表现 | 对 code-tape 的启发 |
+| --- | --- | --- |
+| 多语言 | 产品页写到 70+ coding languages；Interview 语言 FAQ 写到支持 45 种常用语言。两者口径可能随产品范围和更新时间不同，本文只采纳“多语言云 IDE”这个稳定结论 | P0 只需 JS/TS；多语言更适合 P1/P1+ |
+| 运行和测试 | Cloud IDE 文档说明可运行 sample test cases，提交后跑完整测试集；产品页强调可 run/test/debug | P0 应至少保存运行结果快照，避免回放时强制重跑 |
+| 终端 | Terminal 文档说明终端连接 CodeSignal IDE，可运行 shell、安装软件、运行调试器、启动服务、写文件 | 终端属于强能力，但也是事件模型和安全边界的扩展点 |
+| 文件系统 | Quick Start 写到 filesystem question 支持层级文件系统，Terminal 文档说明 Advanced Assessment 中终端改文件会同步到 filesystem | 若 P1 支持项目级讲解，应建模文件树和文件 diff |
+| 前端预览 | Quick Start 写到 Frontend 题型支持 full markup 和 live previewing | code-tape P0 可优先参考 iframe preview |
+| 协作 | 产品页强调 collaborative IDE，候选人和面试官实时协作；Interview 流程中可结合 video/audio/chat/whiteboard | code-tape P0 是录制回放工具，不应先做实时协作 |
+| 题型模板 | Interview 支持 frontend、database、DevOps、single-function、filesystem、free-coding、progressive、advanced assessment 等题型 | 本项目不需要题库平台，但可借鉴按场景选择运行环境 |
+| IDE 个性化 | Candidate 文档提到可调语言、IDE theme、editor type、formatting settings | P0 编辑器可保留语言、主题、字号等 meta 字段 |
+
+## 五、Coding Replay 与 Terminal Session Replay
+
+### Coding replay 记录范围
+
+CodeSignal 的 replay 文档说明，live interview 结束后可以查看候选人的 coding session replay。记录会展示候选人在 live interview 中的 key strokes 和 activity；评审者可以从每道题旁边的 play button 进入 solution replay。
+
+可参考点：
+
+- 回放以“题目/solution”为单位组织，不只是一条全局视频。
+- 记录重点是键盘输入和 IDE 活动，而不是录屏像素。
+- 回放可按 real-time 方式播放，并支持加速到很高倍速。
+- 默认跳过候选人没有 active coding 的片段，降低评审噪音。
+- 默认跟随候选人光标，评审者也可以取消 cursor following。
+- Activity Indicator 用于观察候选人离开 IDE 的频率。
+- 音视频聊天不进入 coding replay，说明代码轨道和媒体聊天轨道是分离的。
+
+对 code-tape 的映射：
+
+| CodeSignal replay 能力 | code-tape 可借鉴设计 |
+| --- | --- |
+| key strokes / activity | 采集 `content-change`、`selection-change`、`shortcut`、`mouse-move` 等操作事件 |
+| 每题 solution replay | P1 可按章节/片段/题目组织回放 |
+| skip inactive portions | P1 可做“跳过静默段/无操作段” |
+| follow cursor / unfollow | P0 回放可默认展示讲解者光标；P1 支持关闭跟随 |
+| activity indicator | P1 可做活动密度时间轴，例如编辑、运行、停顿、离开焦点 |
+| 不捕获内置音视频 | code-tape 与之相反，P0 需要音视频讲解轨道；但应保持媒体轨道与代码事件轨道分离 |
+
+### Terminal session replay 记录范围
+
+Terminal 文档说明，终端连接 CodeSignal IDE，面试中可运行 shell、安装软件、运行代码和调试器、启动服务、写文件；terminal session 会和 candidate coding session 一起被记录，便于团队成员事后回看。
+
+可参考点：
+
+- 终端事件不是孤立能力，它要和 IDE 文件系统同步。
+- 终端支持多实例，Advanced Assessment 支持添加多个 terminal。
+- 终端布局可调整，说明 UI 状态也是复盘上下文的一部分。
+- 终端输出对评审很重要，因为它体现候选人如何运行命令、排错和验证。
+
+对 code-tape 的映射：
+
+| 终端能力 | 如果未来进入 code-tape，需要记录 |
+| --- | --- |
+| 命令输入 | `terminal-input`，包含 terminalId、command、timestamp |
+| stdout/stderr | `terminal-output`，按流式 chunk 记录，避免单条事件过大 |
+| 进程状态 | `terminal-process`，记录 start、exit、exitCode、duration |
+| 文件系统同步 | `file-change`，记录路径、操作、内容快照或 diff |
+| 多终端 | terminalId、activeTerminalId、layout |
+| 服务启动 | `server-ready` 或 `preview-url`，关联运行预览 |
+
+## 六、对本项目 P0 是否需要终端事件的建议
+
+### 建议：P0 不做终端事件
+
+P0 不应把 terminal session 作为必做范围。理由如下：
+
+- 当前 PRD（`docs/PRD/26飞书工程训练营-前端组-实现一个代码讲解工具.md`）和技术拆解（`docs/技术模块拆解.md`）里的 P0 主链路是编辑器操作录制、音视频录制、总控打包和回放。
+- 终端事件会引入命令、流式输出、进程生命周期、文件系统同步和安全边界。
+- 若没有 WebContainers 或后端沙箱，终端本身很难可靠实现。
+- 回放终端不只是展示文本，还要处理 seek 后“终端屏幕状态”的恢复。
+- 对教学 Demo 来说，P0 的演示价值主要来自代码编辑过程、讲解音频/视频和运行结果，而不是完整 shell。
+
+### P0 应预留的最小扩展点
+
+虽然不做终端，事件结构可以预留 `source` 和 `runtime`：
+
+```json
+{
+  "type": "run-output",
+  "timestamp": 42000,
+  "source": "runtime",
+  "payload": {
+    "runtime": "iframe",
+    "command": "preview",
+    "stdout": ["hello"],
+    "stderr": [],
+    "status": "success"
+  }
+}
+```
+
+未来进入终端能力时，可以扩展为：
+
+```json
+{
+  "type": "terminal-output",
+  "timestamp": 52000,
+  "source": "terminal",
+  "payload": {
+    "terminalId": "term_1",
+    "stream": "stdout",
+    "chunk": "npm run dev\\n",
+    "sequence": 17
+  }
+}
+```
+
+### P1 进入条件
+
+只有满足以下条件时，才建议进入 P1：
+
+1. 已有稳定的 iframe preview 或 WebContainers / 后端沙箱 PoC。
+2. 已确定文件系统模型，例如单文件、多文件、项目树。
+3. 回放模块已支持快照 + 增量事件，能恢复任意 seek 点状态。
+4. 明确终端输出是否进入录制包，以及是否可能包含隐私或 token。
+
+## 七、对事件结构的启发
+
+CodeSignal 的 replay 不是单一视频，而是面向评审的活动时间线。code-tape 可以将事件分成四层：
+
+| 事件层 | P0/P1 | 示例事件 | 说明 |
+| --- | --- | --- | --- |
+| 编辑器层 | P0 | `content-change`、`selection-change`、`shortcut` | 还原讲解者写代码的主轨道 |
+| 展示层 | P0 | `mouse-move`、`camera-position`、`annotation` | 帮助观看者理解讲解焦点 |
+| 运行层 | P0/P1 | `run-start`、`run-output`、`run-error` | P0 可先做运行结果快照 |
+| 终端层 | P1 | `terminal-input`、`terminal-output`、`terminal-process` | 等沙箱能力稳定后进入 |
+| 评审层 | P1 | `comment`、`chapter-marker`、`activity-marker` | 支持检索、分享、复盘 |
+
+建议 P0 事件 envelope 保持通用：
+
+```json
+{
+  "id": "evt_00042",
+  "type": "content-change",
+  "timestamp": 12345,
+  "source": "editor",
+  "payload": {},
+  "track": "main"
+}
+```
+
+其中：
+
+- `source` 用于区分 editor、runtime、terminal、media、review。
+- `track` 用于区分讲解主轨、运行输出轨、终端轨、评审批注轨。
+- `timestamp` 统一使用录制总控的有效时间，暂停期间不累积。
+
+## 八、对回放检索、分享和权限的 P1 建议
+
+CodeSignal 支持在 Completed interviews 中搜索候选人姓名或邮箱，也能按 Interviewer / Author 过滤；评审者可以进入详细报告，按题查看 replay，并把 session URL 分享给具备 Manager 或 Admin 权限的同事。
+
+对 code-tape，P1 回放中心建议做：
+
+| 能力 | P1 建议 | 不进 P0 的原因 |
+| --- | --- | --- |
+| 回放列表 | 展示标题、时长、创建时间、语言、是否有运行结果 | P0 可先本地保存/播放单条录制 |
+| 搜索 | 按标题、语言、创建者、关键章节搜索 | 需要云端元数据和索引 |
+| 过滤 | 按创建者、标签、录制类型、是否含运行结果过滤 | 依赖回放中心信息架构 |
+| 章节/题目级 replay | 把长讲解拆成章节或题目片段 | P0 先保证单条时间线稳定 |
+| 活动密度时间轴 | 标记编辑、运行、静默、错误、快捷键密集区 | 需要事件索引和可视化 |
+| 分享链接 | 支持 `?t=12345` 或 `?chapter=xxx` 定位到时间点 | 需要持久化和路由设计 |
+| 权限 | 录制创建者、可查看者、可评论者 | 涉及账号体系和后端权限 |
+| 评审评论 | 在时间点或事件上评论 | P1/P1+，不阻塞 P0 录制回放 |
+
+P1 最小可交付建议：
+
+1. 回放列表页：按录制时间倒序展示录制包。
+2. 详情页 URL 支持时间点参数，例如 `/replays/:id?t=42000`。
+3. 播放器加载后自动 seek 到指定时间点。
+4. 生成活动索引：内容变化、运行、错误、快捷键。
+5. 支持复制分享链接。
+
+## 九、与 code-tape 的边界
+
+| CodeSignal 能力 | 是否建议借鉴 | 边界说明 |
+| --- | --- | --- |
+| 云 IDE 多语言运行 | 部分借鉴 | P0 只做 JS/TS 或前端展示，多语言延后 |
+| coding replay | 强借鉴 | 事件录制、活动索引、光标跟随都很贴近本项目 |
+| terminal session replay | P1 借鉴 | P0 不做终端事件，只预留事件层 |
+| 面试模板和题库 | 暂不借鉴 | code-tape 是代码讲解工具，不是招聘平台 |
+| feedback / 评审流程 | P1 借鉴 | 可转化为讲解批注和团队评论 |
+| 候选人离开 IDE 活动指标 | 可选借鉴 | 本项目可转为“讲解活动密度”，不做监控语义 |
+| 权限化分享 | P1 借鉴 | 需要云端回放中心和账号体系 |
+
+## 十、推荐方案
+
+1. P0 只录制编辑器事件、鼠标、快捷键、音视频和运行结果快照，不录制终端。
+2. 事件模型预留 `source`、`track` 和运行/终端扩展类型。
+3. 回放模块先保证 seek 后编辑器状态、运行结果和媒体轨道一致。
+4. P1 增加活动索引：编辑密集段、运行点、错误点、静默段。
+5. P1 回放中心支持搜索、过滤、时间点分享和权限化查看。
+6. P1/P1+ 再评估终端事件，前提是 WebContainers 或后端沙箱路线已经确定。
+
+## 十一、验收标准映射
+
+| Issue 验收项 | 本文对应位置 |
+| --- | --- |
+| 至少引用 1 个 CodeSignal 官方资料链接 | “二、官方资料”列出多条官方链接 |
+| 明确 coding replay 和 terminal session replay 可参考的点 | “五、Coding Replay 与 Terminal Session Replay” |
+| 输出对本项目 P0 是否需要终端事件的建议 | “六、对本项目 P0 是否需要终端事件的建议” |
+| 给出对回放检索/分享能力的 P1 建议 | “八、对回放检索、分享和权限的 P1 建议” |


### PR DESCRIPTION
## Summary

- Added CodeSignal Interview competitive research under `docs/竞品分析/codesignal-interview.md`.
- Summarized cloud IDE capabilities, coding replay, terminal session replay, and review/share workflows from official CodeSignal sources.
- Recommended that P0 should not include terminal events, while reserving event model extensions for P1.
- Proposed P1 replay search, filtering, activity indexing, time-point sharing, and permissions directions.

## Validation

- `npm test`
- `git diff --check origin/main...HEAD`
- Confirmed PR diff only contains `docs/竞品分析/codesignal-interview.md`.
- Reviewed official CodeSignal sources. Note: CodeSignal support pages are behind Cloudflare challenge for terminal checks; the product URL redirects successfully to `https://codesignal.com/live-tech-interviews/`.

Closes #8