### PR TITLE
[P0] Monaco CodeEditor 基础集成

### DIFF
--- a/apps/web/e2e/scaffold.spec.ts
+++ b/apps/web/e2e/scaffold.spec.ts
@@ -1,17 +1,25 @@
 import { expect, test } from "@playwright/test";
 
-test("scaffold routes are explicit and do not allow fake recording success", async ({ page }) => {
+test("recorder route renders Monaco while scaffold controls stay disabled", async ({ page }) => {
+  const runtimeErrors: string[] = [];
+  page.on("console", (message) => {
+    if (message.type() === "error") runtimeErrors.push(message.text());
+  });
+  page.on("pageerror", (error) => runtimeErrors.push(error.message));
+
   await page.goto("/", { waitUntil: "domcontentloaded" });
   await expect(page.getByRole("heading", { name: "我的录制" })).toBeVisible();
 
   await page.getByRole("link", { name: "新建录制" }).click();
-  await expect(page.getByText(/CodeEditor scaffold/)).toBeVisible();
+  await expect(page.locator("[data-code-editor] .monaco-editor")).toBeVisible();
+  await expect(page.getByText(/CodeEditor scaffold/)).toHaveCount(0);
   await expect(page.getByText(/RecorderControls scaffold/)).toBeVisible();
   await expect(page.getByRole("button", { name: "开始录制" })).toBeDisabled();
   await expect(page.getByRole("button", { name: "运行代码" })).toBeDisabled();
 
   await page.getByRole("button", { name: /Dark|Light/ }).click();
   await expect(page.locator("html")).toHaveAttribute("data-theme", /light|dark/);
+  expect(runtimeErrors.filter((message) => /monaco|worker/i.test(message))).toEqual([]);
 });
 
 test("missing replay id shows an explicit load error", async ({ page }) => {

--- a/apps/web/src/features/editor/CodeEditor.tsx
+++ b/apps/web/src/features/editor/CodeEditor.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, useEffect, useImperativeHandle, useRef } from "react";
+import { forwardRef, useEffect, useImperativeHandle, useRef, useState } from "react";
 import type * as Monaco from "monaco-editor/esm/vs/editor/editor.api";
 import type { RecordingLanguage } from "@/shared/recording-schema";
 
@@ -31,6 +31,7 @@ type MonacoEnvironmentHost = typeof globalThis & {
 let workerPromise: Promise<WorkerConstructors> | null = null;
 let monacoPromise: Promise<MonacoModule> | null = null;
 let themesDefined = false;
+let workersConfigured = false;
 
 function monacoTheme(theme: CodeEditorProps["theme"]): MonacoTheme {
   return theme === "dark" ? "code-tape-dark" : "code-tape-light";
@@ -40,14 +41,20 @@ function loadWorkers() {
   workerPromise ??= Promise.all([
     import("monaco-editor/esm/vs/editor/editor.worker?worker"),
     import("monaco-editor/esm/vs/language/typescript/ts.worker?worker"),
-  ]).then(([editorWorker, tsWorker]) => ({
-    editor: editorWorker.default,
-    typescript: tsWorker.default,
-  }));
+  ])
+    .then(([editorWorker, tsWorker]) => ({
+      editor: editorWorker.default,
+      typescript: tsWorker.default,
+    }))
+    .catch((error: unknown) => {
+      workerPromise = null;
+      throw error;
+    });
   return workerPromise;
 }
 
 function configureWorkers(workers: WorkerConstructors) {
+  if (workersConfigured) return;
   (globalThis as MonacoEnvironmentHost).MonacoEnvironment = {
     getWorker(_workerId, label) {
       if (label === "javascript" || label === "typescript") {
@@ -56,6 +63,7 @@ function configureWorkers(workers: WorkerConstructors) {
       return new workers.editor();
     },
   };
+  workersConfigured = true;
 }
 
 function defineThemes(monaco: MonacoModule) {
@@ -107,7 +115,10 @@ async function loadMonaco() {
     ]);
     defineThemes(monaco);
     return monaco;
-  })();
+  })().catch((error: unknown) => {
+    monacoPromise = null;
+    throw error;
+  });
   return monacoPromise;
 }
 
@@ -122,6 +133,7 @@ export const CodeEditor = forwardRef<CodeEditorHandle, CodeEditorProps>(function
   const initialValueRef = useRef(initialValue);
   const latestPropsRef = useRef({ language, fontSize, theme });
   const onMountRef = useRef(onMount);
+  const [loadError, setLoadError] = useState<unknown>(null);
 
   latestPropsRef.current = { language, fontSize, theme };
   onMountRef.current = onMount;
@@ -136,6 +148,7 @@ export const CodeEditor = forwardRef<CodeEditorHandle, CodeEditorProps>(function
     void loadMonaco()
       .then((monaco) => {
         if (cancelled) return;
+        setLoadError(null);
         const currentProps = latestPropsRef.current;
         const model = monaco.editor.createModel(initialValueRef.current, currentProps.language);
         const editor = monaco.editor.create(host, {
@@ -155,6 +168,7 @@ export const CodeEditor = forwardRef<CodeEditorHandle, CodeEditorProps>(function
       })
       .catch((error: unknown) => {
         if (!cancelled) {
+          setLoadError(error);
           console.error("Failed to initialize Monaco editor", error);
         }
       });
@@ -187,11 +201,16 @@ export const CodeEditor = forwardRef<CodeEditorHandle, CodeEditorProps>(function
   }, [theme]);
 
   return (
-    <div
-      ref={hostRef}
-      aria-label="Code editor"
-      className="relative h-full min-h-[320px] w-full bg-surface"
-      data-code-editor
-    />
+    <div className="relative h-full min-h-[320px] w-full bg-surface" data-code-editor>
+      <div ref={hostRef} aria-label="Code editor" className="h-full min-h-[320px] w-full" />
+      {loadError ? (
+        <div className="absolute inset-0 flex items-center justify-center bg-surface/90 p-4" role="alert">
+          <div className="max-w-sm rounded-md border border-border bg-surface-raised px-4 py-3 shadow-elevation-2">
+            <p className="text-sm font-medium text-foreground">Code editor failed to load.</p>
+            <p className="mt-1 text-xs text-muted">Refresh the page or reopen this view to retry.</p>
+          </div>
+        </div>
+      ) : null}
+    </div>
   );
 });

--- a/apps/web/src/features/editor/CodeEditor.tsx
+++ b/apps/web/src/features/editor/CodeEditor.tsx
@@ -1,10 +1,10 @@
-import { forwardRef, useImperativeHandle, useRef } from "react";
-import type { editor as MonacoEditor } from "monaco-editor";
+import { forwardRef, useEffect, useImperativeHandle, useRef } from "react";
+import type * as Monaco from "monaco-editor/esm/vs/editor/editor.api";
 import type { RecordingLanguage } from "@/shared/recording-schema";
 
 export type CodeEditorHandle = {
   /** Lazy accessor — null until the editor has mounted. */
-  getEditor(): MonacoEditor.IStandaloneCodeEditor | null;
+  getEditor(): Monaco.editor.IStandaloneCodeEditor | null;
 };
 
 export type CodeEditorProps = {
@@ -12,37 +12,186 @@ export type CodeEditorProps = {
   initialValue: string;
   fontSize: number;
   theme: "light" | "dark";
-  onMount?(editor: MonacoEditor.IStandaloneCodeEditor): void;
+  onMount?(editor: Monaco.editor.IStandaloneCodeEditor): void;
 };
 
-/**
- * CodeEditor — Monaco editor host + theme bridge.
- *
- * STUB. Real implementation belongs to issue `[P0] CodeEditor 组件接入 Monaco`.
- *
- * 实装要点：
- *   - 用 monaco-editor 直接 import（不用 @monaco-editor/react，保持依赖最小）
- *   - 在 effect 内 monaco.editor.create(host, { value, language, fontSize, theme })
- *   - props.language / fontSize / theme 改变 → 调对应 setter
- *   - props.initialValue 仅首次写入，后续禁止覆盖（避免回放外部 setValue 触发循环）
- *   - onMount 回调暴露 editor 实例给 EditorProducer.getEditor()
- *   - 暗主题用 "vs-dark"，浅主题用 "vs"；并通过 monaco.editor.defineTheme 注册
- *     一个与 tokens.css 对齐的自定义主题（issue 内细化）
- *   - cleanup 时 editor.dispose()
- */
+type MonacoModule = typeof Monaco;
+type MonacoTheme = "code-tape-light" | "code-tape-dark";
+type WorkerConstructor = new () => Worker;
+type WorkerConstructors = {
+  editor: WorkerConstructor;
+  typescript: WorkerConstructor;
+};
+type MonacoEnvironmentHost = typeof globalThis & {
+  MonacoEnvironment?: {
+    getWorker(workerId: string, label: string): Worker;
+  };
+};
+
+let workerPromise: Promise<WorkerConstructors> | null = null;
+let monacoPromise: Promise<MonacoModule> | null = null;
+let themesDefined = false;
+
+function monacoTheme(theme: CodeEditorProps["theme"]): MonacoTheme {
+  return theme === "dark" ? "code-tape-dark" : "code-tape-light";
+}
+
+function loadWorkers() {
+  workerPromise ??= Promise.all([
+    import("monaco-editor/esm/vs/editor/editor.worker?worker"),
+    import("monaco-editor/esm/vs/language/typescript/ts.worker?worker"),
+  ]).then(([editorWorker, tsWorker]) => ({
+    editor: editorWorker.default,
+    typescript: tsWorker.default,
+  }));
+  return workerPromise;
+}
+
+function configureWorkers(workers: WorkerConstructors) {
+  (globalThis as MonacoEnvironmentHost).MonacoEnvironment = {
+    getWorker(_workerId, label) {
+      if (label === "javascript" || label === "typescript") {
+        return new workers.typescript();
+      }
+      return new workers.editor();
+    },
+  };
+}
+
+function defineThemes(monaco: MonacoModule) {
+  if (themesDefined) return;
+  monaco.editor.defineTheme("code-tape-light", {
+    base: "vs",
+    inherit: true,
+    rules: [],
+    colors: {
+      "editor.background": "#f5f5f4",
+      "editor.foreground": "#24272d",
+      "editorLineNumber.foreground": "#7b808a",
+      "editorLineNumber.activeForeground": "#2f66c9",
+      "editorCursor.foreground": "#2f66c9",
+      "editor.selectionBackground": "#b8d6ff",
+      "editor.inactiveSelectionBackground": "#d7e6fb",
+      "editor.lineHighlightBackground": "#ffffff",
+      "editorGutter.background": "#f5f5f4",
+    },
+  });
+  monaco.editor.defineTheme("code-tape-dark", {
+    base: "vs-dark",
+    inherit: true,
+    rules: [],
+    colors: {
+      "editor.background": "#252931",
+      "editor.foreground": "#e8eaee",
+      "editorLineNumber.foreground": "#9ba2ad",
+      "editorLineNumber.activeForeground": "#8fc4ff",
+      "editorCursor.foreground": "#8fc4ff",
+      "editor.selectionBackground": "#284b74",
+      "editor.inactiveSelectionBackground": "#334153",
+      "editor.lineHighlightBackground": "#2d323b",
+      "editorGutter.background": "#252931",
+    },
+  });
+  themesDefined = true;
+}
+
+async function loadMonaco() {
+  const workers = await loadWorkers();
+  configureWorkers(workers);
+  monacoPromise ??= (async () => {
+    const monaco = await import("monaco-editor/esm/vs/editor/editor.api");
+    await Promise.all([
+      import("monaco-editor/esm/vs/basic-languages/javascript/javascript.contribution"),
+      import("monaco-editor/esm/vs/basic-languages/typescript/typescript.contribution"),
+      import("monaco-editor/esm/vs/language/typescript/monaco.contribution"),
+    ]);
+    defineThemes(monaco);
+    return monaco;
+  })();
+  return monacoPromise;
+}
+
 export const CodeEditor = forwardRef<CodeEditorHandle, CodeEditorProps>(function CodeEditor(
-  _props,
+  { language, initialValue, fontSize, theme, onMount },
   ref,
 ) {
-  const editorRef = useRef<MonacoEditor.IStandaloneCodeEditor | null>(null);
+  const hostRef = useRef<HTMLDivElement | null>(null);
+  const editorRef = useRef<Monaco.editor.IStandaloneCodeEditor | null>(null);
+  const modelRef = useRef<Monaco.editor.ITextModel | null>(null);
+  const monacoRef = useRef<MonacoModule | null>(null);
+  const initialValueRef = useRef(initialValue);
+  const latestPropsRef = useRef({ language, fontSize, theme });
+  const onMountRef = useRef(onMount);
+
+  latestPropsRef.current = { language, fontSize, theme };
+  onMountRef.current = onMount;
+
   useImperativeHandle(ref, () => ({ getEditor: () => editorRef.current }), []);
+
+  useEffect(() => {
+    let cancelled = false;
+    const host = hostRef.current;
+    if (!host) return undefined;
+
+    void loadMonaco()
+      .then((monaco) => {
+        if (cancelled) return;
+        const currentProps = latestPropsRef.current;
+        const model = monaco.editor.createModel(initialValueRef.current, currentProps.language);
+        const editor = monaco.editor.create(host, {
+          model,
+          automaticLayout: true,
+          fontSize: currentProps.fontSize,
+          minimap: { enabled: false },
+          scrollBeyondLastLine: false,
+          tabSize: 2,
+          theme: monacoTheme(currentProps.theme),
+        });
+
+        monacoRef.current = monaco;
+        modelRef.current = model;
+        editorRef.current = editor;
+        onMountRef.current?.(editor);
+      })
+      .catch((error: unknown) => {
+        if (!cancelled) {
+          console.error("Failed to initialize Monaco editor", error);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+      const editor = editorRef.current;
+      const model = modelRef.current;
+      editorRef.current = null;
+      modelRef.current = null;
+      monacoRef.current = null;
+      editor?.dispose();
+      model?.dispose();
+    };
+  }, []);
+
+  useEffect(() => {
+    const monaco = monacoRef.current;
+    const model = modelRef.current;
+    if (!monaco || !model) return;
+    monaco.editor.setModelLanguage(model, language);
+  }, [language]);
+
+  useEffect(() => {
+    editorRef.current?.updateOptions({ fontSize });
+  }, [fontSize]);
+
+  useEffect(() => {
+    monacoRef.current?.editor.setTheme(monacoTheme(theme));
+  }, [theme]);
+
   return (
-    <div className="relative h-full w-full bg-surface">
-      <div className="flex h-full items-center justify-center text-sm text-muted">
-        <span className="font-mono">
-          CodeEditor scaffold · 待 issue「[P0] CodeEditor 组件接入 Monaco」实装
-        </span>
-      </div>
-    </div>
+    <div
+      ref={hostRef}
+      aria-label="Code editor"
+      className="relative h-full min-h-[320px] w-full bg-surface"
+      data-code-editor
+    />
   );
 });

--- a/apps/web/src/features/editor/__tests__/CodeEditor.test.tsx
+++ b/apps/web/src/features/editor/__tests__/CodeEditor.test.tsx
@@ -1,4 +1,4 @@
-import { act, render, waitFor } from "@testing-library/react";
+import { act, render, screen, waitFor } from "@testing-library/react";
 import { createRef } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { CodeEditorHandle } from "../CodeEditor";
@@ -56,7 +56,12 @@ const monacoMock = vi.hoisted(() => {
     editors.push(editor);
     return editor;
   });
-  const defineTheme = vi.fn();
+  const defineTheme = vi.fn(() => {
+    if (monacoMock.failDefineThemeCalls > 0) {
+      monacoMock.failDefineThemeCalls -= 1;
+      throw new Error("define theme failed");
+    }
+  });
   const setTheme = vi.fn();
   const setModelLanguage = vi.fn((model: MockModel, language: string) => {
     model.language = language;
@@ -65,6 +70,8 @@ const monacoMock = vi.hoisted(() => {
   return {
     MockEditorWorker,
     MockTsWorker,
+    failEditorWorkerImports: 0,
+    failDefineThemeCalls: 0,
     models,
     editors,
     editor: {
@@ -82,7 +89,13 @@ vi.mock("monaco-editor/esm/vs/basic-languages/javascript/javascript.contribution
 vi.mock("monaco-editor/esm/vs/basic-languages/typescript/typescript.contribution", () => ({}));
 vi.mock("monaco-editor/esm/vs/language/typescript/monaco.contribution", () => ({}));
 vi.mock("monaco-editor/esm/vs/editor/editor.worker?worker", () => ({
-  default: monacoMock.MockEditorWorker,
+  get default() {
+    if (monacoMock.failEditorWorkerImports > 0) {
+      monacoMock.failEditorWorkerImports -= 1;
+      throw new Error("editor worker import failed");
+    }
+    return monacoMock.MockEditorWorker;
+  },
 }));
 vi.mock("monaco-editor/esm/vs/language/typescript/ts.worker?worker", () => ({
   default: monacoMock.MockTsWorker,
@@ -90,8 +103,11 @@ vi.mock("monaco-editor/esm/vs/language/typescript/ts.worker?worker", () => ({
 
 describe("CodeEditor", () => {
   beforeEach(() => {
+    vi.resetModules();
     monacoMock.models.length = 0;
     monacoMock.editors.length = 0;
+    monacoMock.failEditorWorkerImports = 0;
+    monacoMock.failDefineThemeCalls = 0;
     monacoMock.editor.create.mockClear();
     monacoMock.editor.createModel.mockClear();
     monacoMock.editor.defineTheme.mockClear();
@@ -183,5 +199,58 @@ describe("CodeEditor", () => {
 
     expect(monacoMock.editors[0].disposed).toBe(true);
     expect(monacoMock.models[0].disposed).toBe(true);
+  });
+
+  it("does not rewrite MonacoEnvironment after workers are configured", async () => {
+    const { CodeEditor } = await import("../CodeEditor");
+    const first = render(
+      <CodeEditor language="javascript" initialValue="const first = 1;" fontSize={14} theme="dark" />,
+    );
+    await waitFor(() => expect(monacoMock.editor.create).toHaveBeenCalledTimes(1));
+    const environment = (globalThis as { MonacoEnvironment?: unknown }).MonacoEnvironment;
+    first.unmount();
+
+    render(<CodeEditor language="typescript" initialValue="const second = 2;" fontSize={14} theme="light" />);
+    await waitFor(() => expect(monacoMock.editor.create).toHaveBeenCalledTimes(2));
+
+    expect((globalThis as { MonacoEnvironment?: unknown }).MonacoEnvironment).toBe(environment);
+  });
+
+  it("shows a load error and retries after a Monaco initialization failure", async () => {
+    monacoMock.failDefineThemeCalls = 1;
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    const { CodeEditor } = await import("../CodeEditor");
+    const first = render(
+      <CodeEditor language="javascript" initialValue="const first = 1;" fontSize={14} theme="dark" />,
+    );
+
+    expect(await screen.findByRole("alert")).toHaveTextContent("Code editor failed to load.");
+    expect(monacoMock.editor.create).not.toHaveBeenCalled();
+    first.unmount();
+
+    render(<CodeEditor language="javascript" initialValue="const retry = 1;" fontSize={14} theme="dark" />);
+    await waitFor(() => expect(monacoMock.editor.create).toHaveBeenCalledTimes(1));
+
+    expect(screen.queryByRole("alert")).toBeNull();
+    expect(consoleError).toHaveBeenCalledWith("Failed to initialize Monaco editor", expect.any(Error));
+    consoleError.mockRestore();
+  });
+
+  it("retries after a worker import failure", async () => {
+    monacoMock.failEditorWorkerImports = 1;
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    const { CodeEditor } = await import("../CodeEditor");
+    const first = render(
+      <CodeEditor language="typescript" initialValue="const first = 1;" fontSize={14} theme="dark" />,
+    );
+
+    expect(await screen.findByRole("alert")).toHaveTextContent("Code editor failed to load.");
+    first.unmount();
+
+    render(<CodeEditor language="typescript" initialValue="const retry = 1;" fontSize={14} theme="dark" />);
+    await waitFor(() => expect(monacoMock.editor.create).toHaveBeenCalledTimes(1));
+
+    expect(consoleError).toHaveBeenCalledWith("Failed to initialize Monaco editor", expect.any(Error));
+    consoleError.mockRestore();
   });
 });

--- a/apps/web/src/features/editor/__tests__/CodeEditor.test.tsx
+++ b/apps/web/src/features/editor/__tests__/CodeEditor.test.tsx
@@ -1,0 +1,187 @@
+import { act, render, waitFor } from "@testing-library/react";
+import { createRef } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { CodeEditorHandle } from "../CodeEditor";
+
+const monacoMock = vi.hoisted(() => {
+  class MockEditorWorker {}
+  class MockTsWorker {}
+
+  class MockModel {
+    disposed = false;
+
+    constructor(
+      public value: string,
+      public language: string,
+    ) {}
+
+    getValue() {
+      return this.value;
+    }
+
+    dispose() {
+      this.disposed = true;
+    }
+  }
+
+  class MockEditor {
+    disposed = false;
+    updateOptions = vi.fn((nextOptions: Record<string, unknown>) => {
+      Object.assign(this.options, nextOptions);
+    });
+
+    constructor(
+      public host: HTMLElement,
+      public options: Record<string, unknown> & { model: MockModel },
+    ) {}
+
+    getValue() {
+      return this.options.model.getValue();
+    }
+
+    dispose() {
+      this.disposed = true;
+    }
+  }
+
+  const models: MockModel[] = [];
+  const editors: MockEditor[] = [];
+  const createModel = vi.fn((value: string, language: string) => {
+    const model = new MockModel(value, language);
+    models.push(model);
+    return model;
+  });
+  const create = vi.fn((host: HTMLElement, options: Record<string, unknown> & { model: MockModel }) => {
+    const editor = new MockEditor(host, options);
+    editors.push(editor);
+    return editor;
+  });
+  const defineTheme = vi.fn();
+  const setTheme = vi.fn();
+  const setModelLanguage = vi.fn((model: MockModel, language: string) => {
+    model.language = language;
+  });
+
+  return {
+    MockEditorWorker,
+    MockTsWorker,
+    models,
+    editors,
+    editor: {
+      create,
+      createModel,
+      defineTheme,
+      setTheme,
+      setModelLanguage,
+    },
+  };
+});
+
+vi.mock("monaco-editor/esm/vs/editor/editor.api", () => ({ editor: monacoMock.editor }));
+vi.mock("monaco-editor/esm/vs/basic-languages/javascript/javascript.contribution", () => ({}));
+vi.mock("monaco-editor/esm/vs/basic-languages/typescript/typescript.contribution", () => ({}));
+vi.mock("monaco-editor/esm/vs/language/typescript/monaco.contribution", () => ({}));
+vi.mock("monaco-editor/esm/vs/editor/editor.worker?worker", () => ({
+  default: monacoMock.MockEditorWorker,
+}));
+vi.mock("monaco-editor/esm/vs/language/typescript/ts.worker?worker", () => ({
+  default: monacoMock.MockTsWorker,
+}));
+
+describe("CodeEditor", () => {
+  beforeEach(() => {
+    monacoMock.models.length = 0;
+    monacoMock.editors.length = 0;
+    monacoMock.editor.create.mockClear();
+    monacoMock.editor.createModel.mockClear();
+    monacoMock.editor.defineTheme.mockClear();
+    monacoMock.editor.setTheme.mockClear();
+    monacoMock.editor.setModelLanguage.mockClear();
+    delete (globalThis as { MonacoEnvironment?: unknown }).MonacoEnvironment;
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("lazy-loads Monaco, creates the editor with initial props, and exposes it", async () => {
+    const { CodeEditor } = await import("../CodeEditor");
+    const ref = createRef<CodeEditorHandle>();
+    const onMount = vi.fn();
+
+    render(
+      <CodeEditor
+        ref={ref}
+        language="javascript"
+        initialValue="const answer = 42;"
+        fontSize={16}
+        theme="dark"
+        onMount={onMount}
+      />,
+    );
+
+    expect(monacoMock.editor.create).not.toHaveBeenCalled();
+    await waitFor(() => expect(monacoMock.editor.create).toHaveBeenCalledTimes(1));
+
+    expect(monacoMock.editor.createModel).toHaveBeenCalledWith("const answer = 42;", "javascript");
+    expect(monacoMock.editors[0].options).toEqual(
+      expect.objectContaining({
+        automaticLayout: true,
+        fontSize: 16,
+        model: monacoMock.models[0],
+        theme: "code-tape-dark",
+      }),
+    );
+    expect(ref.current?.getEditor()).toBe(monacoMock.editors[0]);
+    expect(onMount).toHaveBeenCalledWith(monacoMock.editors[0]);
+  });
+
+  it("updates language, font size, and theme without rewriting initialValue", async () => {
+    const { CodeEditor } = await import("../CodeEditor");
+    const { rerender } = render(
+      <CodeEditor language="javascript" initialValue="const first = true;" fontSize={14} theme="dark" />,
+    );
+    await waitFor(() => expect(monacoMock.editor.create).toHaveBeenCalledTimes(1));
+    const model = monacoMock.models[0];
+    const editor = monacoMock.editors[0];
+    model.value = "const userTyped = true;";
+
+    await act(async () => {
+      rerender(
+        <CodeEditor
+          language="typescript"
+          initialValue="const overwritten = true;"
+          fontSize={18}
+          theme="light"
+        />,
+      );
+    });
+
+    expect(model.getValue()).toBe("const userTyped = true;");
+    expect(monacoMock.editor.setModelLanguage).toHaveBeenCalledWith(model, "typescript");
+    expect(editor.updateOptions).toHaveBeenCalledWith({ fontSize: 18 });
+    expect(monacoMock.editor.setTheme).toHaveBeenCalledWith("code-tape-light");
+  });
+
+  it("configures JS/TS workers and disposes editor resources on unmount", async () => {
+    const { CodeEditor } = await import("../CodeEditor");
+    const { unmount } = render(
+      <CodeEditor language="typescript" initialValue="let value: number = 1;" fontSize={14} theme="dark" />,
+    );
+    await waitFor(() => expect(monacoMock.editor.create).toHaveBeenCalledTimes(1));
+
+    const environment = (globalThis as {
+      MonacoEnvironment?: { getWorker(workerId: string, label: string): Worker };
+    }).MonacoEnvironment;
+    expect(environment?.getWorker("", "javascript")).toBeInstanceOf(monacoMock.MockTsWorker);
+    expect(environment?.getWorker("", "typescript")).toBeInstanceOf(monacoMock.MockTsWorker);
+    expect(environment?.getWorker("", "editorWorkerService")).toBeInstanceOf(
+      monacoMock.MockEditorWorker,
+    );
+
+    unmount();
+
+    expect(monacoMock.editors[0].disposed).toBe(true);
+    expect(monacoMock.models[0].disposed).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- Replace CodeEditor scaffold with lazy-loaded Monaco editor using direct monaco-editor ESM imports.
- Configure JS/TS workers and CodeEditor prop updates for language, font size, and theme without rewriting user edits.
- Reset cached Monaco/worker promises after load failures, avoid redundant worker environment rewrites, and show a compact fallback when Monaco cannot initialize.
- Add component tests and update e2e coverage for recorder Monaco rendering.

## GitNexus Impact
- detect_changes reported high risk because CodeEditor load/worker/theme flows affect RecorderPage and ReplayPage.
- GitNexus context/impact for CodeEditor and loadMonaco shows direct consumers are RecorderPage and ReplayPage; upstream impact is LOW and covered by CodeEditor unit tests, recorder e2e, and local browser verification.

## Test Plan
- npm run quality:local
- Browser check on /record: Monaco visible (859x624), fallback not shown, no browser console error logs.
- Note: browser text-input automation hit the Browser tool virtual clipboard limitation, so I did not count that as a verified result.

Closes #55