### PR TITLE
[P0] RuntimeProducer 实装运行事件

### DIFF
--- a/apps/web/src/features/capture/__tests__/runtimeProducer.test.ts
+++ b/apps/web/src/features/capture/__tests__/runtimeProducer.test.ts
@@ -1,0 +1,215 @@
+import { describe, expect, it, vi } from "vitest";
+import type {
+  CompileLanguage,
+  CompileResult,
+  IframeRunInput,
+  IframeRunResult,
+  IframeRuntime,
+  PreviewCompiler,
+} from "@/shared/recording-schema";
+import { createEventBus } from "@/features/recorder/eventBus";
+import { createRecordingClock } from "@/features/recorder/recordingClock";
+import { createRuntimeProducer } from "../runtimeProducer";
+
+function setup(overrides: {
+  compile?: PreviewCompiler["compile"];
+  run?: IframeRuntime["run"];
+} = {}) {
+  const clock = createRecordingClock({ nowProvider: () => 1000 });
+  const bus = createEventBus({ clock, wallTimeProvider: () => "T" });
+  const compile = vi.fn(
+    overrides.compile ??
+      (async (source: string, _language: CompileLanguage): Promise<CompileResult> => ({
+        ok: true,
+        code: `compiled:${source}`,
+        warnings: [],
+      })),
+  );
+  const run = vi.fn(
+    overrides.run ??
+      (async (input: IframeRunInput): Promise<IframeRunResult> => ({
+        runId: input.runId,
+        status: "complete",
+        previewHtml: "<body>ok</body>",
+        stdout: ["hello"],
+        stderr: [],
+      })),
+  );
+  const compiler: PreviewCompiler = { compile };
+  const runtime: IframeRuntime = {
+    mount: vi.fn(),
+    run,
+    renderPreview: vi.fn(),
+    reset: vi.fn(),
+    destroy: vi.fn(),
+  };
+  const producer = createRuntimeProducer({ bus, clock, compiler, runtime });
+  clock.start();
+  producer.start();
+  return { bus, compile, producer, run, runtime };
+}
+
+describe("createRuntimeProducer", () => {
+  it("emits run-start then run-output for a successful iframe run", async () => {
+    const { bus, compile, producer, run } = setup();
+
+    const result = await producer.trigger({
+      language: "javascript",
+      source: "console.log('hello')",
+    });
+
+    const runInput = run.mock.calls[0]?.[0];
+    expect(runInput?.runId).toMatch(/^run-/);
+    expect(runInput?.compiledCode).toBe("compiled:console.log('hello')");
+    expect(runInput?.timeoutMs).toBe(3000);
+    expect(compile).toHaveBeenCalledWith("console.log('hello')", "javascript");
+    expect(result).toEqual({
+      runId: runInput?.runId,
+      status: "complete",
+      previewHtml: "<body>ok</body>",
+      stdout: ["hello"],
+      stderr: [],
+    });
+    expect(bus.drain().map((event) => ({ type: event.type, payload: event.payload }))).toEqual([
+      {
+        type: "run-start",
+        payload: { language: "javascript", runtime: "iframe", runId: runInput?.runId },
+      },
+      {
+        type: "run-output",
+        payload: {
+          runId: runInput?.runId,
+          stdout: ["hello"],
+          stderr: [],
+          previewHtml: "<body>ok</body>",
+          status: "success",
+        },
+      },
+    ]);
+  });
+
+  it("emits run-error with transpile phase when compilation fails", async () => {
+    const { bus, producer, run } = setup({
+      compile: async (): Promise<CompileResult> => ({
+        ok: false,
+        phase: "transpile",
+        message: "Unexpected token",
+        stack: "stacktrace",
+      }),
+    });
+
+    const result = await producer.trigger({
+      language: "typescript",
+      source: "const x: = 1",
+    });
+
+    expect(run).not.toHaveBeenCalled();
+    expect(result.status).toBe("error");
+    if (result.status === "error") {
+      expect(result.phase).toBe("transpile");
+      expect(result.message).toBe("Unexpected token");
+    }
+    expect(bus.drain().map((event) => ({ type: event.type, payload: event.payload }))).toEqual([
+      {
+        type: "run-start",
+        payload: { language: "typescript", runtime: "iframe", runId: result.runId },
+      },
+      {
+        type: "run-error",
+        payload: {
+          runId: result.runId,
+          phase: "transpile",
+          message: "Unexpected token",
+          stack: "stacktrace",
+          stdout: [],
+          stderr: [],
+          previewHtml: null,
+        },
+      },
+    ]);
+  });
+
+  it("emits run-error with runtime phase when iframe run fails", async () => {
+    const { bus, producer } = setup({
+      run: async (input): Promise<IframeRunResult> => ({
+        runId: input.runId,
+        status: "error",
+        phase: "runtime",
+        message: "boom",
+        stack: "stacktrace",
+        stdout: ["before"],
+        stderr: ["warn"],
+      }),
+    });
+
+    const result = await producer.trigger({ language: "javascript", source: "throw new Error()" });
+
+    expect(result.status).toBe("error");
+    expect(bus.drain().map((event) => ({ type: event.type, payload: event.payload }))).toEqual([
+      {
+        type: "run-start",
+        payload: { language: "javascript", runtime: "iframe", runId: result.runId },
+      },
+      {
+        type: "run-error",
+        payload: {
+          runId: result.runId,
+          phase: "runtime",
+          message: "boom",
+          stack: "stacktrace",
+          stdout: ["before"],
+          stderr: ["warn"],
+          previewHtml: null,
+        },
+      },
+    ]);
+  });
+
+  it("emits run-error with runtime phase when iframe run times out", async () => {
+    const { bus, producer } = setup({
+      run: async (input): Promise<IframeRunResult> => ({
+        runId: input.runId,
+        status: "timeout",
+        stdout: ["partial"],
+        stderr: [],
+      }),
+    });
+
+    const result = await producer.trigger({ language: "javascript", source: "await never()" });
+
+    expect(result.status).toBe("timeout");
+    expect(bus.drain().map((event) => ({ type: event.type, payload: event.payload }))).toEqual([
+      {
+        type: "run-start",
+        payload: { language: "javascript", runtime: "iframe", runId: result.runId },
+      },
+      {
+        type: "run-error",
+        payload: {
+          runId: result.runId,
+          phase: "runtime",
+          message: "runtime-timeout",
+          stdout: ["partial"],
+          stderr: [],
+          previewHtml: null,
+        },
+      },
+    ]);
+  });
+
+  it.each(["pause", "stop", "dispose"] as const)(
+    "rejects trigger after %s without emitting runtime events",
+    async (method) => {
+      const { bus, compile, producer, run } = setup();
+      producer[method]();
+
+      await expect(producer.trigger({ language: "javascript", source: "1" })).rejects.toThrow(
+        "RuntimeProducer is not active",
+      );
+
+      expect(compile).not.toHaveBeenCalled();
+      expect(run).not.toHaveBeenCalled();
+      expect(bus.drain()).toEqual([]);
+    },
+  );
+});

--- a/apps/web/src/features/capture/__tests__/runtimeProducer.test.ts
+++ b/apps/web/src/features/capture/__tests__/runtimeProducer.test.ts
@@ -212,4 +212,61 @@ describe("createRuntimeProducer", () => {
       expect(bus.drain()).toEqual([]);
     },
   );
+
+  it("keeps stop terminal even if start is called again", async () => {
+    const { bus, compile, producer, run } = setup();
+    producer.stop();
+    producer.start();
+
+    await expect(producer.trigger({ language: "javascript", source: "1" })).rejects.toThrow(
+      "RuntimeProducer is not active",
+    );
+
+    expect(compile).not.toHaveBeenCalled();
+    expect(run).not.toHaveBeenCalled();
+    expect(bus.drain()).toEqual([]);
+  });
+
+  it("rejects overlapping trigger calls without emitting a second run", async () => {
+    let runCount = 0;
+    let resolveFirstRun: () => void = () => {
+      throw new Error("first run was not started");
+    };
+    const { bus, compile, producer, run } = setup({
+      run: (input) => {
+        runCount += 1;
+        if (runCount > 1) {
+          return Promise.resolve({
+            runId: input.runId,
+            status: "complete",
+            previewHtml: "<body>second</body>",
+            stdout: [],
+            stderr: [],
+          });
+        }
+        return new Promise<IframeRunResult>((resolve) => {
+          resolveFirstRun = () =>
+            resolve({
+              runId: input.runId,
+              status: "complete",
+              previewHtml: "<body>done</body>",
+              stdout: [],
+              stderr: [],
+            });
+        });
+      },
+    });
+
+    const first = producer.trigger({ language: "javascript", source: "first" });
+    await expect(producer.trigger({ language: "javascript", source: "second" })).rejects.toThrow(
+      "RuntimeProducer is already running",
+    );
+
+    expect(compile).toHaveBeenCalledTimes(1);
+    expect(run).toHaveBeenCalledTimes(1);
+    resolveFirstRun?.();
+    await first;
+
+    expect(bus.drain().map((event) => event.type)).toEqual(["run-start", "run-output"]);
+  });
 });

--- a/apps/web/src/features/capture/__tests__/runtimeProducer.test.ts
+++ b/apps/web/src/features/capture/__tests__/runtimeProducer.test.ts
@@ -227,6 +227,17 @@ describe("createRuntimeProducer", () => {
     expect(bus.drain()).toEqual([]);
   });
 
+  it("allows trigger after pause and resume", async () => {
+    const { bus, producer } = setup();
+    producer.pause();
+    producer.resume();
+
+    const result = await producer.trigger({ language: "javascript", source: "1" });
+
+    expect(result.status).toBe("complete");
+    expect(bus.drain().map((event) => event.type)).toEqual(["run-start", "run-output"]);
+  });
+
   it("rejects overlapping trigger calls without emitting a second run", async () => {
     let runCount = 0;
     let resolveFirstRun: () => void = () => {

--- a/apps/web/src/features/capture/runtimeProducer.ts
+++ b/apps/web/src/features/capture/runtimeProducer.ts
@@ -1,8 +1,12 @@
 import type {
   CreateRuntimeProducer,
   RuntimeProducerHandle,
+  RuntimeProducerRunResult,
 } from "./types";
-import type { IframeRunResult } from "@/shared/recording-schema";
+import type { CompileResult, IframeRunResult, RunErrorPayload } from "@/shared/recording-schema";
+import { generateId } from "@/shared/util/ids";
+
+const RUNTIME_TIMEOUT_MS = 3000;
 
 /**
  * RuntimeProducer — emits run-start / run-output / run-error.
@@ -21,21 +25,166 @@ import type { IframeRunResult } from "@/shared/recording-schema";
  *        - status === "timeout"：emit run-error { phase: "runtime", message: "timeout" }
  *   - pause() 期间禁用 trigger（按钮在 UI 层应禁用，producer 双重防御）
  */
-export const createRuntimeProducer: CreateRuntimeProducer = (_deps): RuntimeProducerHandle => {
+function errorInfo(err: unknown): { message: string; stack?: string } {
+  if (err instanceof Error) return { message: err.message, stack: err.stack };
+  return { message: String(err) };
+}
+
+export const createRuntimeProducer: CreateRuntimeProducer = (deps): RuntimeProducerHandle => {
+  const { bus, compiler, runtime } = deps;
+  let paused = false;
+  let stopped = false;
+  let disposed = false;
+
+  const assertActive = () => {
+    if (paused || stopped || disposed) throw new Error("RuntimeProducer is not active");
+  };
+
+  const emitRunError = (payload: RunErrorPayload) => {
+    bus.emit({
+      type: "run-error",
+      source: "runtime",
+      track: "runtime",
+      payload,
+    });
+  };
+
+  const emitCompileError = (
+    runId: string,
+    error: Extract<CompileResult, { ok: false }>,
+  ): RuntimeProducerRunResult => {
+    const result: RuntimeProducerRunResult = {
+      runId,
+      status: "error",
+      phase: "transpile",
+      message: error.message,
+      stack: error.stack,
+      stdout: [],
+      stderr: [],
+      previewHtml: null,
+    };
+    emitRunError({
+      runId,
+      phase: result.phase,
+      message: result.message,
+      stack: result.stack,
+      stdout: result.stdout,
+      stderr: result.stderr,
+      previewHtml: result.previewHtml,
+    });
+    return result;
+  };
+
+  const emitRuntimeThrownError = (runId: string, err: unknown): IframeRunResult => {
+    const info = errorInfo(err);
+    const result: IframeRunResult = {
+      runId,
+      status: "error",
+      phase: "runtime",
+      message: info.message,
+      stack: info.stack,
+      stdout: [],
+      stderr: [],
+    };
+    emitRunError({ ...result, previewHtml: null });
+    return result;
+  };
+
   return {
-    start() {},
-    pause() {},
-    resume() {},
-    stop() {},
-    dispose() {},
-    async trigger(): Promise<IframeRunResult> {
-      return {
-        runId: "stub",
-        status: "complete",
+    start() {
+      if (disposed) return;
+      paused = false;
+      stopped = false;
+    },
+    pause() {
+      if (stopped || disposed) return;
+      paused = true;
+    },
+    resume() {
+      if (stopped || disposed) return;
+      paused = false;
+    },
+    stop() {
+      stopped = true;
+      paused = false;
+    },
+    dispose() {
+      disposed = true;
+      stopped = true;
+      paused = false;
+    },
+    async trigger(input): Promise<RuntimeProducerRunResult> {
+      assertActive();
+
+      const runId = generateId("run");
+      bus.emit({
+        type: "run-start",
+        source: "runtime",
+        track: "runtime",
+        payload: {
+          language: input.language,
+          runtime: "iframe",
+          runId,
+        },
+      });
+
+      let compiled: CompileResult;
+      try {
+        compiled = await compiler.compile(input.source, input.language);
+      } catch (err) {
+        return emitCompileError(runId, { ok: false, phase: "transpile", ...errorInfo(err) });
+      }
+      if (!compiled.ok) return emitCompileError(runId, compiled);
+
+      let result: IframeRunResult;
+      try {
+        result = await runtime.run({
+          runId,
+          compiledCode: compiled.code,
+          timeoutMs: RUNTIME_TIMEOUT_MS,
+        });
+      } catch (err) {
+        return emitRuntimeThrownError(runId, err);
+      }
+
+      if (result.status === "complete") {
+        bus.emit({
+          type: "run-output",
+          source: "runtime",
+          track: "runtime",
+          payload: {
+            runId,
+            stdout: result.stdout,
+            stderr: result.stderr,
+            previewHtml: result.previewHtml,
+            status: "success",
+          },
+        });
+        return result;
+      }
+
+      if (result.status === "timeout") {
+        emitRunError({
+          runId,
+          phase: "runtime",
+          message: "runtime-timeout",
+          stdout: result.stdout,
+          stderr: result.stderr,
+          previewHtml: null,
+        });
+        return result;
+      }
+
+      emitRunError({
+        runId,
+        phase: "runtime",
+        message: result.message,
+        stack: result.stack,
+        stdout: result.stdout,
+        stderr: result.stderr,
         previewHtml: null,
-        stdout: [],
-        stderr: [],
-      };
+      });
+      return result;
     },
   };
 };

--- a/apps/web/src/features/capture/runtimeProducer.ts
+++ b/apps/web/src/features/capture/runtimeProducer.ts
@@ -35,9 +35,11 @@ export const createRuntimeProducer: CreateRuntimeProducer = (deps): RuntimeProdu
   let paused = false;
   let stopped = false;
   let disposed = false;
+  let running = false;
 
   const assertActive = () => {
     if (paused || stopped || disposed) throw new Error("RuntimeProducer is not active");
+    if (running) throw new Error("RuntimeProducer is already running");
   };
 
   const emitRunError = (payload: RunErrorPayload) => {
@@ -92,7 +94,7 @@ export const createRuntimeProducer: CreateRuntimeProducer = (deps): RuntimeProdu
 
   return {
     start() {
-      if (disposed) return;
+      if (stopped || disposed) return;
       paused = false;
       stopped = false;
     },
@@ -115,76 +117,80 @@ export const createRuntimeProducer: CreateRuntimeProducer = (deps): RuntimeProdu
     },
     async trigger(input): Promise<RuntimeProducerRunResult> {
       assertActive();
-
-      const runId = generateId("run");
-      bus.emit({
-        type: "run-start",
-        source: "runtime",
-        track: "runtime",
-        payload: {
-          language: input.language,
-          runtime: "iframe",
-          runId,
-        },
-      });
-
-      let compiled: CompileResult;
+      running = true;
       try {
-        compiled = await compiler.compile(input.source, input.language);
-      } catch (err) {
-        return emitCompileError(runId, { ok: false, phase: "transpile", ...errorInfo(err) });
-      }
-      if (!compiled.ok) return emitCompileError(runId, compiled);
-
-      let result: IframeRunResult;
-      try {
-        result = await runtime.run({
-          runId,
-          compiledCode: compiled.code,
-          timeoutMs: RUNTIME_TIMEOUT_MS,
-        });
-      } catch (err) {
-        return emitRuntimeThrownError(runId, err);
-      }
-
-      if (result.status === "complete") {
+        const runId = generateId("run");
         bus.emit({
-          type: "run-output",
+          type: "run-start",
           source: "runtime",
           track: "runtime",
           payload: {
+            language: input.language,
+            runtime: "iframe",
             runId,
-            stdout: result.stdout,
-            stderr: result.stderr,
-            previewHtml: result.previewHtml,
-            status: "success",
           },
         });
-        return result;
-      }
 
-      if (result.status === "timeout") {
+        let compiled: CompileResult;
+        try {
+          compiled = await compiler.compile(input.source, input.language);
+        } catch (err) {
+          return emitCompileError(runId, { ok: false, phase: "transpile", ...errorInfo(err) });
+        }
+        if (!compiled.ok) return emitCompileError(runId, compiled);
+
+        let result: IframeRunResult;
+        try {
+          result = await runtime.run({
+            runId,
+            compiledCode: compiled.code,
+            timeoutMs: RUNTIME_TIMEOUT_MS,
+          });
+        } catch (err) {
+          return emitRuntimeThrownError(runId, err);
+        }
+
+        if (result.status === "complete") {
+          bus.emit({
+            type: "run-output",
+            source: "runtime",
+            track: "runtime",
+            payload: {
+              runId,
+              stdout: result.stdout,
+              stderr: result.stderr,
+              previewHtml: result.previewHtml,
+              status: "success",
+            },
+          });
+          return result;
+        }
+
+        if (result.status === "timeout") {
+          emitRunError({
+            runId,
+            phase: "runtime",
+            message: "runtime-timeout",
+            stdout: result.stdout,
+            stderr: result.stderr,
+            previewHtml: null,
+          });
+          return result;
+        }
+
         emitRunError({
           runId,
           phase: "runtime",
-          message: "runtime-timeout",
+          message: result.message,
+          stack: result.stack,
           stdout: result.stdout,
           stderr: result.stderr,
           previewHtml: null,
         });
         return result;
+      } finally {
+        running = false;
       }
-
-      emitRunError({
-        runId,
-        phase: "runtime",
-        message: result.message,
-        stack: result.stack,
-        stdout: result.stdout,
-        stderr: result.stderr,
-        previewHtml: null,
-      });
-      return result;
     },
   };
 };

--- a/apps/web/src/features/capture/runtimeProducer.ts
+++ b/apps/web/src/features/capture/runtimeProducer.ts
@@ -96,7 +96,6 @@ export const createRuntimeProducer: CreateRuntimeProducer = (deps): RuntimeProdu
     start() {
       if (stopped || disposed) return;
       paused = false;
-      stopped = false;
     },
     pause() {
       if (stopped || disposed) return;

--- a/apps/web/src/features/capture/types.ts
+++ b/apps/web/src/features/capture/types.ts
@@ -102,6 +102,19 @@ export type RuntimeProducerDeps = ProducerCommonDeps & {
   runtime: IframeRuntime;
 };
 
+export type RuntimeProducerRunResult =
+  | IframeRunResult
+  | {
+      runId: string;
+      status: "error";
+      phase: "transpile";
+      message: string;
+      stack?: string;
+      stdout: string[];
+      stderr: string[];
+      previewHtml: null;
+    };
+
 export type RuntimeProducerHandle = EventProducer & {
   /**
    * Compile + execute the user's source. Emits `run-start`, then exactly one of
@@ -111,7 +124,7 @@ export type RuntimeProducerHandle = EventProducer & {
   trigger(input: {
     language: "javascript" | "typescript";
     source: string;
-  }): Promise<IframeRunResult>;
+  }): Promise<RuntimeProducerRunResult>;
 };
 
 export type CreateRuntimeProducer = (deps: RuntimeProducerDeps) => RuntimeProducerHandle;


### PR DESCRIPTION
## 关联 Issue

Closes #56

## 变更说明

- 实现 RuntimeProducer.trigger：生成 runId，按 run-start -> run-output/run-error 写入 EventBus。
- 接入 previewCompiler 与 iframeRuntime，覆盖 transpile/runtime/timeout 分支。
- 新增 runtimeProducer 单测，覆盖 success、transpile error、runtime error、timeout、pause/stop/dispose guard。

## GitNexus 影响分析摘要

- 风险等级: medium
- 关键骨架变更: apps/web/src/features/capture/runtimeProducer.ts、apps/web/src/features/capture/types.ts
- GitNexus 影响面: 受影响流程为 Trigger -> EmitRunError；未发现跨模块高风险扩散。
- 验证结果: 已运行 npm run quality:local；GitNexus contract passed。

## 自检

- [x] PR author 是该 Issue 的认领者
- [x] 未修改 `docs/progress.json` 或 `docs/progress.md`
- [x] 已运行 `npm run quality:local`，或说明无法运行的原因
- [x] 如果改动关键骨架，已补充契约测试并填写 GitNexus 影响分析摘要
- [ ] 已邀请至少一名非作者同学 CR