### PR TITLE
[codex] Implement editor producer event capture

### DIFF
--- a/apps/web/src/features/capture/__tests__/editorProducer.test.ts
+++ b/apps/web/src/features/capture/__tests__/editorProducer.test.ts
@@ -1,0 +1,516 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createEventBus } from "@/features/recorder/eventBus";
+import { createRecordingClock } from "@/features/recorder/recordingClock";
+import type { RecordingLanguage, RecordingTheme } from "@/shared/recording-schema";
+import { createEditorProducer } from "../editorProducer";
+import type { EditorProducerDeps } from "../types";
+
+type Disposable = { dispose(): void };
+type ContentChangeEvent = {
+  changes?: Array<{ text: string; rangeLength?: number }>;
+  isUndoing?: boolean;
+  isRedoing?: boolean;
+};
+type Selection = {
+  startLineNumber: number;
+  startColumn: number;
+  endLineNumber: number;
+  endColumn: number;
+};
+
+class MockModel {
+  constructor(
+    private value: string,
+    public language: RecordingLanguage,
+  ) {}
+
+  getValue() {
+    return this.value;
+  }
+
+  setValue(next: string) {
+    this.value = next;
+  }
+}
+
+class MockEditor {
+  private contentListeners = new Set<(event: ContentChangeEvent) => void>();
+  private pasteListeners = new Set<() => void>();
+  private selectionListeners = new Set<() => void>();
+  private scrollListeners = new Set<() => void>();
+  private position: { lineNumber: number; column: number } | null = { lineNumber: 1, column: 1 };
+  private selection: Selection | null = {
+    startLineNumber: 1,
+    startColumn: 1,
+    endLineNumber: 1,
+    endColumn: 1,
+  };
+  private scroll = { scrollTop: 0, scrollLeft: 0 };
+
+  constructor(
+    private readonly model: MockModel,
+    private readonly rawOptions: { fontSize: number; theme: string } = {
+      fontSize: 16,
+      theme: "code-tape-dark",
+    },
+  ) {}
+
+  getModel() {
+    return this.model;
+  }
+
+  getValue() {
+    return this.model.getValue();
+  }
+
+  getPosition() {
+    return this.position;
+  }
+
+  getSelection() {
+    return this.selection;
+  }
+
+  getScrollTop() {
+    return this.scroll.scrollTop;
+  }
+
+  getScrollLeft() {
+    return this.scroll.scrollLeft;
+  }
+
+  getRawOptions() {
+    return this.rawOptions;
+  }
+
+  onDidChangeModelContent(listener: (event: ContentChangeEvent) => void): Disposable {
+    this.contentListeners.add(listener);
+    return { dispose: () => this.contentListeners.delete(listener) };
+  }
+
+  onDidPaste(listener: () => void): Disposable {
+    this.pasteListeners.add(listener);
+    return { dispose: () => this.pasteListeners.delete(listener) };
+  }
+
+  onDidChangeCursorSelection(listener: () => void): Disposable {
+    this.selectionListeners.add(listener);
+    return { dispose: () => this.selectionListeners.delete(listener) };
+  }
+
+  onDidScrollChange(listener: () => void): Disposable {
+    this.scrollListeners.add(listener);
+    return { dispose: () => this.scrollListeners.delete(listener) };
+  }
+
+  changeContent(next: string, event: ContentChangeEvent = { changes: [{ text: next }] }) {
+    this.model.setValue(next);
+    this.contentListeners.forEach((listener) => listener(event));
+  }
+
+  pasteContent(next: string, event: ContentChangeEvent = { changes: [{ text: next }] }) {
+    this.changeContent(next, event);
+    this.pasteListeners.forEach((listener) => listener());
+  }
+
+  changeSelection(position: { lineNumber: number; column: number } | null, selection: Selection | null) {
+    this.position = position;
+    this.selection = selection;
+    this.selectionListeners.forEach((listener) => listener());
+  }
+
+  changeScroll(scrollTop: number, scrollLeft: number) {
+    this.scroll = { scrollTop, scrollLeft };
+    this.scrollListeners.forEach((listener) => listener());
+  }
+}
+
+function setup() {
+  vi.useFakeTimers();
+  let wall = 1000;
+  const clock = createRecordingClock({ nowProvider: () => wall });
+  const bus = createEventBus({ clock, wallTimeProvider: () => "T" });
+  let language: RecordingLanguage = "javascript";
+  let editor: MockEditor | null = null;
+  const setModelLanguage = vi.fn((model: MockModel, next: RecordingLanguage) => {
+    model.language = next;
+    language = next;
+  });
+  const producer = createEditorProducer({
+    bus,
+    clock,
+    getEditor: () => editor as never,
+    getCurrentLanguage: () => language,
+    setModelLanguage,
+  } as unknown as EditorProducerDeps & {
+    setModelLanguage: (model: MockModel, next: RecordingLanguage) => void;
+  });
+
+  clock.start();
+  producer.start();
+
+  return {
+    bus,
+    clock,
+    producer,
+    setEditor(next: MockEditor | null) {
+      editor = next;
+      vi.advanceTimersByTime(100);
+    },
+    setLanguage(next: RecordingLanguage) {
+      language = next;
+    },
+    setWall(next: number) {
+      wall = next;
+    },
+    setModelLanguage,
+  };
+}
+
+function editor(value = "", language: RecordingLanguage = "javascript", theme: RecordingTheme = "dark") {
+  return new MockEditor(
+    new MockModel(value, language),
+    { fontSize: 16, theme: `code-tape-${theme}` },
+  );
+}
+
+describe("createEditorProducer", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("coalesces content changes with debounce, idle flush, semantic flush, and hash dedupe", () => {
+    const env = setup();
+    const mounted = editor();
+    env.setEditor(mounted);
+
+    mounted.changeContent("a", { changes: [{ text: "a" }] });
+    vi.advanceTimersByTime(299);
+    expect(env.bus.drain()).toEqual([]);
+
+    mounted.changeContent("ab", { changes: [{ text: "b" }] });
+    vi.advanceTimersByTime(300);
+
+    expect(env.bus.drain().map((event) => ({ type: event.type, payload: event.payload }))).toEqual([
+      {
+        type: "content-change",
+        payload: expect.objectContaining({
+          fileId: "main",
+          version: 1,
+          code: "ab",
+          language: "javascript",
+          changeReason: "input",
+          changeCount: 2,
+          flushedBy: "debounce",
+        }),
+      },
+    ]);
+
+    mounted.changeContent("abc", { changes: [{ text: "c" }] });
+    vi.advanceTimersByTime(299);
+    mounted.changeContent("abcd", { changes: [{ text: "d" }] });
+    vi.advanceTimersByTime(299);
+    mounted.changeContent("abcde", { changes: [{ text: "e" }] });
+    vi.advanceTimersByTime(299);
+    mounted.changeContent("abcdef", { changes: [{ text: "f" }] });
+    vi.advanceTimersByTime(102);
+    expect(env.bus.drain()).toEqual([]);
+    vi.advanceTimersByTime(1);
+
+    expect(env.bus.drain()[0]).toMatchObject({
+      type: "content-change",
+      payload: { version: 2, code: "abcdef", changeCount: 4, flushedBy: "idle" },
+    });
+
+    mounted.changeContent("abcdefg", { changes: [{ text: "g" }] });
+    env.producer.flushPending();
+    expect(env.bus.drain()[0]).toMatchObject({
+      type: "content-change",
+      payload: { version: 3, code: "abcdefg", flushedBy: "run" },
+    });
+
+    mounted.changeContent("abcdefg", { changes: [{ text: "" }] });
+    vi.advanceTimersByTime(300);
+    expect(env.bus.drain()).toEqual([]);
+
+    mounted.changeContent("abcdefg\n", { changes: [{ text: "\n", rangeLength: 0 }] });
+    vi.advanceTimersByTime(299);
+    expect(env.bus.drain()).toEqual([]);
+    vi.advanceTimersByTime(1);
+    expect(env.bus.drain()[0]).toMatchObject({
+      type: "content-change",
+      payload: {
+        version: 4,
+        code: "abcdefg\n",
+        changeReason: "input",
+        flushedBy: "debounce",
+      },
+    });
+  });
+
+  it("flushes single-line paste from Monaco paste signal immediately", () => {
+    const env = setup();
+    const mounted = editor();
+    env.setEditor(mounted);
+
+    mounted.pasteContent("hello", { changes: [{ text: "hello" }] });
+
+    expect(env.bus.drain()[0]).toMatchObject({
+      type: "content-change",
+      payload: {
+        code: "hello",
+        changeReason: "paste",
+        flushedBy: "paste",
+      },
+    });
+  });
+
+  it("flushes paste, undo, redo, pause, stop, and snapshot boundaries immediately", async () => {
+    const env = setup();
+    const mounted = editor("old");
+    env.setEditor(mounted);
+
+    mounted.changeContent("first\nsecond", { changes: [{ text: "first\nsecond" }] });
+    expect(env.bus.drain()[0]).toMatchObject({
+      type: "content-change",
+      payload: { changeReason: "paste", flushedBy: "paste", changeCount: 1 },
+    });
+
+    mounted.changeContent("first", { isUndoing: true, changes: [{ text: "", rangeLength: 7 }] });
+    expect(env.bus.drain()[0]).toMatchObject({
+      type: "content-change",
+      payload: { changeReason: "undo", flushedBy: "undo" },
+    });
+
+    mounted.changeContent("first\nsecond", { isRedoing: true, changes: [{ text: "\nsecond" }] });
+    expect(env.bus.drain()[0]).toMatchObject({
+      type: "content-change",
+      payload: { changeReason: "redo", flushedBy: "redo" },
+    });
+
+    mounted.changeContent("const formatted = true;\n", {
+      changes: [{ text: "const" }, { text: " formatted" }],
+    });
+    expect(env.bus.drain()[0]).toMatchObject({
+      type: "content-change",
+      payload: { changeReason: "format", flushedBy: "format" },
+    });
+
+    mounted.changeContent("pending-pause", { changes: [{ text: "pending-pause" }] });
+    env.producer.pause();
+    expect(env.bus.drain()[0]).toMatchObject({
+      type: "content-change",
+      payload: { code: "pending-pause", flushedBy: "pause" },
+    });
+
+    env.producer.resume();
+    mounted.changeContent("pending-snapshot", { changes: [{ text: "pending-snapshot" }] });
+    await env.producer.takeSnapshot();
+    expect(env.bus.drain()[0]).toMatchObject({
+      type: "content-change",
+      payload: { code: "pending-snapshot", flushedBy: "snapshot" },
+    });
+
+    mounted.changeContent("pending-stop", { changes: [{ text: "pending-stop" }] });
+    env.producer.stop();
+    expect(env.bus.drain()[0]).toMatchObject({
+      type: "content-change",
+      payload: { code: "pending-stop", flushedBy: "stop" },
+    });
+  });
+
+  it("emits selection changes and throttled scroll events", () => {
+    const env = setup();
+    const mounted = editor();
+    env.setEditor(mounted);
+
+    mounted.changeSelection(
+      { lineNumber: 2, column: 4 },
+      { startLineNumber: 2, startColumn: 1, endLineNumber: 2, endColumn: 4 },
+    );
+    expect(env.bus.drain()[0]).toMatchObject({
+      type: "selection-change",
+      payload: {
+        cursor: { lineNumber: 2, column: 4 },
+        selection: { startLineNumber: 2, startColumn: 1, endLineNumber: 2, endColumn: 4 },
+      },
+    });
+
+    mounted.changeScroll(10, 1);
+    mounted.changeScroll(20, 2);
+    vi.advanceTimersByTime(99);
+    expect(env.bus.drain()).toEqual([]);
+    vi.advanceTimersByTime(1);
+    expect(env.bus.drain()[0]).toMatchObject({
+      type: "editor-scroll",
+      payload: { scrollTop: 20, scrollLeft: 2 },
+    });
+  });
+
+  it("reads latest dependency language for snapshots and resume baselines", async () => {
+    const env = setup();
+    const mounted = editor("const answer = 42;");
+    env.setEditor(mounted);
+
+    env.setLanguage("typescript");
+    const snapshot = await env.producer.takeSnapshot();
+    expect(snapshot?.state.editor.language).toBe("typescript");
+
+    env.producer.pause();
+    env.bus.drain();
+    env.setLanguage("javascript");
+    env.producer.resume();
+    await Promise.resolve();
+
+    expect(env.bus.drain()[0]).toMatchObject({
+      type: "resume-baseline",
+      payload: {
+        reason: "paused-state-changed",
+        snapshot: { editor: { language: "javascript" } },
+      },
+    });
+  });
+
+  it("updates model language, emits language-change once, and snapshots stable editor state", async () => {
+    const env = setup();
+    const mounted = editor("const answer = 42;", "javascript", "light");
+    env.setEditor(mounted);
+
+    env.producer.setLanguage("typescript");
+    env.producer.setLanguage("typescript");
+
+    expect(env.setModelLanguage).toHaveBeenCalledOnce();
+    expect(env.bus.drain()).toEqual([
+      expect.objectContaining({
+        type: "language-change",
+        payload: { from: "javascript", to: "typescript" },
+      }),
+    ]);
+
+    mounted.changeSelection(
+      { lineNumber: 1, column: 7 },
+      { startLineNumber: 1, startColumn: 1, endLineNumber: 1, endColumn: 7 },
+    );
+    mounted.changeScroll(24, 3);
+    vi.advanceTimersByTime(100);
+    env.bus.drain();
+    env.setWall(1250);
+
+    const snapshot = await env.producer.takeSnapshot();
+
+    expect(snapshot).toMatchObject({
+      id: expect.stringMatching(/^snap-/),
+      timestampMs: 250,
+      state: {
+        editor: {
+          code: "const answer = 42;",
+          language: "typescript",
+          cursor: { lineNumber: 1, column: 7 },
+          selection: { startLineNumber: 1, startColumn: 1, endLineNumber: 1, endColumn: 7 },
+          scrollTop: 24,
+          scrollLeft: 3,
+          fontSize: 16,
+          theme: "light",
+        },
+      },
+    });
+  });
+
+  it("uses the global last event seq for snapshots after the bus has drained", async () => {
+    const env = setup();
+    const mounted = editor();
+    env.setEditor(mounted);
+
+    mounted.changeContent("const drained = true;", { changes: [{ text: "const drained = true;" }] });
+    env.producer.flushPending();
+    const [contentEvent] = env.bus.drain();
+
+    const snapshot = await env.producer.takeSnapshot();
+
+    expect(snapshot?.eventSeq).toBe(contentEvent.seq);
+  });
+
+  it("flushes pending content before rebinding to a new editor instance", () => {
+    const env = setup();
+    const first = editor("first");
+    env.setEditor(first);
+
+    first.changeContent("first pending", { changes: [{ text: " pending" }] });
+    vi.advanceTimersByTime(99);
+    const second = editor("second");
+    env.setEditor(second);
+
+    expect(env.bus.drain()).toEqual([
+      expect.objectContaining({
+        type: "content-change",
+        payload: expect.objectContaining({
+          code: "first pending",
+          flushedBy: "snapshot",
+        }),
+      }),
+    ]);
+
+    vi.advanceTimersByTime(300);
+    expect(env.bus.drain()).toEqual([]);
+
+    second.changeContent("second next", { changes: [{ text: " next" }] });
+    vi.advanceTimersByTime(300);
+    expect(env.bus.drain()).toEqual([
+      expect.objectContaining({
+        type: "content-change",
+        payload: expect.objectContaining({ code: "second next" }),
+      }),
+    ]);
+  });
+
+  it("returns null before mount, rebinds editor instances, resumes with a baseline, and stays silent after terminal states", async () => {
+    const env = setup();
+
+    await expect(env.producer.takeSnapshot()).resolves.toBeNull();
+
+    const first = editor("one");
+    env.setEditor(first);
+    first.changeContent("two", { changes: [{ text: "two" }] });
+    env.producer.pause();
+    env.bus.drain();
+
+    first.changeContent("paused-edit", { changes: [{ text: "paused-edit" }] });
+    expect(env.bus.drain()).toEqual([]);
+
+    env.producer.resume();
+    await Promise.resolve();
+    expect(env.bus.drain()[0]).toMatchObject({
+      type: "resume-baseline",
+      payload: {
+        reason: "paused-state-changed",
+        snapshot: { editor: { code: "paused-edit" } },
+      },
+    });
+
+    const second = editor("second");
+    env.setEditor(second);
+    first.changeContent("old-instance", { changes: [{ text: "old-instance" }] });
+    second.changeContent("second-next", { changes: [{ text: "second-next" }] });
+    vi.advanceTimersByTime(300);
+    expect(env.bus.drain()).toEqual([
+      expect.objectContaining({
+        type: "content-change",
+        payload: expect.objectContaining({ code: "second-next" }),
+      }),
+    ]);
+
+    env.producer.stop();
+    second.changeContent("stopped", { changes: [{ text: "stopped" }] });
+    vi.advanceTimersByTime(300);
+    expect(env.bus.drain()).toEqual([]);
+    env.producer.start();
+    second.changeContent("terminal", { changes: [{ text: "terminal" }] });
+    vi.advanceTimersByTime(300);
+    expect(env.bus.drain()).toEqual([]);
+
+    env.producer.dispose();
+    second.changeContent("disposed", { changes: [{ text: "disposed" }] });
+    vi.advanceTimersByTime(300);
+    expect(env.bus.drain()).toEqual([]);
+  });
+});

--- a/apps/web/src/features/capture/editorProducer.ts
+++ b/apps/web/src/features/capture/editorProducer.ts
@@ -1,31 +1,420 @@
+import type { editor as MonacoEditor } from "monaco-editor";
 import type { CreateEditorProducer, EditorProducerHandle } from "./types";
+import type {
+  ContentChangePayload,
+  RecordingLanguage,
+  RecordingSnapshot,
+  RecordingTheme,
+  ReplayStableState,
+  SelectionChangePayload,
+} from "@/shared/recording-schema";
+import { generateId } from "@/shared/util/ids";
 
-/**
- * EditorProducer — bridges Monaco editor events into the EventBus.
- *
- * STUB. Real implementation belongs to issue `[P0] editorProducer 实装`.
- *
- * 实装时需要：
- *   - 订阅 Monaco editor.onDidChangeModelContent（debounce 200ms → content-change，
- *     带 contentHash 用于去重；force flush on pause/stop/run/snapshot）
- *   - editor.onDidChangeCursorSelection → selection-change
- *   - editor.onDidScrollChange (throttle 100ms) → editor-scroll
- *   - setLanguage 调 monaco.editor.setModelLanguage + emit language-change
- *   - takeSnapshot 读出 model.getValue() + 当前 cursor/selection/scroll/fontSize/theme
- *   - pause() 时停止订阅；resume() 时 emit resume-baseline 与 stored snapshot 比对，
- *     若 diff 则强制 emit content-change 同步当前 buffer
- */
-export const createEditorProducer: CreateEditorProducer = (_deps): EditorProducerHandle => {
-  return {
-    start() {},
-    pause() {},
-    resume() {},
-    stop() {},
-    dispose() {},
-    flushPending() {},
-    async takeSnapshot() {
-      return null;
+const CONTENT_DEBOUNCE_MS = 300;
+const CONTENT_IDLE_FLUSH_MS = 1000;
+const EDITOR_REBIND_POLL_MS = 100;
+const SCROLL_THROTTLE_MS = 100;
+
+type Disposable = { dispose(): void };
+type ContentChangedEvent = {
+  changes?: Array<{ text?: string; rangeLength?: number }>;
+  isUndoing?: boolean;
+  isRedoing?: boolean;
+};
+type DetectedContentChangeReason = Exclude<ContentChangePayload["changeReason"], "programmatic">;
+type MonacoSelectionLike = {
+  startLineNumber: number;
+  startColumn: number;
+  endLineNumber: number;
+  endColumn: number;
+};
+type ScrollPosition = { scrollTop: number; scrollLeft: number };
+type PendingContent = {
+  code: string;
+  contentHash: string;
+  language: RecordingLanguage;
+  changeReason: ContentChangePayload["changeReason"];
+  changeCount: number;
+};
+type ContentFlushReason = ContentChangePayload["flushedBy"];
+
+export const createEditorProducer: CreateEditorProducer = (deps): EditorProducerHandle => {
+  const { bus, clock } = deps;
+
+  let currentEditor: MonacoEditor.IStandaloneCodeEditor | null = null;
+  let currentLanguage = deps.getCurrentLanguage();
+  let disposables: Disposable[] = [];
+  let rebindTimer: ReturnType<typeof setInterval> | null = null;
+  let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+  let idleTimer: ReturnType<typeof setTimeout> | null = null;
+  let scrollTimer: ReturnType<typeof setTimeout> | null = null;
+  let pendingContent: PendingContent | null = null;
+  let pendingScroll: ScrollPosition | null = null;
+  let pasteSignalPending = false;
+  let lastContentHash: string | null = null;
+  let version = 0;
+  let pausedState: ReplayStableState | null = null;
+  let active = false;
+  let paused = false;
+  let stopped = false;
+  let disposed = false;
+
+  const isListening = () => active && !paused && !stopped && !disposed;
+
+  const clearContentTimers = () => {
+    if (debounceTimer) clearTimeout(debounceTimer);
+    if (idleTimer) clearTimeout(idleTimer);
+    debounceTimer = null;
+    idleTimer = null;
+  };
+
+  const clearScrollTimer = () => {
+    if (scrollTimer) clearTimeout(scrollTimer);
+    scrollTimer = null;
+    pendingScroll = null;
+  };
+
+  const stopRebindPolling = () => {
+    if (!rebindTimer) return;
+    clearInterval(rebindTimer);
+    rebindTimer = null;
+  };
+
+  const disposeEditorListeners = () => {
+    disposables.forEach((disposable) => disposable.dispose());
+    disposables = [];
+    currentEditor = null;
+  };
+
+  const getEditorValue = (editor: MonacoEditor.IStandaloneCodeEditor): string => {
+    const model = editor.getModel();
+    return model?.getValue() ?? editor.getValue();
+  };
+
+  const readLanguage = (): RecordingLanguage => {
+    currentLanguage = deps.getCurrentLanguage() ?? currentLanguage;
+    return currentLanguage;
+  };
+
+  const setStableLanguage = (next: RecordingLanguage) => {
+    currentLanguage = next;
+  };
+
+  const emitContent = (flushedBy: ContentFlushReason) => {
+    if (!pendingContent) return;
+    clearContentTimers();
+
+    const pending = pendingContent;
+    pendingContent = null;
+    if (pending.contentHash === lastContentHash) return;
+
+    version += 1;
+    lastContentHash = pending.contentHash;
+    bus.emit({
+      type: "content-change",
+      source: "editor",
+      track: "main",
+      payload: {
+        fileId: "main",
+        version,
+        code: pending.code,
+        contentHash: pending.contentHash,
+        language: pending.language,
+        changeReason: pending.changeReason,
+        changeCount: pending.changeCount,
+        flushedBy,
+      },
+    });
+  };
+
+  const scheduleContentFlush = () => {
+    if (debounceTimer) clearTimeout(debounceTimer);
+    debounceTimer = setTimeout(() => emitContent("debounce"), CONTENT_DEBOUNCE_MS);
+    idleTimer ??= setTimeout(() => emitContent("idle"), CONTENT_IDLE_FLUSH_MS);
+  };
+
+  const emitSelection = (editor: MonacoEditor.IStandaloneCodeEditor) => {
+    if (!isListening()) return;
+    bus.emit({
+      type: "selection-change",
+      source: "editor",
+      track: "main",
+      payload: {
+        cursor: editor.getPosition(),
+        selection: toSelection(editor.getSelection()),
+      },
+    });
+  };
+
+  const emitScroll = () => {
+    scrollTimer = null;
+    if (!pendingScroll || !isListening()) {
+      pendingScroll = null;
+      return;
+    }
+    const scroll = pendingScroll;
+    pendingScroll = null;
+    bus.emit({
+      type: "editor-scroll",
+      source: "editor",
+      track: "main",
+      payload: scroll,
+    });
+  };
+
+  const scheduleScroll = (editor: MonacoEditor.IStandaloneCodeEditor) => {
+    if (!isListening()) return;
+    pendingScroll = {
+      scrollTop: editor.getScrollTop(),
+      scrollLeft: editor.getScrollLeft(),
+    };
+    scrollTimer ??= setTimeout(emitScroll, SCROLL_THROTTLE_MS);
+  };
+
+  const handleContentChange = (
+    editor: MonacoEditor.IStandaloneCodeEditor,
+    event: ContentChangedEvent,
+  ) => {
+    if (!isListening()) return;
+    const changeReason = pasteSignalPending ? "paste" : classifyContentChange(event);
+    pasteSignalPending = false;
+    const code = getEditorValue(editor);
+    const existingCount = pendingContent?.changeCount ?? 0;
+    pendingContent = {
+      code,
+      contentHash: hashContent(code),
+      language: readLanguage(),
+      changeReason,
+      changeCount: existingCount + 1,
+    };
+
+    if (changeReason !== "input") {
+      emitContent(changeReason);
+      return;
+    }
+    scheduleContentFlush();
+  };
+
+  const handlePasteSignal = () => {
+    if (!isListening()) return;
+    if (pendingContent) {
+      pendingContent = { ...pendingContent, changeReason: "paste" };
+      emitContent("paste");
+      return;
+    }
+    pasteSignalPending = true;
+    queueMicrotask(() => {
+      pasteSignalPending = false;
+    });
+  };
+
+  const bindEditor = (editor: MonacoEditor.IStandaloneCodeEditor) => {
+    currentEditor = editor;
+    currentLanguage = deps.getCurrentLanguage();
+    lastContentHash ??= hashContent(getEditorValue(editor));
+    disposables = [
+      editor.onDidChangeModelContent((event: ContentChangedEvent) => handleContentChange(editor, event)),
+      editor.onDidPaste(handlePasteSignal),
+      editor.onDidChangeCursorSelection(() => emitSelection(editor)),
+      editor.onDidScrollChange(() => scheduleScroll(editor)),
+    ];
+  };
+
+  const syncEditor = () => {
+    const nextEditor = isListening() ? deps.getEditor() : null;
+    if (nextEditor === currentEditor) return;
+    if (currentEditor && pendingContent) {
+      emitContent("snapshot");
+    }
+    pasteSignalPending = false;
+    clearScrollTimer();
+    disposeEditorListeners();
+    if (nextEditor) bindEditor(nextEditor);
+  };
+
+  const startRebindPolling = () => {
+    if (rebindTimer || stopped || disposed) return;
+    rebindTimer = setInterval(syncEditor, EDITOR_REBIND_POLL_MS);
+  };
+
+  const snapshotState = (editor: MonacoEditor.IStandaloneCodeEditor): ReplayStableState => ({
+    editor: {
+      code: getEditorValue(editor),
+      language: readLanguage(),
+      cursor: editor.getPosition(),
+      selection: toSelection(editor.getSelection()),
+      scrollTop: editor.getScrollTop(),
+      scrollLeft: editor.getScrollLeft(),
+      fontSize: readFontSize(editor),
+      theme: readTheme(editor),
     },
-    setLanguage(_next) {},
+    pointer: null,
+    media: {
+      microphoneEnabled: false,
+      cameraEnabled: false,
+      cameraPosition: { x: 0, y: 0 },
+    },
+    runtime: {
+      status: "idle",
+      stdout: [],
+      stderr: [],
+      previewHtml: null,
+      errorMessage: null,
+    },
+  });
+
+  const emitResumeBaselineIfNeeded = () => {
+    syncEditor();
+    if (!currentEditor || !pausedState) return;
+    const nextState = snapshotState(currentEditor);
+    if (stableStateKey(nextState) === stableStateKey(pausedState)) return;
+    lastContentHash = hashContent(nextState.editor.code);
+    bus.emit({
+      type: "resume-baseline",
+      source: "recorder",
+      track: "main",
+      payload: {
+        reason: "paused-state-changed",
+        snapshot: nextState,
+      },
+    });
+  };
+
+  return {
+    start() {
+      if (stopped || disposed) return;
+      active = true;
+      paused = false;
+      syncEditor();
+      startRebindPolling();
+    },
+    pause() {
+      if (stopped || disposed || paused) return;
+      emitContent("pause");
+      syncEditor();
+      pausedState = currentEditor ? snapshotState(currentEditor) : null;
+      paused = true;
+      active = false;
+      clearContentTimers();
+      clearScrollTimer();
+      disposeEditorListeners();
+      stopRebindPolling();
+    },
+    resume() {
+      if (stopped || disposed || !paused) return;
+      active = true;
+      paused = false;
+      syncEditor();
+      startRebindPolling();
+      queueMicrotask(emitResumeBaselineIfNeeded);
+    },
+    stop() {
+      if (stopped || disposed) return;
+      emitContent("stop");
+      stopped = true;
+      active = false;
+      paused = false;
+      clearContentTimers();
+      clearScrollTimer();
+      disposeEditorListeners();
+      stopRebindPolling();
+    },
+    dispose() {
+      if (disposed) return;
+      disposed = true;
+      stopped = true;
+      active = false;
+      paused = false;
+      clearContentTimers();
+      clearScrollTimer();
+      disposeEditorListeners();
+      stopRebindPolling();
+    },
+    flushPending() {
+      if (!isListening()) return;
+      emitContent("run");
+    },
+    async takeSnapshot(): Promise<RecordingSnapshot | null> {
+      syncEditor();
+      if (!currentEditor) return null;
+      emitContent("snapshot");
+      return {
+        id: generateId("snap"),
+        timestampMs: clock.now(),
+        eventSeq: bus.lastSeq(),
+        state: snapshotState(currentEditor),
+      };
+    },
+    setLanguage(next) {
+      syncEditor();
+      if (!currentEditor || !isListening()) return;
+      const from = readLanguage();
+      if (from === next) return;
+      emitContent("snapshot");
+      const model = currentEditor.getModel();
+      if (model) {
+        deps.setModelLanguage?.(model, next);
+      }
+      setStableLanguage(next);
+      bus.emit({
+        type: "language-change",
+        source: "editor",
+        track: "main",
+        payload: { from, to: next },
+      });
+    },
   };
 };
+
+function classifyContentChange(event: ContentChangedEvent): DetectedContentChangeReason {
+  if (event.isUndoing) return "undo";
+  if (event.isRedoing) return "redo";
+  const changes = event.changes ?? [];
+  if (changes.length > 1) return "format";
+  if (changes.some((change) => (change.text?.length ?? 0) > 1 && change.text?.includes("\n"))) {
+    return "paste";
+  }
+  return "input";
+}
+
+function toSelection(selection: MonacoSelectionLike | null): SelectionChangePayload["selection"] {
+  if (!selection) return null;
+  return {
+    startLineNumber: selection.startLineNumber,
+    startColumn: selection.startColumn,
+    endLineNumber: selection.endLineNumber,
+    endColumn: selection.endColumn,
+  };
+}
+
+function readFontSize(editor: MonacoEditor.IStandaloneCodeEditor): number {
+  const options = readRawOptions(editor);
+  return typeof options.fontSize === "number" ? options.fontSize : 14;
+}
+
+function readTheme(editor: MonacoEditor.IStandaloneCodeEditor): RecordingTheme {
+  const options = readRawOptions(editor);
+  const theme = typeof options.theme === "string" ? options.theme : "";
+  return theme.includes("light") ? "light" : "dark";
+}
+
+function readRawOptions(editor: MonacoEditor.IStandaloneCodeEditor): Record<string, unknown> {
+  const candidate = editor as MonacoEditor.IStandaloneCodeEditor & {
+    getRawOptions?: () => unknown;
+  };
+  const options = candidate.getRawOptions?.();
+  return typeof options === "object" && options !== null ? (options as Record<string, unknown>) : {};
+}
+
+function hashContent(value: string): string {
+  let hash = 0x811c9dc5;
+  for (let index = 0; index < value.length; index += 1) {
+    hash ^= value.charCodeAt(index);
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return `fnv1a-${(hash >>> 0).toString(16)}`;
+}
+
+function stableStateKey(state: ReplayStableState): string {
+  return JSON.stringify(state);
+}

--- a/apps/web/src/features/capture/types.ts
+++ b/apps/web/src/features/capture/types.ts
@@ -35,6 +35,11 @@ export type EditorProducerDeps = ProducerCommonDeps & {
   getEditor(): MonacoEditor.IStandaloneCodeEditor | null;
   /** Reports the *current* editor language so language-change events can be deduped. */
   getCurrentLanguage(): RecordingLanguage;
+  /** Applies a producer-driven language change to the current Monaco model. */
+  setModelLanguage?(
+    model: MonacoEditor.ITextModel,
+    language: RecordingLanguage,
+  ): void;
 };
 
 export type EditorProducerHandle = EventProducer & {

--- a/apps/web/src/features/editor/CodeEditor.tsx
+++ b/apps/web/src/features/editor/CodeEditor.tsx
@@ -5,6 +5,7 @@ import type { RecordingLanguage } from "@/shared/recording-schema";
 export type CodeEditorHandle = {
   /** Lazy accessor — null until the editor has mounted. */
   getEditor(): Monaco.editor.IStandaloneCodeEditor | null;
+  setModelLanguage(language: RecordingLanguage): void;
 };
 
 export type CodeEditorProps = {
@@ -138,7 +139,19 @@ export const CodeEditor = forwardRef<CodeEditorHandle, CodeEditorProps>(function
   latestPropsRef.current = { language, fontSize, theme };
   onMountRef.current = onMount;
 
-  useImperativeHandle(ref, () => ({ getEditor: () => editorRef.current }), []);
+  useImperativeHandle(
+    ref,
+    () => ({
+      getEditor: () => editorRef.current,
+      setModelLanguage: (nextLanguage) => {
+        const monaco = monacoRef.current;
+        const model = modelRef.current;
+        if (!monaco || !model) return;
+        monaco.editor.setModelLanguage(model, nextLanguage);
+      },
+    }),
+    [],
+  );
 
   useEffect(() => {
     let cancelled = false;

--- a/apps/web/src/features/recorder/RecorderPage.tsx
+++ b/apps/web/src/features/recorder/RecorderPage.tsx
@@ -22,7 +22,9 @@ import {
 import type {
   CameraPositionPayload,
   RecordingControllerState,
+  RecordingLanguage,
   RecordStartPayload,
+  RunStartPayload,
 } from "@/shared/recording-schema";
 
 const INITIAL_CONTROLLER_STATE: RecordingControllerState = {
@@ -62,11 +64,18 @@ export function RecorderPage() {
     const runtime = createIframeRuntime();
     const repository = createRecordingStore();
     const devices = createMediaDevicesController();
+    let currentEditorLanguage: RecordingLanguage = "javascript";
+    const getCurrentRuntimeLanguage = (): RunStartPayload["language"] =>
+      currentEditorLanguage === "typescript" ? "typescript" : "javascript";
     const editorProducer = createEditorProducer({
       bus,
       clock,
       getEditor: () => editorRef.current?.getEditor() ?? null,
-      getCurrentLanguage: () => "javascript",
+      getCurrentLanguage: () => currentEditorLanguage,
+      setModelLanguage: (_model, language) => {
+        currentEditorLanguage = language;
+        editorRef.current?.setModelLanguage(language);
+      },
     });
     const pointerProducer = createPointerProducer({
       bus,
@@ -104,6 +113,8 @@ export function RecorderPage() {
       editorProducer,
       mediaProducer,
       runtimeProducer,
+      getCurrentEditorLanguage: () => currentEditorLanguage,
+      getCurrentRuntimeLanguage,
     };
   }, []);
 
@@ -120,7 +131,7 @@ export function RecorderPage() {
 
   const handleStart = async () => {
     const payload: RecordStartPayload = {
-      initialLanguage: "javascript",
+      initialLanguage: stack.getCurrentEditorLanguage(),
       initialFontSize: 14,
       initialTheme: "dark",
       selectedAudioDeviceId: null,
@@ -141,8 +152,9 @@ export function RecorderPage() {
   const handleRun = async () => {
     const editor = editorRef.current?.getEditor();
     if (!editor) return;
+    stack.editorProducer.flushPending();
     await stack.runtimeProducer.trigger({
-      language: "javascript",
+      language: stack.getCurrentRuntimeLanguage(),
       source: editor.getValue(),
     });
   };

--- a/apps/web/src/features/recorder/__tests__/RecorderPage.test.tsx
+++ b/apps/web/src/features/recorder/__tests__/RecorderPage.test.tsx
@@ -1,0 +1,159 @@
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { forwardRef, useImperativeHandle } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { EditorProducerDeps, EditorProducerHandle } from "@/features/capture/types";
+import type { CodeEditorHandle } from "@/features/editor/CodeEditor";
+import type { RecordingLanguage } from "@/shared/recording-schema";
+import type * as ReactRouterDom from "react-router-dom";
+
+const recorderPageMock = vi.hoisted(() => {
+  const editorModel = {};
+  const editorValue = { current: "" };
+  const editor = {
+    getValue: vi.fn(() => editorValue.current),
+    getModel: vi.fn(() => editorModel),
+  };
+  const setModelLanguage = vi.fn();
+  const navigate = vi.fn();
+  const trigger = vi.fn(async () => ({
+    runId: "run-test",
+    status: "complete" as const,
+    stdout: [],
+    stderr: [],
+    previewHtml: "<div>ok</div>",
+  }));
+  const flushPending = vi.fn();
+  const editorProducer = {
+    start: vi.fn(),
+    pause: vi.fn(),
+    resume: vi.fn(),
+    stop: vi.fn(),
+    dispose: vi.fn(),
+    flushPending,
+    takeSnapshot: vi.fn(async () => null),
+    setLanguage: vi.fn((next: RecordingLanguage) => {
+      editorProducerDeps?.setModelLanguage?.(editorModel as never, next);
+    }),
+  } as unknown as EditorProducerHandle;
+  let editorProducerDeps: EditorProducerDeps | null = null;
+
+  return {
+    editor,
+    editorValue,
+    setModelLanguage,
+    navigate,
+    trigger,
+    flushPending,
+    editorProducer,
+    get editorProducerDeps() {
+      return editorProducerDeps;
+    },
+    setEditorProducerDeps(next: EditorProducerDeps) {
+      editorProducerDeps = next;
+    },
+    reset() {
+      editorValue.current = "";
+      editor.getValue.mockClear();
+      editor.getModel.mockClear();
+      setModelLanguage.mockClear();
+      navigate.mockClear();
+      trigger.mockClear();
+      flushPending.mockClear();
+      vi.mocked(editorProducer.start).mockClear();
+      vi.mocked(editorProducer.pause).mockClear();
+      vi.mocked(editorProducer.resume).mockClear();
+      vi.mocked(editorProducer.stop).mockClear();
+      vi.mocked(editorProducer.dispose).mockClear();
+      vi.mocked(editorProducer.takeSnapshot).mockClear();
+      vi.mocked(editorProducer.setLanguage).mockClear();
+      editorProducerDeps = null;
+    },
+  };
+});
+
+vi.mock("react-router-dom", async () => {
+  const actual = await vi.importActual<typeof ReactRouterDom>("react-router-dom");
+  return {
+    ...actual,
+    useNavigate: () => recorderPageMock.navigate,
+  };
+});
+
+vi.mock("@/features/editor/CodeEditor", () => ({
+  CodeEditor: forwardRef<CodeEditorHandle>(function MockCodeEditor(_props, ref) {
+    useImperativeHandle(ref, () => ({
+      getEditor: () => recorderPageMock.editor as never,
+      setModelLanguage: recorderPageMock.setModelLanguage,
+    }));
+    return <div aria-label="Mock code editor" />;
+  }),
+}));
+
+vi.mock("@/features/capture", () => ({
+  createEditorProducer: vi.fn((deps: EditorProducerDeps) => {
+    recorderPageMock.setEditorProducerDeps(deps);
+    return recorderPageMock.editorProducer;
+  }),
+  createMediaProducer: vi.fn(() => ({
+    start: vi.fn(),
+    pause: vi.fn(),
+    resume: vi.fn(),
+    stop: vi.fn(),
+    dispose: vi.fn(),
+    setMicrophoneEnabled: vi.fn(),
+    setCameraEnabled: vi.fn(),
+    reportCameraPosition: vi.fn(),
+  })),
+  createPointerProducer: vi.fn(() => ({
+    start: vi.fn(),
+    pause: vi.fn(),
+    resume: vi.fn(),
+    stop: vi.fn(),
+    dispose: vi.fn(),
+  })),
+  createRuntimeProducer: vi.fn(() => ({
+    start: vi.fn(),
+    pause: vi.fn(),
+    resume: vi.fn(),
+    stop: vi.fn(),
+    dispose: vi.fn(),
+    trigger: recorderPageMock.trigger,
+  })),
+  createShortcutProducer: vi.fn(() => ({
+    start: vi.fn(),
+    pause: vi.fn(),
+    resume: vi.fn(),
+    stop: vi.fn(),
+    dispose: vi.fn(),
+  })),
+}));
+
+describe("RecorderPage", () => {
+  beforeEach(() => {
+    recorderPageMock.reset();
+  });
+
+  it("runs with the current editor language after producer-driven language changes", async () => {
+    const { RecorderPage } = await import("../RecorderPage");
+    recorderPageMock.editorValue.current = "const value: number = 1;";
+
+    render(<RecorderPage />);
+    await waitFor(() => expect(recorderPageMock.editorProducerDeps).not.toBeNull());
+
+    await act(async () => {
+      recorderPageMock.editorProducer.setLanguage("typescript");
+    });
+    fireEvent.click(screen.getByRole("button", { name: "运行代码" }));
+
+    await waitFor(() =>
+      expect(recorderPageMock.trigger).toHaveBeenCalledWith({
+        language: "typescript",
+        source: "const value: number = 1;",
+      }),
+    );
+    expect(recorderPageMock.flushPending).toHaveBeenCalledTimes(1);
+    expect(recorderPageMock.flushPending.mock.invocationCallOrder[0]).toBeLessThan(
+      recorderPageMock.trigger.mock.invocationCallOrder[0],
+    );
+  });
+});

--- a/apps/web/src/features/recorder/__tests__/eventBus.test.ts
+++ b/apps/web/src/features/recorder/__tests__/eventBus.test.ts
@@ -60,6 +60,24 @@ describe("createEventBus", () => {
     expect(bus.peek().length).toBe(0);
   });
 
+  it("keeps the last emitted seq after drain and resets it on reset", () => {
+    const { bus } = setup();
+    expect(bus.lastSeq()).toBe(0);
+
+    const event = bus.emit({
+      type: "language-change",
+      source: "editor",
+      track: "main",
+      payload: { from: "javascript", to: "typescript" },
+    });
+
+    expect(bus.lastSeq()).toBe(event.seq);
+    bus.drain();
+    expect(bus.lastSeq()).toBe(event.seq);
+    bus.reset();
+    expect(bus.lastSeq()).toBe(0);
+  });
+
   it("notifies subscribers in arrival order", () => {
     const { bus } = setup();
     const seen: number[] = [];

--- a/apps/web/src/features/recorder/eventBus.ts
+++ b/apps/web/src/features/recorder/eventBus.ts
@@ -29,6 +29,7 @@ export function createEventBus(options: EventBusOptions): EventBus {
   const wallTimeProvider = options.wallTimeProvider ?? (() => new Date().toISOString());
 
   let nextSeq = 1;
+  let lastSeq = 0;
   const buffer: RecordingEvent[] = [];
   const listeners = new Set<(event: RecordingEvent) => void>();
 
@@ -48,6 +49,7 @@ export function createEventBus(options: EventBusOptions): EventBus {
         type: input.type,
         payload: input.payload,
       } as Extract<RecordingEvent, { type: TType }>;
+      lastSeq = seq;
       buffer.push(event);
       listeners.forEach((listener) => listener(event));
       return event;
@@ -60,6 +62,9 @@ export function createEventBus(options: EventBusOptions): EventBus {
     peek() {
       return Object.freeze(buffer.slice());
     },
+    lastSeq() {
+      return lastSeq;
+    },
     subscribe(listener) {
       listeners.add(listener);
       return () => {
@@ -68,6 +73,7 @@ export function createEventBus(options: EventBusOptions): EventBus {
     },
     reset() {
       nextSeq = 1;
+      lastSeq = 0;
       buffer.length = 0;
     },
   };

--- a/apps/web/src/shared/recording-schema/__tests__/validators.test.ts
+++ b/apps/web/src/shared/recording-schema/__tests__/validators.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   RECORDING_SCHEMA_VERSION,
+  type EventBus,
   type RecordingEvent,
   type RecordingPackageV1,
 } from "../types";
@@ -155,6 +156,16 @@ describe("assertEventSeqInvariants", () => {
   it("rejects out-of-order seq", () => {
     const result = assertEventSeqInvariants([mockEvent(2), mockEvent(1)]);
     expect(result.ok).toBe(false);
+  });
+});
+
+describe("EventBus contract", () => {
+  it("exposes a global lastSeq accessor for snapshot alignment after drain", () => {
+    const busContract: Pick<EventBus, "lastSeq"> = {
+      lastSeq: () => 12,
+    };
+
+    expect(busContract.lastSeq()).toBe(12);
   });
 });
 

--- a/apps/web/src/shared/recording-schema/types.ts
+++ b/apps/web/src/shared/recording-schema/types.ts
@@ -482,6 +482,7 @@ export type EventBus = {
   ): Extract<RecordingEvent, { type: TType }>;
   drain(): RecordingEvent[];
   peek(): readonly RecordingEvent[];
+  lastSeq(): number;
   subscribe(listener: (event: RecordingEvent) => void): () => void;
   reset(): void;
 };


### PR DESCRIPTION
## Summary

- Implement `createEditorProducer` for Monaco content, selection, scroll, language, lifecycle, and snapshot capture.
- Coalesce `content-change` with 300ms debounce and 1000ms idle flush, with semantic flush before run/pause/stop/snapshot and paste/format/undo/redo.
- Wire run-time flush and producer-driven model language updates through `RecorderPage` and `CodeEditor`.
- Harden snapshot/rebind contracts: snapshots use global last event seq after drain, and editor rebind flushes pending content before switching instances.
- Add focused unit coverage for debounce/flush, dedupe, selection, scroll, language, snapshot, rebind, pause/resume, stop, dispose, and TypeScript run language behavior.

## GitNexus 影响分析摘要

风险等级: CRITICAL
关键骨架变更: `EventBus` 增加 `lastSeq()` 快照对齐契约；`editorProducer.takeSnapshot()` 改用全局 last seq；`syncEditor()` 在 rebind 前同步 flush pending content；`RecorderPage` 的 Run 路径使用当前 JS/TS runtime language。
GitNexus 影响面: `detect_changes` 报 critical，涉及 `createEditorProducer`、`syncEditor`、`createEventBus` 和 recording-schema type；`context/impact` 显示 `createEventBus` 上游仅 `RecorderPage.stack` 且风险 LOW，`syncEditor` 上游影响 start/pause/resume/takeSnapshot/setLanguage 等 capture 内部流程且风险 CRITICAL。
验证结果: 红绿测试覆盖 bus drain 后 snapshot eventSeq、rebind pending flush、TypeScript Run language；`npm run test:web -- editorProducer eventBus validators`、`npm run test:web -- editorProducer eventBus RecorderPage CodeEditor runtimeProducer recordingController packageBuilder`、`npm run lint:web -- --quiet`、`npm run quality:local` 均已通过。

## Validation

- `npm run quality:predev`
- `npm run agent:bootstrap`
- `npm run test:web -- editorProducer eventBus validators`
- `npm run test:web -- editorProducer eventBus RecorderPage CodeEditor runtimeProducer recordingController packageBuilder`
- `npm run lint:web -- --quiet`
- `npm run quality:local`
- Commit hook: `quality:precommit`
- Push hook: `quality:local`

Closes #65
