### PR TITLE
#59 #2 RecordingLibraryPage 列表 UI 与导入导出入口

### DIFF
--- a/apps/web/src/features/library/RecordingLibraryPage.tsx
+++ b/apps/web/src/features/library/RecordingLibraryPage.tsx
@@ -1,9 +1,9 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
-import { Link } from "react-router-dom";
+import { type ChangeEvent, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { Link, useNavigate } from "react-router-dom";
 import { createRecordingStore } from "./recordingStore";
 import { formatDurationMs } from "@/shared/time/duration";
-import { IconButton } from "@/shared/ui";
-import type { RecordingListItem } from "@/shared/recording-schema";
+import { IconButton, Popover, Tooltip } from "@/shared/ui";
+import type { RecordingListItem, SaveResult } from "@/shared/recording-schema";
 
 /**
  * RecordingLibraryPage — wires the RecordingRepository and lists completed
@@ -15,102 +15,574 @@ import type { RecordingListItem } from "@/shared/recording-schema";
  * works and supplies the minimum entries (open, rename, delete, export).
  */
 export function RecordingLibraryPage() {
+  const navigate = useNavigate();
   const repository = useMemo(() => createRecordingStore(), []);
   const [items, setItems] = useState<RecordingListItem[]>([]);
   const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
+  const [feedbackDialog, setFeedbackDialog] = useState<{ tone: "success" | "error"; message: string } | null>(null);
+  const [pendingRenameId, setPendingRenameId] = useState<string | null>(null);
+  const [pendingRenameValue, setPendingRenameValue] = useState("");
+  const [renameError, setRenameError] = useState<string | null>(null);
+  const [pendingDeleteId, setPendingDeleteId] = useState<string | null>(null);
+  const [deleteError, setDeleteError] = useState<string | null>(null);
+  const [busyKey, setBusyKey] = useState<string | null>(null);
+  const [importing, setImporting] = useState(false);
+  const [quota, setQuota] = useState<{ usageBytes: number; quotaBytes: number } | null>(null);
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
 
   const refresh = useCallback(async () => {
     setLoading(true);
+    let loadError: string | null = null;
     try {
       const list = await repository.list();
       setItems(list);
-      setError(null);
+      
     } catch (err) {
-      setError((err as Error).message);
+      loadError = `读取失败：${(err as Error).message}`;
+      
     } finally {
       setLoading(false);
+    }
+    if (loadError) {
+      setTimeout(() => {
+        setFeedbackDialog({ tone: "error", message: loadError as string });
+      }, 0);
+    }
+  }, [repository]);
+
+  const refreshQuota = useCallback(async () => {
+    try {
+      const estimate = await repository.estimateQuota();
+      setQuota(estimate.quotaBytes > 0 ? estimate : null);
+    } catch {
+      setQuota(null);
     }
   }, [repository]);
 
   useEffect(() => {
     void refresh();
-    void repository.sweep();
-  }, [refresh, repository]);
+    void refreshQuota();
+    void repository.sweep().catch(() => {
+      // Sweep failure should not block library rendering.
+    });
+  }, [refresh, refreshQuota, repository]);
 
-  const handleDelete = async (id: string) => {
-    await repository.remove(id);
-    void refresh();
+  const handleDelete = async (item: RecordingListItem) => {
+    setBusyKey(`delete-${item.id}`);
+    setDeleteError(null);
+    try {
+      await repository.remove(item.id);
+      setPendingDeleteId(null);
+      await refresh();
+      await refreshQuota();
+    } catch (err) {
+      setDeleteError(`删除失败：${(err as Error).message}`);
+    } finally {
+      setBusyKey(null);
+    }
+  };
+
+  const handleRenameStart = (item: RecordingListItem) => {
+    setPendingRenameId(item.id);
+    setPendingRenameValue(item.title);
+    setRenameError(null);
+  };
+
+  const handleRenameCancel = () => {
+    setPendingRenameId(null);
+    setPendingRenameValue("");
+    setRenameError(null);
+  };
+
+  const handleRenameSubmit = async (item: RecordingListItem) => {
+    const nextTitle = pendingRenameValue.trim();
+    if (!nextTitle) {
+      setRenameError("标题不能为空。");
+      return;
+    }
+    if (nextTitle === item.title) {
+      handleRenameCancel();
+      return;
+    }
+    setBusyKey(`rename-${item.id}`);
+    try {
+      await repository.rename(item.id, nextTitle);
+      handleRenameCancel();
+      await refresh();
+    } catch (err) {
+      setRenameError(`重命名失败：${(err as Error).message}`);
+    } finally {
+      setBusyKey(null);
+    }
+  };
+
+  const handleExport = async (item: RecordingListItem) => {
+    setBusyKey(`export-${item.id}`);
+    try {
+      const zipBlob = await repository.exportZip(item.id);
+      downloadBlob(zipBlob, `${safeFilenameStem(item.title, item.id)}.zip`);
+      openFeedbackDialog("success", `已导出「${item.title}」。`);
+    } catch (err) {
+      openFeedbackDialog("error", `导出失败：${(err as Error).message}`);
+    } finally {
+      setBusyKey(null);
+    }
+  };
+
+  const handleImportChange = async (event: ChangeEvent<HTMLInputElement>) => {
+    const file = event.currentTarget.files?.[0];
+    event.currentTarget.value = "";
+    if (!file) return;
+    setImporting(true);
+    try {
+      const imported = await repository.importZip(file);
+      if (!imported.ok) {
+        openFeedbackDialog("error", buildImportErrorMessage(imported));
+        return;
+      }
+      openFeedbackDialog("success", `导入成功：${file.name}`);
+      await refresh();
+      await refreshQuota();
+    } catch (err) {
+      openFeedbackDialog("error", `导入失败：${(err as Error).message}`);
+    } finally {
+      setImporting(false);
+    }
+  };
+
+  const quotaLabel = useMemo(() => {
+    if (!quota || quota.quotaBytes <= 0) return null;
+    const usageMB = (quota.usageBytes / (1024 * 1024)).toFixed(1);
+    const quotaMB = (quota.quotaBytes / (1024 * 1024)).toFixed(1);
+    const ratio = Math.round((quota.usageBytes / quota.quotaBytes) * 100);
+    return `本地存储 ${usageMB} / ${quotaMB} MB (${ratio}%)`;
+  }, [quota]);
+
+  const canImport = !loading && !importing;
+  const showEmpty = !loading && items.length === 0;
+
+  const openImportPicker = () => {
+    fileInputRef.current?.click();
+  };
+
+  const openFeedbackDialog = (tone: "success" | "error", message: string) => {
+    setFeedbackDialog({ tone, message });
   };
 
   return (
-    <div className="mx-auto flex h-full max-w-5xl flex-col gap-6 px-6 py-10">
-      <header className="flex items-center justify-between gap-4">
+    <div className="flex h-full flex-col gap-6 px-16 py-6">
+      <header className="flex flex-wrap items-center justify-between gap-4">
         <div>
           <p className="text-xs uppercase tracking-[0.3em] text-muted">code-tape</p>
           <h1 className="font-display text-3xl font-semibold">我的录制</h1>
+          {quotaLabel ? <p className="mt-2 text-xs text-muted">{quotaLabel}</p> : null}
         </div>
-        <Link
-          to="/record"
-          className="rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition-opacity hover:opacity-90"
-        >
-          新建录制
-        </Link>
+        <div className="flex items-center gap-2">
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept=".zip,application/zip"
+            className="hidden"
+            aria-label="导入 zip 文件"
+            onChange={(event) => void handleImportChange(event)}
+          />
+          <button
+            type="button"
+            className="rounded-md border border-border bg-surface px-3 py-2 text-sm font-medium text-foreground transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50"
+            onClick={openImportPicker}
+            disabled={!canImport}
+          >
+            {importing ? "导入中…" : "导入 ZIP"}
+          </button>
+          <Link
+            to="/record"
+            className="rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition-opacity hover:opacity-90"
+          >
+            新建录制
+          </Link>
+        </div>
       </header>
 
-      {loading ? (
-        <p className="text-sm text-muted">加载中…</p>
-      ) : error ? (
-        <p className="text-sm text-danger">读取失败：{error}</p>
-      ) : items.length === 0 ? (
+      {showEmpty ? (
         <div className="flex flex-1 flex-col items-center justify-center gap-3 rounded-md border border-dashed border-border bg-surface/60 p-12 text-center">
           <p className="font-display text-lg">还没有录制</p>
           <p className="max-w-sm text-sm text-muted">
             点击右上角「新建录制」开始第一段代码讲解。
-            <br />
-            列表 UI 由 issue「[P0] RecordingLibraryPage 列表 UI」深化。
           </p>
         </div>
       ) : (
-        <ul className="divide-y divide-border rounded-md border border-border bg-surface/60">
-          {items.map((item) => (
-            <li key={item.id} className="flex items-center justify-between gap-4 px-4 py-3">
-              <div className="min-w-0">
-                <Link
-                  to={`/replay/${item.id}`}
-                  className="block truncate font-medium text-foreground hover:underline"
-                >
-                  {item.title}
-                </Link>
-                <p className="mt-1 text-xs text-muted">
-                  {new Date(item.createdAt).toLocaleString()} · {formatDurationMs(item.durationMs)} ·{" "}
-                  {item.initialLanguage}
-                  {item.hasAudio ? " · 音频" : ""}
-                  {item.hasCamera ? " · 摄像头" : ""}
-                </p>
-              </div>
-              <div className="flex items-center gap-1">
-                <IconButton
-                  icon={<span aria-hidden>▶</span>}
-                  label="回放"
-                  variant="ghost"
-                  size="sm"
-                  onClick={() => {
-                    window.location.assign(`/replay/${item.id}`);
-                  }}
-                />
-                <IconButton
-                  icon={<span aria-hidden>✕</span>}
-                  label="删除"
-                  variant="ghost"
-                  size="sm"
-                  onClick={() => void handleDelete(item.id)}
-                />
-              </div>
-            </li>
-          ))}
-        </ul>
+        <div className="overflow-x-auto rounded-md border border-border bg-surface/60">
+          <table className="w-full table-fixed border-collapse text-sm">
+            <colgroup>
+              <col className="w-[18rem]" />
+              <col className="w-[13rem]" />
+              <col className="w-[12rem]" />
+              <col className="w-[8rem]" />
+              <col className="w-[8rem]" />
+              <col className="w-[13rem]" />
+            </colgroup>
+            <thead className="bg-surface-raised text-xs uppercase tracking-wide text-muted">
+              <tr>
+                <th className="px-4 py-3 text-center font-medium">标题</th>
+                <th className="px-4 py-3 text-left font-medium">创建时间</th>
+                <th className="px-4 py-3 text-left font-medium">时长</th>
+                <th className="px-4 py-3 text-left font-medium">语言</th>
+                <th className="px-4 py-3 text-left font-medium">设备</th>
+                <th className="px-4 py-3 text-center font-medium">操作</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-border">
+              {items.map((item) => (
+                <tr key={item.id} className="align-top">
+                  <td className="px-4 py-3 text-center">
+                    <EllipsisLink
+                      to={`/replay/${item.id}`}
+                      text={item.title}
+                      className="font-medium text-foreground hover:underline"
+                      align="center"
+                    />
+                  </td>
+                  <td className="px-4 py-3 text-muted">
+                    <EllipsisText text={formatCreatedAt(item.createdAt)} />
+                  </td>
+                  <td className="px-4 py-3 text-muted">
+                    <EllipsisText text={formatDurationMs(item.durationMs)} />
+                  </td>
+                  <td className="px-4 py-3 text-muted">
+                    <EllipsisText text={formatLanguage(item.initialLanguage)} />
+                  </td>
+                  <td className="px-4 py-3 text-muted">
+                    <EllipsisText
+                      text={`${item.hasAudio ? "音频" : "无音频"} · ${item.hasCamera ? "摄像头" : "无摄像头"}`}
+                    />
+                  </td>
+                  <td className="px-4 py-3">
+                    <div className="flex items-center justify-end gap-1">
+                      <IconButton
+                        icon={<span aria-hidden>▶</span>}
+                        label="回放"
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => navigate(`/replay/${item.id}`)}
+                        disabled={busyKey !== null || importing}
+                      />
+                      <Popover
+                        open={pendingRenameId === item.id}
+                        onOpenChange={(open) => {
+                          if (open) {
+                            handleRenameStart(item);
+                          } else {
+                            handleRenameCancel();
+                          }
+                        }}
+                        align="end"
+                        side="top"
+                        width={300}
+                        trigger={(
+                          <IconButton
+                            icon={<span aria-hidden>✎</span>}
+                            label="重命名"
+                            variant="ghost"
+                            size="sm"
+                            disabled={busyKey !== null || importing}
+                          />
+                        )}
+                      >
+                        <form
+                          className="space-y-2"
+                          onSubmit={(event) => {
+                            event.preventDefault();
+                            void handleRenameSubmit(item);
+                          }}
+                        >
+                          <p className="text-xs text-foreground">重命名「{item.title}」</p>
+                          <input
+                            value={pendingRenameId === item.id ? pendingRenameValue : item.title}
+                            onChange={(event) => setPendingRenameValue(event.target.value)}
+                            className="w-full rounded-md border border-border bg-background px-3 py-1.5 text-sm text-foreground outline-none focus:ring-2 focus:ring-focus"
+                            placeholder="输入新标题"
+                            aria-label={`重命名 ${item.title}`}
+                            autoFocus
+                          />
+                          {renameError && pendingRenameId === item.id ? (
+                            <p className="text-[11px] text-danger">{renameError}</p>
+                          ) : null}
+                          <div className="flex justify-end gap-2">
+                            <button
+                              type="button"
+                              className="rounded-md border border-border px-2 py-1 text-xs text-muted"
+                              onClick={handleRenameCancel}
+                              disabled={busyKey === `rename-${item.id}`}
+                            >
+                              取消
+                            </button>
+                            <button
+                              type="submit"
+                              className="rounded-md border border-border px-2 py-1 text-xs text-foreground"
+                              disabled={busyKey === `rename-${item.id}`}
+                            >
+                              {busyKey === `rename-${item.id}` ? "保存中…" : "保存"}
+                            </button>
+                          </div>
+                        </form>
+                      </Popover>
+                      <IconButton
+                        icon={<span aria-hidden>⇩</span>}
+                        label="导出 ZIP"
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => void handleExport(item)}
+                        disabled={busyKey !== null || importing}
+                      />
+                      <Popover
+                        open={pendingDeleteId === item.id}
+                        onOpenChange={(open) => {
+                          setPendingDeleteId(open ? item.id : null);
+                          if (!open) setDeleteError(null);
+                        }}
+                        align="end"
+                        side="top"
+                        width={260}
+                        trigger={(
+                          <IconButton
+                            icon={<span aria-hidden>✕</span>}
+                            label="删除"
+                            variant="ghost"
+                            size="sm"
+                            disabled={busyKey !== null || importing}
+                          />
+                        )}
+                      >
+                        <div className="space-y-2">
+                          <p className="text-xs text-foreground">确认删除「{item.title}」？</p>
+                          <p className="text-[11px] text-muted">删除后不可恢复。</p>
+                          {deleteError && pendingDeleteId === item.id ? (
+                            <p className="text-[11px] text-danger">{deleteError}</p>
+                          ) : null}
+                          <div className="flex justify-end gap-2">
+                            <button
+                              type="button"
+                              className="rounded-md border border-border px-2 py-1 text-xs text-muted"
+                              onClick={() => {
+                                setPendingDeleteId(null);
+                                setDeleteError(null);
+                              }}
+                              disabled={busyKey === `delete-${item.id}`}
+                            >
+                              取消
+                            </button>
+                            <button
+                              type="button"
+                              className="rounded-md border border-danger/50 bg-danger/10 px-2 py-1 text-xs text-danger"
+                              onClick={() => void handleDelete(item)}
+                              disabled={busyKey === `delete-${item.id}`}
+                            >
+                              {busyKey === `delete-${item.id}` ? "删除中…" : "确认删除"}
+                            </button>
+                          </div>
+                        </div>
+                      </Popover>
+                    </div>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
       )}
+      {loading ? (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-background/60 p-4 backdrop-blur-sm">
+          <div
+            role="status"
+            aria-live="polite"
+            className="w-full max-w-xs rounded-md border border-border bg-popover p-4 shadow-elevation-3"
+          >
+            <p className="text-sm text-foreground">加载中…</p>
+          </div>
+        </div>
+      ) : null}
+      {feedbackDialog ? (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-background/60 p-4 backdrop-blur-sm">
+          <div
+            role="dialog"
+            aria-modal="true"
+            className="w-full max-w-sm rounded-md border border-border bg-popover p-4 shadow-elevation-3"
+          >
+            <p
+              className={[
+                "text-sm",
+                feedbackDialog.tone === "error" ? "text-danger" : "text-foreground",
+              ].join(" ")}
+            >
+              {feedbackDialog.message}
+            </p>
+            <div className="mt-4 flex justify-end">
+              <button
+                type="button"
+                className="rounded-md border border-border px-3 py-1.5 text-xs text-foreground"
+                onClick={() => setFeedbackDialog(null)}
+              >
+                确认
+              </button>
+            </div>
+          </div>
+        </div>
+      ) : null}
     </div>
   );
+}
+
+type EllipsisTextProps = {
+  text: string;
+  align?: "left" | "center" | "right";
+  className?: string;
+};
+
+function EllipsisText({ text, align = "left", className = "" }: EllipsisTextProps) {
+  const ref = useRef<HTMLSpanElement | null>(null);
+  const [overflowing, setOverflowing] = useState(false);
+
+  useEffect(() => {
+    const node = ref.current;
+    if (!node) return;
+    const checkOverflow = () => {
+      setOverflowing(node.scrollWidth > node.clientWidth);
+    };
+    checkOverflow();
+    const observer = typeof ResizeObserver !== "undefined" ? new ResizeObserver(checkOverflow) : null;
+    observer?.observe(node);
+    window.addEventListener("resize", checkOverflow);
+    return () => {
+      observer?.disconnect();
+      window.removeEventListener("resize", checkOverflow);
+    };
+  }, [text]);
+
+  const base = (
+    <span
+      ref={ref}
+      className={[
+        "block w-full truncate",
+        align === "center" ? "text-center" : align === "right" ? "text-right" : "text-left",
+        className,
+      ].join(" ")}
+    >
+      {text}
+    </span>
+  );
+
+  if (!overflowing) return base;
+  return (
+    <Tooltip content={text} delayMs={80}>
+      <span className="block w-full">{base}</span>
+    </Tooltip>
+  );
+}
+
+type EllipsisLinkProps = {
+  to: string;
+  text: string;
+  align?: "left" | "center" | "right";
+  className?: string;
+};
+
+function EllipsisLink({ to, text, align = "left", className = "" }: EllipsisLinkProps) {
+  const ref = useRef<HTMLAnchorElement | null>(null);
+  const [overflowing, setOverflowing] = useState(false);
+  const checkOverflow = useCallback(() => {
+    const node = ref.current;
+    if (!node) return;
+    setOverflowing(node.scrollWidth > node.clientWidth + 1);
+  }, []);
+
+  useEffect(() => {
+    const node = ref.current;
+    if (!node) return;
+    checkOverflow();
+    const observer = typeof ResizeObserver !== "undefined" ? new ResizeObserver(checkOverflow) : null;
+    observer?.observe(node);
+    window.addEventListener("resize", checkOverflow);
+    return () => {
+      observer?.disconnect();
+      window.removeEventListener("resize", checkOverflow);
+    };
+  }, [checkOverflow, text]);
+
+  const link = (
+    <Link
+      ref={ref}
+      to={to}
+      onMouseEnter={checkOverflow}
+      onFocus={checkOverflow}
+      className={[
+        "inline-block max-w-full truncate align-middle",
+        align === "center" ? "text-center" : align === "right" ? "text-right" : "text-left",
+        className,
+      ].join(" ")}
+    >
+      {text}
+    </Link>
+  );
+
+  if (!overflowing) return link;
+  return (
+    <Tooltip content={text} delayMs={80}>
+      {link}
+    </Tooltip>
+  );
+}
+
+function buildImportErrorMessage(result: Extract<SaveResult, { ok: false }>): string {
+  return `导入失败：${buildSaveResultError(result)}`;
+}
+
+function buildSaveResultError(result: Extract<SaveResult, { ok: false }>): string {
+  if (result.reason === "validation-failed") {
+    return `压缩包校验不通过（${result.message}）。`;
+  }
+  if (result.reason === "quota-exceeded") {
+    return "本地存储空间不足，请清理旧录制后重试。";
+  }
+  if (result.reason === "media-write-failed") {
+    return `媒体写入失败（${result.message}）。`;
+  }
+  return result.message;
+}
+
+function safeFilenameStem(title: string, fallbackId: string): string {
+  const blockedChars = new Set(["<", ">", ":", "\"", "/", "\\", "|", "?", "*"]);
+  const normalized = [...title.trim()]
+    .map((char) => {
+      if (blockedChars.has(char)) return "_";
+      if (char.charCodeAt(0) < 32) return "_";
+      return char;
+    })
+    .join("")
+    .replace(/\s+/g, " ")
+    .slice(0, 80);
+  return normalized || fallbackId;
+}
+
+function downloadBlob(blob: Blob, filename: string): void {
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement("a");
+  anchor.href = url;
+  anchor.download = filename;
+  document.body.append(anchor);
+  anchor.click();
+  anchor.remove();
+  URL.revokeObjectURL(url);
+}
+
+function formatCreatedAt(value: string): string {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  return date.toLocaleString();
+}
+
+function formatLanguage(language: string): string {
+  if (language === "javascript") return "JavaScript";
+  if (language === "typescript") return "TypeScript";
+  if (language === "python") return "Python";
+  return language;
 }

--- a/apps/web/src/features/library/RecordingLibraryPage.tsx
+++ b/apps/web/src/features/library/RecordingLibraryPage.tsx
@@ -19,6 +19,7 @@ export function RecordingLibraryPage() {
   const repository = useMemo(() => createRecordingStore(), []);
   const [items, setItems] = useState<RecordingListItem[]>([]);
   const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState<string | null>(null);
   const [feedbackDialog, setFeedbackDialog] = useState<{ tone: "success" | "error"; message: string } | null>(null);
   const [pendingRenameId, setPendingRenameId] = useState<string | null>(null);
   const [pendingRenameValue, setPendingRenameValue] = useState("");
@@ -32,14 +33,15 @@ export function RecordingLibraryPage() {
 
   const refresh = useCallback(async () => {
     setLoading(true);
+    setLoadError(null);
     let loadError: string | null = null;
     try {
       const list = await repository.list();
       setItems(list);
-      
+      setLoadError(null);
     } catch (err) {
       loadError = `读取失败：${(err as Error).message}`;
-      
+      setLoadError(loadError);
     } finally {
       setLoading(false);
     }
@@ -159,7 +161,7 @@ export function RecordingLibraryPage() {
   }, [quota]);
 
   const canImport = !loading && !importing;
-  const showEmpty = !loading && items.length === 0;
+  const showEmpty = !loading && !loadError && items.length === 0;
 
   const openImportPicker = () => {
     fileInputRef.current?.click();
@@ -203,7 +205,18 @@ export function RecordingLibraryPage() {
         </div>
       </header>
 
-      {showEmpty ? (
+      {loadError ? (
+        <div className="flex flex-col gap-3 rounded-md border border-danger/40 bg-danger/10 p-4">
+          <p className="text-sm text-danger">{loadError}</p>
+          <button
+            type="button"
+            className="w-fit rounded-md border border-danger/50 px-3 py-1.5 text-xs font-medium text-danger"
+            onClick={() => void refresh()}
+          >
+            重试
+          </button>
+        </div>
+      ) : showEmpty ? (
         <div className="flex flex-1 flex-col items-center justify-center gap-3 rounded-md border border-dashed border-border bg-surface/60 p-12 text-center">
           <p className="font-display text-lg">还没有录制</p>
           <p className="max-w-sm text-sm text-muted">

--- a/apps/web/src/features/library/RecordingLibraryPage.tsx
+++ b/apps/web/src/features/library/RecordingLibraryPage.tsx
@@ -160,7 +160,7 @@ export function RecordingLibraryPage() {
     return `本地存储 ${usageMB} / ${quotaMB} MB (${ratio}%)`;
   }, [quota]);
 
-  const canImport = !loading && !importing;
+  const canImport = !loading && !importing && busyKey === null;
   const showEmpty = !loading && !loadError && items.length === 0;
 
   const openImportPicker = () => {

--- a/apps/web/src/features/library/RecordingLibraryPage.tsx
+++ b/apps/web/src/features/library/RecordingLibraryPage.tsx
@@ -584,7 +584,8 @@ function downloadBlob(blob: Blob, filename: string): void {
   document.body.append(anchor);
   anchor.click();
   anchor.remove();
-  URL.revokeObjectURL(url);
+  // Revoke in a later macrotask so browsers can start consuming the download URL.
+  setTimeout(() => URL.revokeObjectURL(url), 0);
 }
 
 function formatCreatedAt(value: string): string {

--- a/apps/web/src/features/library/__tests__/RecordingLibraryPage.test.tsx
+++ b/apps/web/src/features/library/__tests__/RecordingLibraryPage.test.tsx
@@ -1,0 +1,193 @@
+import { fireEvent, render, screen, waitFor, waitForElementToBeRemoved } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { RecordingListItem, RecordingRepository } from "@/shared/recording-schema";
+
+const repositoryMocks = {
+  saveDraft: vi.fn(),
+  commit: vi.fn(),
+  list: vi.fn(),
+  load: vi.fn(),
+  rename: vi.fn(),
+  remove: vi.fn(),
+  exportZip: vi.fn(),
+  importZip: vi.fn(),
+  sweep: vi.fn(),
+  estimateQuota: vi.fn(),
+};
+
+vi.mock("../recordingStore", () => ({
+  createRecordingStore: () => repositoryMocks as unknown as RecordingRepository,
+}));
+
+import { RecordingLibraryPage } from "../RecordingLibraryPage";
+
+const BASE_TITLE = "Two Sum \u8bb2\u89e3";
+const BASE_ITEM: RecordingListItem = {
+  id: "rec-1",
+  title: BASE_TITLE,
+  createdAt: "2026-05-24T08:00:00.000Z",
+  durationMs: 12_000,
+  ownerId: null,
+  creatorInfo: null,
+  initialLanguage: "typescript",
+  hasAudio: true,
+  hasCamera: false,
+  thumbnailBlobId: null,
+};
+
+function renderPage() {
+  render(
+    <MemoryRouter>
+      <RecordingLibraryPage />
+    </MemoryRouter>,
+  );
+}
+
+describe("RecordingLibraryPage", () => {
+  beforeEach(() => {
+    Object.values(repositoryMocks).forEach((fn) => fn.mockReset());
+    repositoryMocks.list.mockResolvedValue([]);
+    repositoryMocks.sweep.mockResolvedValue({ removedDrafts: 0, removedBlobs: 0 });
+    repositoryMocks.estimateQuota.mockResolvedValue({ usageBytes: 0, quotaBytes: 0 });
+    repositoryMocks.rename.mockResolvedValue(undefined);
+    repositoryMocks.remove.mockResolvedValue(undefined);
+    repositoryMocks.exportZip.mockResolvedValue(new Blob(["zip"], { type: "application/zip" }));
+    repositoryMocks.importZip.mockResolvedValue({ ok: true, recordingId: "rec-new" });
+
+    if (typeof URL.createObjectURL !== "function") {
+      Object.defineProperty(URL, "createObjectURL", {
+        writable: true,
+        value: vi.fn(() => "blob:mock"),
+      });
+    } else {
+      vi.spyOn(URL, "createObjectURL").mockReturnValue("blob:mock");
+    }
+    if (typeof URL.revokeObjectURL !== "function") {
+      Object.defineProperty(URL, "revokeObjectURL", {
+        writable: true,
+        value: vi.fn(),
+      });
+    } else {
+      vi.spyOn(URL, "revokeObjectURL").mockImplementation(() => {});
+    }
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("shows loading dialog first, then empty state", async () => {
+    renderPage();
+    expect(screen.getByRole("status")).toHaveTextContent("\u52a0\u8f7d\u4e2d");
+    await waitForElementToBeRemoved(() => screen.queryByRole("status"));
+    expect(await screen.findByText("\u8fd8\u6ca1\u6709\u5f55\u5236")).toBeInTheDocument();
+  });
+
+  it("closes loading dialog first, then shows load error dialog", async () => {
+    repositoryMocks.list.mockRejectedValueOnce(new Error("idb read failed"));
+    renderPage();
+    expect(screen.getByRole("status")).toHaveTextContent("\u52a0\u8f7d\u4e2d");
+    await waitForElementToBeRemoved(() => screen.queryByRole("status"));
+    expect(await screen.findByRole("dialog")).toHaveTextContent(
+      "\u8bfb\u53d6\u5931\u8d25\uff1aidb read failed",
+    );
+  });
+
+  it("renders recording row and replay link", async () => {
+    repositoryMocks.list.mockResolvedValue([BASE_ITEM]);
+    renderPage();
+    await waitForElementToBeRemoved(() => screen.queryByRole("status"));
+
+    expect(screen.getByRole("link", { name: BASE_TITLE })).toHaveAttribute(
+      "href",
+      expect.stringContaining("/replay/rec-1"),
+    );
+    expect(screen.getByText(/TypeScript/)).toBeInTheDocument();
+    expect(screen.getByText(/\u97f3\u9891/)).toBeInTheDocument();
+    expect(screen.getByText(/\u65e0\u6444\u50cf\u5934/)).toBeInTheDocument();
+  });
+
+  it("renames a recording and refreshes list", async () => {
+    repositoryMocks.list.mockResolvedValue([BASE_ITEM]);
+    renderPage();
+    await waitForElementToBeRemoved(() => screen.queryByRole("status"));
+
+    fireEvent.click(screen.getByRole("button", { name: "\u91cd\u547d\u540d" }));
+    fireEvent.change(screen.getByLabelText(`\u91cd\u547d\u540d ${BASE_TITLE}`), {
+      target: { value: "Two Sum \u8fdb\u9636" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "\u4fdd\u5b58" }));
+
+    await waitFor(() => {
+      expect(repositoryMocks.rename).toHaveBeenCalledWith("rec-1", "Two Sum \u8fdb\u9636");
+    });
+    expect(repositoryMocks.list).toHaveBeenCalledTimes(2);
+  });
+
+  it("deletes a recording only after confirm", async () => {
+    repositoryMocks.list.mockResolvedValue([BASE_ITEM]);
+    renderPage();
+    await waitForElementToBeRemoved(() => screen.queryByRole("status"));
+
+    fireEvent.click(screen.getByRole("button", { name: "\u5220\u9664" }));
+    expect(repositoryMocks.remove).not.toHaveBeenCalled();
+    fireEvent.click(screen.getByRole("button", { name: "\u786e\u8ba4\u5220\u9664" }));
+
+    await waitFor(() => {
+      expect(repositoryMocks.remove).toHaveBeenCalledWith("rec-1");
+      expect(repositoryMocks.list).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  it("exports a recording to zip", async () => {
+    repositoryMocks.list.mockResolvedValue([BASE_ITEM]);
+    vi.spyOn(HTMLAnchorElement.prototype, "click").mockImplementation(() => {});
+    renderPage();
+    await waitForElementToBeRemoved(() => screen.queryByRole("status"));
+
+    fireEvent.click(screen.getByRole("button", { name: "\u5bfc\u51fa ZIP" }));
+
+    await waitFor(() => {
+      expect(repositoryMocks.exportZip).toHaveBeenCalledWith("rec-1");
+      expect(URL.createObjectURL).toHaveBeenCalled();
+      expect(URL.revokeObjectURL).toHaveBeenCalled();
+    });
+  });
+
+  it("imports valid zip and refreshes list", async () => {
+    repositoryMocks.list
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([{ ...BASE_ITEM, id: "rec-new", title: "\u5bfc\u5165\u6210\u529f\u6837\u4f8b" }]);
+    renderPage();
+    await waitForElementToBeRemoved(() => screen.queryByRole("status"));
+
+    const file = new File(["zip"], "valid.zip", { type: "application/zip" });
+    fireEvent.change(screen.getByLabelText("\u5bfc\u5165 zip \u6587\u4ef6"), { target: { files: [file] } });
+
+    await waitFor(() => {
+      expect(repositoryMocks.importZip).toHaveBeenCalledTimes(1);
+      expect(repositoryMocks.list).toHaveBeenCalledTimes(2);
+    });
+    expect(await screen.findByText("\u5bfc\u5165\u6210\u529f\u6837\u4f8b")).toBeInTheDocument();
+    expect(screen.getByRole("dialog")).toHaveTextContent("\u5bfc\u5165\u6210\u529f\uff1avalid.zip");
+  });
+
+  it("shows clear error dialog for invalid zip import", async () => {
+    repositoryMocks.importZip.mockResolvedValueOnce({
+      ok: false,
+      reason: "validation-failed",
+      message: "checksum-mismatch:events",
+    });
+    renderPage();
+    await waitForElementToBeRemoved(() => screen.queryByRole("status"));
+
+    const file = new File(["bad"], "invalid.zip", { type: "application/zip" });
+    fireEvent.change(screen.getByLabelText("\u5bfc\u5165 zip \u6587\u4ef6"), { target: { files: [file] } });
+
+    expect(await screen.findByRole("dialog")).toHaveTextContent(
+      "\u5bfc\u5165\u5931\u8d25\uff1a\u538b\u7f29\u5305\u6821\u9a8c\u4e0d\u901a\u8fc7",
+    );
+  });
+});
+

--- a/apps/web/src/features/library/__tests__/RecordingLibraryPage.test.tsx
+++ b/apps/web/src/features/library/__tests__/RecordingLibraryPage.test.tsx
@@ -190,6 +190,31 @@ describe("RecordingLibraryPage", () => {
     });
   });
 
+  it("disables zip import while an item operation is busy", async () => {
+    repositoryMocks.list.mockResolvedValue([BASE_ITEM]);
+    vi.spyOn(HTMLAnchorElement.prototype, "click").mockImplementation(() => {});
+    let finishExport: (blob: Blob) => void = () => {};
+    repositoryMocks.exportZip.mockImplementationOnce(
+      () =>
+        new Promise<Blob>((resolve) => {
+          finishExport = resolve;
+        }),
+    );
+    renderPage();
+    await waitForElementToBeRemoved(() => screen.queryByRole("status"));
+
+    fireEvent.click(screen.getByRole("button", { name: "\u5bfc\u51fa ZIP" }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "\u5bfc\u5165 ZIP" })).toBeDisabled();
+    });
+
+    finishExport(new Blob(["zip"], { type: "application/zip" }));
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "\u5bfc\u5165 ZIP" })).not.toBeDisabled();
+    });
+  });
+
   it("shows export failure dialog", async () => {
     repositoryMocks.list.mockResolvedValue([BASE_ITEM]);
     repositoryMocks.exportZip.mockRejectedValueOnce(new Error("zip failed"));

--- a/apps/web/src/features/library/__tests__/RecordingLibraryPage.test.tsx
+++ b/apps/web/src/features/library/__tests__/RecordingLibraryPage.test.tsx
@@ -196,4 +196,3 @@ describe("RecordingLibraryPage", () => {
     );
   });
 });
-

--- a/apps/web/src/features/library/__tests__/RecordingLibraryPage.test.tsx
+++ b/apps/web/src/features/library/__tests__/RecordingLibraryPage.test.tsx
@@ -131,6 +131,21 @@ describe("RecordingLibraryPage", () => {
     expect(repositoryMocks.list).toHaveBeenCalledTimes(2);
   });
 
+  it("rejects blank rename title without calling repository", async () => {
+    repositoryMocks.list.mockResolvedValue([BASE_ITEM]);
+    renderPage();
+    await waitForElementToBeRemoved(() => screen.queryByRole("status"));
+
+    fireEvent.click(screen.getByRole("button", { name: "\u91cd\u547d\u540d" }));
+    fireEvent.change(screen.getByLabelText(`\u91cd\u547d\u540d ${BASE_TITLE}`), {
+      target: { value: "   " },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "\u4fdd\u5b58" }));
+
+    expect(await screen.findByText("\u6807\u9898\u4e0d\u80fd\u4e3a\u7a7a\u3002")).toBeInTheDocument();
+    expect(repositoryMocks.rename).not.toHaveBeenCalled();
+  });
+
   it("deletes a recording only after confirm", async () => {
     repositoryMocks.list.mockResolvedValue([BASE_ITEM]);
     renderPage();
@@ -146,6 +161,20 @@ describe("RecordingLibraryPage", () => {
     });
   });
 
+  it("keeps delete confirmation open when delete fails", async () => {
+    repositoryMocks.list.mockResolvedValue([BASE_ITEM]);
+    repositoryMocks.remove.mockRejectedValueOnce(new Error("idb delete failed"));
+    renderPage();
+    await waitForElementToBeRemoved(() => screen.queryByRole("status"));
+
+    fireEvent.click(screen.getByRole("button", { name: "\u5220\u9664" }));
+    fireEvent.click(screen.getByRole("button", { name: "\u786e\u8ba4\u5220\u9664" }));
+
+    expect(await screen.findByText("\u5220\u9664\u5931\u8d25\uff1aidb delete failed")).toBeInTheDocument();
+    expect(screen.getByText(`\u786e\u8ba4\u5220\u9664\u300c${BASE_TITLE}\u300d\uff1f`)).toBeInTheDocument();
+    expect(repositoryMocks.list).toHaveBeenCalledTimes(1);
+  });
+
   it("exports a recording to zip", async () => {
     repositoryMocks.list.mockResolvedValue([BASE_ITEM]);
     vi.spyOn(HTMLAnchorElement.prototype, "click").mockImplementation(() => {});
@@ -159,6 +188,18 @@ describe("RecordingLibraryPage", () => {
       expect(URL.createObjectURL).toHaveBeenCalled();
       expect(URL.revokeObjectURL).toHaveBeenCalled();
     });
+  });
+
+  it("shows export failure dialog", async () => {
+    repositoryMocks.list.mockResolvedValue([BASE_ITEM]);
+    repositoryMocks.exportZip.mockRejectedValueOnce(new Error("zip failed"));
+    renderPage();
+    await waitForElementToBeRemoved(() => screen.queryByRole("status"));
+
+    fireEvent.click(screen.getByRole("button", { name: "\u5bfc\u51fa ZIP" }));
+
+    expect(await screen.findByRole("dialog")).toHaveTextContent("\u5bfc\u51fa\u5931\u8d25\uff1azip failed");
+    expect(URL.createObjectURL).not.toHaveBeenCalled();
   });
 
   it("imports valid zip and refreshes list", async () => {
@@ -194,5 +235,36 @@ describe("RecordingLibraryPage", () => {
     expect(await screen.findByRole("dialog")).toHaveTextContent(
       "\u5bfc\u5165\u5931\u8d25\uff1a\u538b\u7f29\u5305\u6821\u9a8c\u4e0d\u901a\u8fc7",
     );
+  });
+
+  it("shows quota guidance when zip import exceeds local storage", async () => {
+    repositoryMocks.importZip.mockResolvedValueOnce({
+      ok: false,
+      reason: "quota-exceeded",
+      message: "quota exceeded",
+    });
+    renderPage();
+    await waitForElementToBeRemoved(() => screen.queryByRole("status"));
+
+    const file = new File(["zip"], "large.zip", { type: "application/zip" });
+    fireEvent.change(screen.getByLabelText("\u5bfc\u5165 zip \u6587\u4ef6"), { target: { files: [file] } });
+
+    expect(await screen.findByRole("dialog")).toHaveTextContent(
+      "\u672c\u5730\u5b58\u50a8\u7a7a\u95f4\u4e0d\u8db3",
+    );
+    expect(repositoryMocks.list).toHaveBeenCalledTimes(1);
+  });
+
+  it("recovers list after load failure retry", async () => {
+    repositoryMocks.list.mockRejectedValueOnce(new Error("idb read failed")).mockResolvedValueOnce([BASE_ITEM]);
+    renderPage();
+    await waitForElementToBeRemoved(() => screen.queryByRole("status"));
+
+    fireEvent.click(await screen.findByRole("button", { name: "\u786e\u8ba4" }));
+    fireEvent.click(screen.getByRole("button", { name: "\u91cd\u8bd5" }));
+
+    expect(await screen.findByRole("link", { name: BASE_TITLE })).toBeInTheDocument();
+    expect(screen.queryByText("\u8bfb\u53d6\u5931\u8d25\uff1aidb read failed")).not.toBeInTheDocument();
+    expect(repositoryMocks.list).toHaveBeenCalledTimes(2);
   });
 });

--- a/apps/web/src/features/library/__tests__/RecordingLibraryPage.test.tsx
+++ b/apps/web/src/features/library/__tests__/RecordingLibraryPage.test.tsx
@@ -84,14 +84,20 @@ describe("RecordingLibraryPage", () => {
     expect(await screen.findByText("\u8fd8\u6ca1\u6709\u5f55\u5236")).toBeInTheDocument();
   });
 
-  it("closes loading dialog first, then shows load error dialog", async () => {
+  it("keeps persistent load error state after closing load-failed dialog", async () => {
     repositoryMocks.list.mockRejectedValueOnce(new Error("idb read failed"));
     renderPage();
     expect(screen.getByRole("status")).toHaveTextContent("\u52a0\u8f7d\u4e2d");
     await waitForElementToBeRemoved(() => screen.queryByRole("status"));
-    expect(await screen.findByRole("dialog")).toHaveTextContent(
+    const dialog = await screen.findByRole("dialog");
+    expect(dialog).toHaveTextContent(
       "\u8bfb\u53d6\u5931\u8d25\uff1aidb read failed",
     );
+    fireEvent.click(screen.getByRole("button", { name: "\u786e\u8ba4" }));
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    expect(screen.getByText("\u8bfb\u53d6\u5931\u8d25\uff1aidb read failed")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "\u91cd\u8bd5" })).toBeInTheDocument();
+    expect(screen.queryByText("\u8fd8\u6ca1\u6709\u5f55\u5236")).not.toBeInTheDocument();
   });
 
   it("renders recording row and replay link", async () => {


### PR DESCRIPTION

## 关联 Issue

Closes #59

## 变更说明

- 完善 RecordingLibraryPage 列表 UI，展示标题、创建时间、时长、语言、设备状态与操作入口。
- 增加本地录制的重命名、删除确认、ZIP 导出、ZIP 导入、加载/错误反馈与存储配额展示。
- 补充 RecordingLibraryPage 单元测试，覆盖加载、空态、加载失败、列表渲染、重命名、删除确认、导出、导入成功和导入校验失败。
- 维护者补充 fb2a2c3，移除测试文件 EOF 多余空行，修复 git diff --check hygiene 问题。
- 维护者补充 3c39b2a，增加失败路径覆盖：空标题重命名、删除失败、导出失败、导入 quota-exceeded、加载失败后重试恢复。
- 维护者补充 bcd21fa，修复导出/删除/重命名等 item 操作期间导入 ZIP 仍可触发的并发入口，并增加回归测试。

## GitNexus 影响分析摘要

- 风险等级: GitNexus detect_changes 对完整 PR 报 high，原因是单页新增/触碰符号较多；关键 upstream impact 为 LOW。
- 关键骨架变更: 无 API route、schema、controller 骨架变更；变更集中在 RecordingLibraryPage 和对应测试。
- GitNexus 影响面: RecordingLibraryPage upstream 仅影响 routes.tsx -> App.tsx；handleImportChange upstream 为页面内 Library 流程，直接调用方是 RecordingLibraryPage。
- 第二轮修复影响面: unstaged detect_changes 曾报 2 个 changed symbols / 6 affected processes；RecordingLibraryPage upstream impact 仍为 LOW，直接入口仅 routes.tsx。
- GitNexus contract: passed；无 critical contract surface changed，分析为 advisory。

## 验证结果

- npm run quality:predev: passed。
- npm run agent:bootstrap: passed。
- TDD 回归: 新增 “disables zip import while an item operation is busy” 先红后绿。
- npm run test:web -- RecordingLibraryPage: passed；14/14。
- npm run quality:local: passed；包含 GitNexus contract、root node tests 36/36、web lint、web Vitest 24 files / 142 tests、build、Playwright e2e 2/2。
- git diff --check origin/main...HEAD: passed。
- push hook 再次运行 npm run quality:local: passed，并已推送到 feature/1.0。
- 浏览器手测: 列表渲染、回放入口、空标题重命名校验、重命名保存、ZIP 下载事件、导出成功提示、删除确认。

## 自检

- [x] PR author 是该 Issue 的认领者
- [x] 未修改 `docs/progress.json` 或 `docs/progress.md`
- [x] 已运行 `npm run quality:local`，或说明无法运行的原因
- [x] 如果改动关键骨架，已补充契约测试并填写 GitNexus 影响分析摘要
- [x] 已邀请至少一名非作者同学 CR
