### PR TITLE
推进录制回放闭环

### DIFF
--- a/apps/web/src/features/capture/runtimeProducer.ts
+++ b/apps/web/src/features/capture/runtimeProducer.ts
@@ -10,20 +10,6 @@ const RUNTIME_TIMEOUT_MS = 3000;
 
 /**
  * RuntimeProducer — emits run-start / run-output / run-error.
- *
- * STUB. Real implementation belongs to issue `[P0] runtimeProducer 实装`.
- *
- * 实装时需要：
- *   - trigger(input):
- *     1. 生成 runId（用 shared/util/ids.generateId("run")）
- *     2. emit run-start { language, runtime: "iframe", runId }
- *     3. await compiler.compile(source, language)
- *        - 失败：emit run-error { phase: "transpile", message, stack, previewHtml: null }
- *     4. 成功后 await runtime.run({ runId, compiledCode, timeoutMs: 5000 })
- *        - status === "complete"：emit run-output（stdout/stderr/previewHtml）
- *        - status === "error"  ：emit run-error { phase: "runtime", ... }
- *        - status === "timeout"：emit run-error { phase: "runtime", message: "timeout" }
- *   - pause() 期间禁用 trigger（按钮在 UI 层应禁用，producer 双重防御）
  */
 function errorInfo(err: unknown): { message: string; stack?: string } {
   if (err instanceof Error) return { message: err.message, stack: err.stack };

--- a/apps/web/src/features/editor/CodeEditor.tsx
+++ b/apps/web/src/features/editor/CodeEditor.tsx
@@ -1,6 +1,6 @@
 import { forwardRef, useEffect, useImperativeHandle, useRef, useState } from "react";
 import type * as Monaco from "monaco-editor/esm/vs/editor/editor.api";
-import type { RecordingLanguage } from "@/shared/recording-schema";
+import type { RecordingLanguage, ReplayStableState } from "@/shared/recording-schema";
 
 export type CodeEditorHandle = {
   /** Lazy accessor — null until the editor has mounted. */
@@ -11,8 +11,14 @@ export type CodeEditorHandle = {
 export type CodeEditorProps = {
   language: RecordingLanguage;
   initialValue: string;
+  value?: string;
   fontSize: number;
   theme: "light" | "dark";
+  readOnly?: boolean;
+  cursor?: ReplayStableState["editor"]["cursor"];
+  selection?: ReplayStableState["editor"]["selection"];
+  scrollTop?: number;
+  scrollLeft?: number;
   onMount?(editor: Monaco.editor.IStandaloneCodeEditor): void;
 };
 
@@ -124,7 +130,19 @@ async function loadMonaco() {
 }
 
 export const CodeEditor = forwardRef<CodeEditorHandle, CodeEditorProps>(function CodeEditor(
-  { language, initialValue, fontSize, theme, onMount },
+  {
+    language,
+    initialValue,
+    value,
+    fontSize,
+    theme,
+    readOnly = false,
+    cursor,
+    selection,
+    scrollTop,
+    scrollLeft,
+    onMount,
+  },
   ref,
 ) {
   const hostRef = useRef<HTMLDivElement | null>(null);
@@ -132,11 +150,31 @@ export const CodeEditor = forwardRef<CodeEditorHandle, CodeEditorProps>(function
   const modelRef = useRef<Monaco.editor.ITextModel | null>(null);
   const monacoRef = useRef<MonacoModule | null>(null);
   const initialValueRef = useRef(initialValue);
-  const latestPropsRef = useRef({ language, fontSize, theme });
+  const latestPropsRef = useRef({
+    language,
+    value,
+    fontSize,
+    theme,
+    readOnly,
+    cursor,
+    selection,
+    scrollTop,
+    scrollLeft,
+  });
   const onMountRef = useRef(onMount);
   const [loadError, setLoadError] = useState<unknown>(null);
 
-  latestPropsRef.current = { language, fontSize, theme };
+  latestPropsRef.current = {
+    language,
+    value,
+    fontSize,
+    theme,
+    readOnly,
+    cursor,
+    selection,
+    scrollTop,
+    scrollLeft,
+  };
   onMountRef.current = onMount;
 
   useImperativeHandle(
@@ -169,6 +207,7 @@ export const CodeEditor = forwardRef<CodeEditorHandle, CodeEditorProps>(function
           automaticLayout: true,
           fontSize: currentProps.fontSize,
           minimap: { enabled: false },
+          readOnly: currentProps.readOnly,
           scrollBeyondLastLine: false,
           tabSize: 2,
           theme: monacoTheme(currentProps.theme),
@@ -177,6 +216,7 @@ export const CodeEditor = forwardRef<CodeEditorHandle, CodeEditorProps>(function
         monacoRef.current = monaco;
         modelRef.current = model;
         editorRef.current = editor;
+        applyControlledEditorState(editor, currentProps);
         onMountRef.current?.(editor);
       })
       .catch((error: unknown) => {
@@ -210,8 +250,40 @@ export const CodeEditor = forwardRef<CodeEditorHandle, CodeEditorProps>(function
   }, [fontSize]);
 
   useEffect(() => {
+    editorRef.current?.updateOptions({ readOnly });
+  }, [readOnly]);
+
+  useEffect(() => {
     monacoRef.current?.editor.setTheme(monacoTheme(theme));
   }, [theme]);
+
+  useEffect(() => {
+    const editor = editorRef.current;
+    if (!editor || value === undefined || editor.getValue() === value) return;
+    editor.setValue(value);
+  }, [value]);
+
+  useEffect(() => {
+    const editor = editorRef.current;
+    if (!editor) return;
+    if (selection) {
+      editor.setSelection(selection);
+    } else if (cursor) {
+      editor.setPosition(cursor);
+    }
+  }, [cursor, selection]);
+
+  useEffect(() => {
+    const editor = editorRef.current;
+    if (!editor || scrollTop === undefined) return;
+    editor.setScrollTop(scrollTop);
+  }, [scrollTop]);
+
+  useEffect(() => {
+    const editor = editorRef.current;
+    if (!editor || scrollLeft === undefined) return;
+    editor.setScrollLeft(scrollLeft);
+  }, [scrollLeft]);
 
   return (
     <div className="relative h-full min-h-[320px] w-full bg-surface" data-code-editor>
@@ -227,3 +299,25 @@ export const CodeEditor = forwardRef<CodeEditorHandle, CodeEditorProps>(function
     </div>
   );
 });
+
+function applyControlledEditorState(
+  editor: Monaco.editor.IStandaloneCodeEditor,
+  props: {
+    value?: string;
+    cursor?: ReplayStableState["editor"]["cursor"];
+    selection?: ReplayStableState["editor"]["selection"];
+    scrollTop?: number;
+    scrollLeft?: number;
+  },
+) {
+  if (props.value !== undefined && editor.getValue() !== props.value) {
+    editor.setValue(props.value);
+  }
+  if (props.selection) {
+    editor.setSelection(props.selection);
+  } else if (props.cursor) {
+    editor.setPosition(props.cursor);
+  }
+  if (props.scrollTop !== undefined) editor.setScrollTop(props.scrollTop);
+  if (props.scrollLeft !== undefined) editor.setScrollLeft(props.scrollLeft);
+}

--- a/apps/web/src/features/editor/__tests__/CodeEditor.test.tsx
+++ b/apps/web/src/features/editor/__tests__/CodeEditor.test.tsx
@@ -19,6 +19,10 @@ const monacoMock = vi.hoisted(() => {
       return this.value;
     }
 
+    setValue(next: string) {
+      this.value = next;
+    }
+
     dispose() {
       this.disposed = true;
     }
@@ -29,6 +33,13 @@ const monacoMock = vi.hoisted(() => {
     updateOptions = vi.fn((nextOptions: Record<string, unknown>) => {
       Object.assign(this.options, nextOptions);
     });
+    setValue = vi.fn((next: string) => {
+      this.options.model.setValue(next);
+    });
+    setPosition = vi.fn();
+    setSelection = vi.fn();
+    setScrollTop = vi.fn();
+    setScrollLeft = vi.fn();
 
     constructor(
       public host: HTMLElement,
@@ -177,6 +188,66 @@ describe("CodeEditor", () => {
     expect(monacoMock.editor.setModelLanguage).toHaveBeenCalledWith(model, "typescript");
     expect(editor.updateOptions).toHaveBeenCalledWith({ fontSize: 18 });
     expect(monacoMock.editor.setTheme).toHaveBeenCalledWith("code-tape-light");
+  });
+
+  it("applies controlled replay state without changing initialValue semantics", async () => {
+    const { CodeEditor } = await import("../CodeEditor");
+    const { rerender } = render(
+      <CodeEditor
+        language="javascript"
+        initialValue="const first = true;"
+        value="const replay = 1;"
+        fontSize={14}
+        theme="dark"
+        readOnly
+        cursor={{ lineNumber: 2, column: 3 }}
+        selection={null}
+        scrollTop={120}
+        scrollLeft={8}
+      />,
+    );
+    await waitFor(() => expect(monacoMock.editor.create).toHaveBeenCalledTimes(1));
+    const editor = monacoMock.editors[0];
+
+    expect(editor.getValue()).toBe("const replay = 1;");
+    expect(editor.options.readOnly).toBe(true);
+    expect(editor.setPosition).toHaveBeenCalledWith({ lineNumber: 2, column: 3 });
+    expect(editor.setScrollTop).toHaveBeenCalledWith(120);
+    expect(editor.setScrollLeft).toHaveBeenCalledWith(8);
+
+    await act(async () => {
+      rerender(
+        <CodeEditor
+          language="javascript"
+          initialValue="const ignored = true;"
+          value="const replay = 2;"
+          fontSize={14}
+          theme="dark"
+          readOnly={false}
+          cursor={null}
+          selection={{
+            startLineNumber: 1,
+            startColumn: 1,
+            endLineNumber: 1,
+            endColumn: 5,
+          }}
+          scrollTop={240}
+          scrollLeft={16}
+        />,
+      );
+    });
+
+    expect(editor.getValue()).toBe("const replay = 2;");
+    expect(editor.setValue).toHaveBeenCalledWith("const replay = 2;");
+    expect(editor.updateOptions).toHaveBeenCalledWith({ readOnly: false });
+    expect(editor.setSelection).toHaveBeenCalledWith({
+      startLineNumber: 1,
+      startColumn: 1,
+      endLineNumber: 1,
+      endColumn: 5,
+    });
+    expect(editor.setScrollTop).toHaveBeenCalledWith(240);
+    expect(editor.setScrollLeft).toHaveBeenCalledWith(16);
   });
 
   it("configures JS/TS workers and disposes editor resources on unmount", async () => {

--- a/apps/web/src/features/player/ReplayPage.tsx
+++ b/apps/web/src/features/player/ReplayPage.tsx
@@ -42,8 +42,8 @@ const INITIAL_STABLE_STATE: ReplayStableState = {
  * ReplayPage — wires the replay core (scheduler + clock + repository + runtime)
  * and renders the playback layout.
  *
- * UI shell is intentionally minimal. Mouse laser, shortcut badge overlay,
- * console panel rendering, chapter marker tooltips are delegated to issues.
+ * Mouse laser, shortcut badge overlay, and chapter marker tooltips remain layered
+ * on top of the scheduler's transient event stream.
  */
 export function ReplayPage() {
   const { id } = useParams();
@@ -108,11 +108,20 @@ export function ReplayPage() {
           <CodeEditor
             language={stableState.editor.language}
             initialValue={stableState.editor.code}
+            value={stableState.editor.code}
             fontSize={stableState.editor.fontSize}
             theme={stableState.editor.theme}
+            readOnly
+            cursor={stableState.editor.cursor}
+            selection={stableState.editor.selection}
+            scrollTop={stableState.editor.scrollTop}
+            scrollLeft={stableState.editor.scrollLeft}
           />
         </div>
-        <PreviewPane runtime={runtime} previewHtml={stableState.runtime.previewHtml} />
+        <div className="flex min-h-0 flex-col">
+          <PreviewPane runtime={runtime} previewHtml={stableState.runtime.previewHtml} className="min-h-0 flex-1" />
+          <RuntimeOutputPanel runtime={stableState.runtime} />
+        </div>
       </div>
       <ReplayControls
         state={schedulerState}
@@ -135,5 +144,39 @@ export function ReplayPage() {
         }}
       />
     </div>
+  );
+}
+
+function RuntimeOutputPanel({ runtime }: { runtime: ReplayStableState["runtime"] }) {
+  const hasOutput = runtime.stdout.length > 0 || runtime.stderr.length > 0 || runtime.errorMessage;
+
+  return (
+    <section className="border-t border-border bg-background px-4 py-3" aria-label="Runtime output">
+      <div className="mb-2 flex items-center justify-between gap-3">
+        <h2 className="text-xs font-semibold uppercase tracking-wide text-muted">Console</h2>
+        <span className="rounded-sm border border-border px-2 py-0.5 text-[11px] font-medium text-muted">
+          {runtime.status}
+        </span>
+      </div>
+      {hasOutput ? (
+        <div className="max-h-40 space-y-2 overflow-auto font-mono text-xs leading-5">
+          {runtime.stdout.map((line, index) => (
+            <pre key={`stdout-${index}`} className="whitespace-pre-wrap text-foreground">
+              {line}
+            </pre>
+          ))}
+          {runtime.stderr.map((line, index) => (
+            <pre key={`stderr-${index}`} className="whitespace-pre-wrap text-warning">
+              {line}
+            </pre>
+          ))}
+          {runtime.errorMessage ? (
+            <pre className="whitespace-pre-wrap text-danger">{runtime.errorMessage}</pre>
+          ) : null}
+        </div>
+      ) : (
+        <p className="text-xs text-muted">No output</p>
+      )}
+    </section>
   );
 }

--- a/apps/web/src/features/player/__tests__/ReplayPage.test.tsx
+++ b/apps/web/src/features/player/__tests__/ReplayPage.test.tsx
@@ -1,6 +1,9 @@
 import { act, render, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { ReplayControlsProps } from "../ReplayControls";
+import type { CodeEditorProps } from "@/features/editor/CodeEditor";
+import type { PreviewPaneProps } from "@/features/runtime-preview/PreviewPane";
+import type { ReplayStableState } from "@/shared/recording-schema";
 import type * as ReactRouterDom from "react-router-dom";
 
 const replayPageMock = vi.hoisted(() => {
@@ -67,6 +70,9 @@ const replayPageMock = vi.hoisted(() => {
     repository,
     packageData,
     controlsProps: null as ReplayControlsProps | null,
+    codeEditorProps: null as CodeEditorProps | null,
+    previewPaneProps: null as PreviewPaneProps | null,
+    onTick: null as ((state: ReplayStableState) => void) | null,
     reset() {
       scheduler.load.mockClear();
       scheduler.play.mockClear();
@@ -79,6 +85,9 @@ const replayPageMock = vi.hoisted(() => {
       scheduler.subscribe.mockClear();
       repository.load.mockClear();
       this.controlsProps = null;
+      this.codeEditorProps = null;
+      this.previewPaneProps = null;
+      this.onTick = null;
     },
   };
 });
@@ -92,11 +101,17 @@ vi.mock("react-router-dom", async () => {
 });
 
 vi.mock("@/features/editor/CodeEditor", () => ({
-  CodeEditor: () => <div aria-label="Mock code editor" />,
+  CodeEditor: (props: CodeEditorProps) => {
+    replayPageMock.codeEditorProps = props;
+    return <div aria-label="Mock code editor" />;
+  },
 }));
 
 vi.mock("@/features/runtime-preview/PreviewPane", () => ({
-  PreviewPane: () => <div aria-label="Mock preview pane" />,
+  PreviewPane: (props: PreviewPaneProps) => {
+    replayPageMock.previewPaneProps = props;
+    return <div aria-label="Mock preview pane" />;
+  },
 }));
 
 vi.mock("@/features/runtime-preview/iframeRuntime", () => ({
@@ -108,7 +123,10 @@ vi.mock("@/features/library/recordingStore", () => ({
 }));
 
 vi.mock("../replayScheduler", () => ({
-  createReplayScheduler: vi.fn(() => replayPageMock.scheduler),
+  createReplayScheduler: vi.fn((options: { onTick?: (state: ReplayStableState) => void }) => {
+    replayPageMock.onTick = options.onTick ?? null;
+    return replayPageMock.scheduler;
+  }),
   defaultTickStrategy: vi.fn(() => ({})),
 }));
 
@@ -149,5 +167,64 @@ describe("ReplayPage", () => {
     expect(replayPageMock.scheduler.setMuted).toHaveBeenCalledWith(true);
     await waitFor(() => expect(replayPageMock.controlsProps?.volume).toBe(35));
     expect(replayPageMock.controlsProps?.muted).toBe(true);
+  });
+
+  it("renders scheduler stable state into the read-only editor and runtime panel", async () => {
+    const { ReplayPage } = await import("../ReplayPage");
+
+    render(<ReplayPage />);
+    await waitFor(() => expect(replayPageMock.scheduler.load).toHaveBeenCalledWith(replayPageMock.packageData));
+
+    act(() => {
+      replayPageMock.onTick?.({
+        editor: {
+          code: "console.log('replayed');",
+          language: "typescript",
+          cursor: { lineNumber: 1, column: 8 },
+          selection: {
+            startLineNumber: 1,
+            startColumn: 1,
+            endLineNumber: 1,
+            endColumn: 8,
+          },
+          scrollTop: 88,
+          scrollLeft: 4,
+          fontSize: 16,
+          theme: "light",
+        },
+        pointer: null,
+        media: { microphoneEnabled: false, cameraEnabled: false, cameraPosition: { x: 0, y: 0 } },
+        runtime: {
+          status: "error",
+          stdout: ["hello"],
+          stderr: ["warn"],
+          previewHtml: "<main>preview</main>",
+          errorMessage: "boom",
+        },
+      });
+    });
+
+    expect(replayPageMock.codeEditorProps).toEqual(
+      expect.objectContaining({
+        language: "typescript",
+        value: "console.log('replayed');",
+        readOnly: true,
+        cursor: { lineNumber: 1, column: 8 },
+        selection: {
+          startLineNumber: 1,
+          startColumn: 1,
+          endLineNumber: 1,
+          endColumn: 8,
+        },
+        scrollTop: 88,
+        scrollLeft: 4,
+        fontSize: 16,
+        theme: "light",
+      }),
+    );
+    expect(replayPageMock.previewPaneProps?.previewHtml).toBe("<main>preview</main>");
+    expect(document.body).toHaveTextContent("hello");
+    expect(document.body).toHaveTextContent("warn");
+    expect(document.body).toHaveTextContent("boom");
   });
 });

--- a/apps/web/src/features/recorder/RecorderPage.tsx
+++ b/apps/web/src/features/recorder/RecorderPage.tsx
@@ -11,6 +11,7 @@ import { PreviewPane } from "@/features/runtime-preview/PreviewPane";
 import { createPreviewCompiler } from "@/features/runtime-preview/previewCompiler";
 import { createIframeRuntime } from "@/features/runtime-preview/iframeRuntime";
 import { createMediaDevicesController } from "@/features/media/mediaDevices";
+import { createMediaRecorderWrapper } from "@/features/media/mediaRecorder";
 import { createRecordingStore } from "@/features/library/recordingStore";
 import {
   createEditorProducer,
@@ -21,8 +22,13 @@ import {
 } from "@/features/capture";
 import type {
   CameraPositionPayload,
+  MediaCapability,
+  MediaDevicesController,
+  OpenStreamResult,
   RecordingControllerState,
+  RecordingControllerStatus,
   RecordingLanguage,
+  PackageBuildInput,
   RecordStartPayload,
   RunStartPayload,
 } from "@/shared/recording-schema";
@@ -47,15 +53,16 @@ const APP_VERSION = "0.0.0";
 /**
  * RecorderPage — wires the recording core (clock + bus + producers + builder
  * + repository + media + runtime) and renders the workshop layout.
- *
- * UI shell is intentionally minimal. The expressive UI (control bar, camera
- * dragging, shortcut badges, run/output panel) is delegated to issues. This
- * page guarantees the *infrastructure* is correctly wired so those issues can
- * focus on visual + interaction polish.
  */
 export function RecorderPage() {
   const navigate = useNavigate();
   const editorRef = useRef<CodeEditorHandle | null>(null);
+  const mediaRecorderRef = useRef<ReturnType<typeof createMediaRecorderWrapper> | null>(null);
+  const mountedRef = useRef(true);
+  const startInFlightRef = useRef(false);
+  const startTokenRef = useRef(0);
+  const stopTokenRef = useRef(0);
+  const [mediaStream, setMediaStream] = useState<MediaStream | null>(null);
 
   const stack = useMemo(() => {
     const clock = createRecordingClock();
@@ -65,6 +72,7 @@ export function RecorderPage() {
     const repository = createRecordingStore();
     const devices = createMediaDevicesController();
     let currentEditorLanguage: RecordingLanguage = "javascript";
+    let currentMediaCapability: MediaCapability = INITIAL_CONTROLLER_STATE.mediaCapability;
     const getCurrentRuntimeLanguage = (): RunStartPayload["language"] =>
       currentEditorLanguage === "typescript" ? "typescript" : "javascript";
     const editorProducer = createEditorProducer({
@@ -91,7 +99,7 @@ export function RecorderPage() {
       bus,
       clock,
       devices,
-      getCapability: () => INITIAL_CONTROLLER_STATE.mediaCapability,
+      getCapability: () => currentMediaCapability,
     });
     const runtimeProducer = createRuntimeProducer({ bus, clock, compiler, runtime });
     const packageBuilder = createPackageBuilder();
@@ -103,6 +111,27 @@ export function RecorderPage() {
       repository,
       appVersion: APP_VERSION,
       snapshotSource: () => editorProducer.takeSnapshot(),
+      mediaSource: async () => {
+        const recorder = mediaRecorderRef.current;
+        mediaRecorderRef.current = null;
+        try {
+          if (!recorder) return null;
+          const result = await recorder.stop();
+          return {
+            blob: result.blob,
+            durationMs: result.durationMs,
+            mimeType: result.mimeType,
+            hasAudio: result.hasAudio,
+            hasCamera: result.hasCamera,
+          } satisfies PackageBuildInput["media"];
+        } catch (err) {
+          console.warn("[recorder-page] media finalization failed:", err);
+          return null;
+        } finally {
+          devices.release();
+          if (mountedRef.current) setMediaStream(null);
+        }
+      },
     });
     return {
       controller,
@@ -113,6 +142,9 @@ export function RecorderPage() {
       editorProducer,
       mediaProducer,
       runtimeProducer,
+      setCurrentMediaCapability: (capability: MediaCapability) => {
+        currentMediaCapability = capability;
+      },
       getCurrentEditorLanguage: () => currentEditorLanguage,
       getCurrentRuntimeLanguage,
     };
@@ -127,27 +159,161 @@ export function RecorderPage() {
     INITIAL_CAMERA_POSITION,
   );
 
-  useEffect(() => stack.controller.subscribe(setControllerState), [stack.controller]);
+  useEffect(
+    () => {
+      mountedRef.current = true;
+      return stack.controller.subscribe((nextState) => {
+        if (mountedRef.current) setControllerState(nextState);
+      });
+    },
+    [stack.controller],
+  );
+  useEffect(
+    () => {
+      mountedRef.current = true;
+      return () => {
+        mountedRef.current = false;
+        startInFlightRef.current = false;
+        startTokenRef.current += 1;
+        stopTokenRef.current += 1;
+        const isFinalizing = isFinalizingRecordingStatus(stack.controller.state.status);
+        if (!isFinalizing) {
+          stack.controller.reset();
+          const recorder = mediaRecorderRef.current;
+          mediaRecorderRef.current = null;
+          void recorder?.stop().catch((err) => {
+            console.warn("[recorder-page] cleanup media stop failed:", err);
+          });
+          stack.devices.release();
+        }
+      };
+    },
+    [stack.controller, stack.devices],
+  );
+
+  const isCurrentStart = (token: number) => mountedRef.current && startTokenRef.current === token;
 
   const handleStart = async () => {
-    const payload: RecordStartPayload = {
-      initialLanguage: stack.getCurrentEditorLanguage(),
-      initialFontSize: 14,
-      initialTheme: "dark",
-      selectedAudioDeviceId: null,
-      selectedCameraDeviceId: null,
-      mediaCapability: {
-        audio: "unsupported",
-        camera: "unsupported",
-        selectedAudioDeviceId: null,
-        selectedCameraDeviceId: null,
-      },
-    };
-    await stack.controller.start(payload);
+    if (startInFlightRef.current) return;
+    startInFlightRef.current = true;
+    const startToken = (startTokenRef.current += 1);
+    try {
+      let media = await openDefaultMedia(stack.devices);
+      if (!isCurrentStart(startToken)) {
+        stack.devices.release();
+        return;
+      }
+      if (media.stream) {
+        setMediaStream(media.stream);
+        let recorder: ReturnType<typeof createMediaRecorderWrapper> | null = null;
+        try {
+          recorder = createMediaRecorderWrapper();
+          mediaRecorderRef.current = recorder;
+          await recorder.start(media.stream);
+          if (!isCurrentStart(startToken)) {
+            if (mediaRecorderRef.current === recorder) {
+              mediaRecorderRef.current = null;
+              await recorder.stop().catch(() => undefined);
+            }
+            stack.devices.release();
+            return;
+          }
+        } catch (err) {
+          console.warn("[recorder-page] media recorder start failed:", err);
+          if (recorder && mediaRecorderRef.current === recorder) {
+            mediaRecorderRef.current = null;
+            await recorder.stop().catch((stopErr) => {
+              console.warn("[recorder-page] media recorder cleanup after start failed:", stopErr);
+            });
+          }
+          if (!isCurrentStart(startToken)) {
+            stack.devices.release();
+            return;
+          }
+          stack.devices.release();
+          setMediaStream(null);
+          media = eventOnlyMedia();
+        }
+      }
+      setMicrophoneEnabled(media.capability.audio === "available");
+      setCameraEnabled(media.capability.camera === "available");
+      stack.setCurrentMediaCapability(media.capability);
+
+      const payload: RecordStartPayload = {
+        initialLanguage: stack.getCurrentEditorLanguage(),
+        initialFontSize: 14,
+        initialTheme: "dark",
+        selectedAudioDeviceId: media.capability.selectedAudioDeviceId,
+        selectedCameraDeviceId: media.capability.selectedCameraDeviceId,
+        mediaCapability: media.capability,
+      };
+      try {
+        await stack.controller.start(payload);
+        if (!isCurrentStart(startToken) && isActiveRecordingStatus(stack.controller.state.status)) {
+          stack.controller.reset();
+        }
+      } catch (error) {
+        const recorder = mediaRecorderRef.current;
+        mediaRecorderRef.current = null;
+        await recorder?.stop().catch(() => undefined);
+        stack.devices.release();
+        if (isCurrentStart(startToken)) {
+          setMediaStream(null);
+          setMicrophoneEnabled(false);
+          setCameraEnabled(false);
+          stack.setCurrentMediaCapability(INITIAL_CONTROLLER_STATE.mediaCapability);
+        }
+        throw error;
+      }
+    } finally {
+      startInFlightRef.current = false;
+    }
   };
   const handleStop = async () => {
-    const pkg = await stack.controller.stop("user");
-    navigate(`/replay/${pkg.meta.id}`);
+    const stopToken = (stopTokenRef.current += 1);
+    try {
+      const pkg = await stack.controller.stop("user");
+      if (mountedRef.current && stopTokenRef.current === stopToken) {
+        navigate(`/replay/${pkg.meta.id}`);
+      } else {
+        stack.controller.reset();
+      }
+    } catch (error) {
+      if (mountedRef.current && stopTokenRef.current === stopToken) throw error;
+      stack.controller.reset();
+      console.warn("[recorder-page] stop ignored after unmount:", error);
+    }
+  };
+  const handlePause = () => {
+    if (stack.controller.state.status !== "recording") return;
+    const recorder = mediaRecorderRef.current;
+    stack.controller.pause();
+    try {
+      recorder?.pause();
+    } catch (err) {
+      console.warn("[recorder-page] media pause failed:", err);
+      void stack.controller.resume().catch((rollbackErr) => {
+        console.warn("[recorder-page] controller pause rollback failed:", rollbackErr);
+      });
+    }
+  };
+  const handleResume = () => {
+    if (stack.controller.state.status !== "paused") return;
+    const recorder = mediaRecorderRef.current;
+    try {
+      recorder?.resume();
+    } catch (err) {
+      console.warn("[recorder-page] media resume failed:", err);
+      return;
+    }
+    void stack.controller.resume().catch((err) => {
+      console.warn("[recorder-page] controller resume failed:", err);
+      try {
+        recorder?.pause();
+      } catch (rollbackErr) {
+        console.warn("[recorder-page] media resume rollback failed:", rollbackErr);
+      }
+    });
   };
   const handleRun = async () => {
     const editor = editorRef.current?.getEditor();
@@ -166,15 +332,21 @@ export function RecorderPage() {
         microphoneEnabled={microphoneEnabled}
         cameraEnabled={cameraEnabled}
         onStart={handleStart}
-        onPause={() => stack.controller.pause()}
-        onResume={() => void stack.controller.resume()}
+        onPause={handlePause}
+        onResume={handleResume}
         onStop={handleStop}
         onToggleMicrophone={(next) => {
           setMicrophoneEnabled(next);
+          if (stack.controller.state.status === "paused") {
+            stack.devices.setTrackEnabled("audio", next);
+          }
           stack.mediaProducer.setMicrophoneEnabled(next);
         }}
         onToggleCamera={(next) => {
           setCameraEnabled(next);
+          if (stack.controller.state.status === "paused") {
+            stack.devices.setTrackEnabled("camera", next);
+          }
           stack.mediaProducer.setCameraEnabled(next);
         }}
         onRun={handleRun}
@@ -189,7 +361,7 @@ export function RecorderPage() {
             theme="dark"
           />
           <CameraPreview
-            stream={null}
+            stream={mediaStream}
             enabled={cameraEnabled}
             position={cameraPosition}
             draggable
@@ -203,4 +375,41 @@ export function RecorderPage() {
       </div>
     </div>
   );
+}
+
+async function openDefaultMedia(devices: MediaDevicesController): Promise<OpenStreamResult> {
+  try {
+    const available = await devices.enumerate();
+    const audioDeviceId = available.audio[0]?.deviceId ?? null;
+    const cameraDeviceId = available.camera[0]?.deviceId ?? null;
+
+    if (!audioDeviceId && !cameraDeviceId) return eventOnlyMedia();
+
+    const result = await devices.openStream({ audioDeviceId, cameraDeviceId });
+    if (!result.stream) {
+      devices.release();
+      return eventOnlyMedia(result.warnings);
+    }
+    return result;
+  } catch (err) {
+    console.warn("[recorder-page] media devices unavailable:", err);
+    devices.release();
+    return eventOnlyMedia();
+  }
+}
+
+function eventOnlyMedia(warnings: OpenStreamResult["warnings"] = []): OpenStreamResult {
+  return {
+    stream: null,
+    warnings,
+    capability: INITIAL_CONTROLLER_STATE.mediaCapability,
+  };
+}
+
+function isActiveRecordingStatus(status: RecordingControllerStatus): boolean {
+  return status === "requestingPermission" || status === "recording" || status === "paused";
+}
+
+function isFinalizingRecordingStatus(status: RecordingControllerStatus): boolean {
+  return status === "stopping" || status === "processing";
 }

--- a/apps/web/src/features/recorder/__tests__/RecorderPage.test.tsx
+++ b/apps/web/src/features/recorder/__tests__/RecorderPage.test.tsx
@@ -1,9 +1,19 @@
 import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { forwardRef, useImperativeHandle } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { EditorProducerDeps, EditorProducerHandle } from "@/features/capture/types";
+import type {
+  EditorProducerDeps,
+  EditorProducerHandle,
+  MediaProducerDeps,
+} from "@/features/capture/types";
 import type { CodeEditorHandle } from "@/features/editor/CodeEditor";
-import type { RecordingLanguage } from "@/shared/recording-schema";
+import type { CameraPreviewProps } from "@/features/media/CameraPreview";
+import type {
+  MediaDevicesController,
+  OpenStreamResult,
+  RecordingLanguage,
+  SaveDraftInput,
+} from "@/shared/recording-schema";
 import type * as ReactRouterDom from "react-router-dom";
 
 const recorderPageMock = vi.hoisted(() => {
@@ -45,7 +55,82 @@ const recorderPageMock = vi.hoisted(() => {
     setCameraEnabled: vi.fn(),
     reportCameraPosition: vi.fn(),
   };
+  const pointerProducer = {
+    start: vi.fn(),
+    pause: vi.fn(),
+    resume: vi.fn(),
+    stop: vi.fn(),
+    dispose: vi.fn(),
+  };
+  const runtimeProducer = {
+    start: vi.fn(),
+    pause: vi.fn(),
+    resume: vi.fn(),
+    stop: vi.fn(),
+    dispose: vi.fn(),
+    trigger,
+  };
+  const shortcutProducer = {
+    start: vi.fn(),
+    pause: vi.fn(),
+    resume: vi.fn(),
+    stop: vi.fn(),
+    dispose: vi.fn(),
+  };
+  const stream = {
+    getTracks: vi.fn(() => []),
+    getAudioTracks: vi.fn(() => []),
+    getVideoTracks: vi.fn(() => []),
+  } as unknown as MediaStream;
+  const devices = {
+    enumerate: vi.fn(async () => ({
+      audio: [{ deviceId: "mic-1", label: "Mic", kind: "audioinput" as const }],
+      camera: [{ deviceId: "cam-1", label: "Camera", kind: "videoinput" as const }],
+    })),
+    requestPermission: vi.fn(),
+    openStream: vi.fn<MediaDevicesController["openStream"]>(async () => ({
+      stream,
+      warnings: [],
+      capability: {
+        audio: "available" as const,
+        camera: "available" as const,
+        selectedAudioDeviceId: "mic-1",
+        selectedCameraDeviceId: "cam-1",
+      },
+    })),
+    setTrackEnabled: vi.fn(),
+    release: vi.fn(),
+    subscribe: vi.fn(() => vi.fn()),
+  };
+  const mediaRecorder = {
+    start: vi.fn(async () => {}),
+    pause: vi.fn(),
+    resume: vi.fn(),
+    stop: vi.fn(async () => ({
+      blob: new Blob(["media"], { type: "video/webm" }),
+      mimeType: "video/webm",
+      durationMs: 1_000,
+      hasAudio: true,
+      hasCamera: true,
+    })),
+    onChunk: vi.fn(() => vi.fn()),
+    onError: vi.fn(() => vi.fn()),
+  };
+  const createMediaRecorderWrapper = vi.fn(() => mediaRecorder);
+  const repository = {
+    saveDraft: vi.fn(async (input: SaveDraftInput) => ({ ok: true as const, recordingId: input.meta.id })),
+    commit: vi.fn(async (id: string) => ({ ok: true as const, recordingId: id })),
+    list: vi.fn(),
+    load: vi.fn(),
+    rename: vi.fn(),
+    remove: vi.fn(),
+    exportZip: vi.fn(),
+    importZip: vi.fn(),
+    sweep: vi.fn(),
+    estimateQuota: vi.fn(),
+  };
   let editorProducerDeps: EditorProducerDeps | null = null;
+  let mediaProducerDeps: MediaProducerDeps | null = null;
 
   return {
     editor,
@@ -56,11 +141,26 @@ const recorderPageMock = vi.hoisted(() => {
     flushPending,
     editorProducer,
     mediaProducer,
+    pointerProducer,
+    runtimeProducer,
+    shortcutProducer,
+    stream,
+    devices,
+    mediaRecorder,
+    createMediaRecorderWrapper,
+    repository,
+    cameraPreviewProps: null as CameraPreviewProps | null,
     get editorProducerDeps() {
       return editorProducerDeps;
     },
+    get mediaProducerDeps() {
+      return mediaProducerDeps;
+    },
     setEditorProducerDeps(next: EditorProducerDeps) {
       editorProducerDeps = next;
+    },
+    setMediaProducerDeps(next: MediaProducerDeps) {
+      mediaProducerDeps = next;
     },
     reset() {
       editorValue.current = "";
@@ -85,7 +185,36 @@ const recorderPageMock = vi.hoisted(() => {
       mediaProducer.setMicrophoneEnabled.mockClear();
       mediaProducer.setCameraEnabled.mockClear();
       mediaProducer.reportCameraPosition.mockClear();
+      pointerProducer.start.mockClear();
+      pointerProducer.pause.mockClear();
+      pointerProducer.resume.mockClear();
+      pointerProducer.stop.mockClear();
+      pointerProducer.dispose.mockClear();
+      runtimeProducer.start.mockClear();
+      runtimeProducer.pause.mockClear();
+      runtimeProducer.resume.mockClear();
+      runtimeProducer.stop.mockClear();
+      runtimeProducer.dispose.mockClear();
+      shortcutProducer.start.mockClear();
+      shortcutProducer.pause.mockClear();
+      shortcutProducer.resume.mockClear();
+      shortcutProducer.stop.mockClear();
+      shortcutProducer.dispose.mockClear();
+      devices.enumerate.mockClear();
+      devices.openStream.mockClear();
+      devices.setTrackEnabled.mockClear();
+      devices.release.mockClear();
+      createMediaRecorderWrapper.mockClear();
+      createMediaRecorderWrapper.mockImplementation(() => mediaRecorder);
+      mediaRecorder.start.mockClear();
+      mediaRecorder.pause.mockClear();
+      mediaRecorder.resume.mockClear();
+      mediaRecorder.stop.mockClear();
+      repository.saveDraft.mockClear();
+      repository.commit.mockClear();
+      this.cameraPreviewProps = null;
       editorProducerDeps = null;
+      mediaProducerDeps = null;
     },
   };
 });
@@ -109,15 +238,26 @@ vi.mock("@/features/editor/CodeEditor", () => ({
 }));
 
 vi.mock("@/features/media/CameraPreview", () => ({
-  CameraPreview: ({
-    onPositionChange,
-  }: {
-    onPositionChange?: (position: { x: number; y: number }) => void;
-  }) => (
-    <button type="button" onClick={() => onPositionChange?.({ x: 0.25, y: 0.75 })}>
-      Move camera preview
-    </button>
-  ),
+  CameraPreview: (props: CameraPreviewProps) => {
+    recorderPageMock.cameraPreviewProps = props;
+    return (
+      <button type="button" onClick={() => props.onPositionChange?.({ x: 0.25, y: 0.75 })}>
+        Move camera preview
+      </button>
+    );
+  },
+}));
+
+vi.mock("@/features/media/mediaDevices", () => ({
+  createMediaDevicesController: vi.fn(() => recorderPageMock.devices),
+}));
+
+vi.mock("@/features/media/mediaRecorder", () => ({
+  createMediaRecorderWrapper: recorderPageMock.createMediaRecorderWrapper,
+}));
+
+vi.mock("@/features/library/recordingStore", () => ({
+  createRecordingStore: vi.fn(() => recorderPageMock.repository),
 }));
 
 vi.mock("@/features/capture", () => ({
@@ -125,28 +265,18 @@ vi.mock("@/features/capture", () => ({
     recorderPageMock.setEditorProducerDeps(deps);
     return recorderPageMock.editorProducer;
   }),
-  createMediaProducer: vi.fn(() => recorderPageMock.mediaProducer),
+  createMediaProducer: vi.fn((deps: MediaProducerDeps) => {
+    recorderPageMock.setMediaProducerDeps(deps);
+    return recorderPageMock.mediaProducer;
+  }),
   createPointerProducer: vi.fn(() => ({
-    start: vi.fn(),
-    pause: vi.fn(),
-    resume: vi.fn(),
-    stop: vi.fn(),
-    dispose: vi.fn(),
+    ...recorderPageMock.pointerProducer,
   })),
   createRuntimeProducer: vi.fn(() => ({
-    start: vi.fn(),
-    pause: vi.fn(),
-    resume: vi.fn(),
-    stop: vi.fn(),
-    dispose: vi.fn(),
-    trigger: recorderPageMock.trigger,
+    ...recorderPageMock.runtimeProducer,
   })),
   createShortcutProducer: vi.fn(() => ({
-    start: vi.fn(),
-    pause: vi.fn(),
-    resume: vi.fn(),
-    stop: vi.fn(),
-    dispose: vi.fn(),
+    ...recorderPageMock.shortcutProducer,
   })),
 }));
 
@@ -189,5 +319,425 @@ describe("RecorderPage", () => {
       x: 0.25,
       y: 0.75,
     });
+  });
+
+  it("opens the selected media stream and starts media recording before controller start", async () => {
+    const { RecorderPage } = await import("../RecorderPage");
+
+    render(<RecorderPage />);
+    fireEvent.click(screen.getByRole("button", { name: "开始录制" }));
+
+    await waitFor(() =>
+      expect(recorderPageMock.devices.openStream).toHaveBeenCalledWith({
+        audioDeviceId: "mic-1",
+        cameraDeviceId: "cam-1",
+      }),
+    );
+    expect(recorderPageMock.mediaRecorder.start).toHaveBeenCalledWith(recorderPageMock.stream);
+    expect(recorderPageMock.cameraPreviewProps?.stream).toBe(recorderPageMock.stream);
+    expect(recorderPageMock.mediaProducerDeps?.getCapability()).toEqual(
+      expect.objectContaining({
+        audio: "available",
+        camera: "available",
+        selectedAudioDeviceId: "mic-1",
+        selectedCameraDeviceId: "cam-1",
+      }),
+    );
+  });
+
+  it("falls back to event-only recording when the media recorder cannot start", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    recorderPageMock.mediaRecorder.start.mockRejectedValueOnce(new Error("MediaRecorder unsupported"));
+    const { RecorderPage } = await import("../RecorderPage");
+
+    render(<RecorderPage />);
+    fireEvent.click(screen.getByRole("button", { name: "开始录制" }));
+
+    await waitFor(() => expect(recorderPageMock.devices.release).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(recorderPageMock.mediaProducer.start).toHaveBeenCalledTimes(1));
+    expect(recorderPageMock.mediaRecorder.stop).toHaveBeenCalledTimes(1);
+    expect(recorderPageMock.mediaProducerDeps?.getCapability()).toEqual({
+      audio: "unsupported",
+      camera: "unsupported",
+      selectedAudioDeviceId: null,
+      selectedCameraDeviceId: null,
+    });
+    expect(recorderPageMock.cameraPreviewProps?.stream).toBeNull();
+    warn.mockRestore();
+  });
+
+  it("falls back to event-only recording when the media recorder factory throws", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    recorderPageMock.createMediaRecorderWrapper.mockImplementationOnce(() => {
+      throw new Error("MediaRecorder constructor failed");
+    });
+    const { RecorderPage } = await import("../RecorderPage");
+
+    render(<RecorderPage />);
+    fireEvent.click(screen.getByRole("button", { name: "开始录制" }));
+
+    await waitFor(() => expect(recorderPageMock.devices.release).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(recorderPageMock.mediaProducer.start).toHaveBeenCalledTimes(1));
+    expect(recorderPageMock.mediaProducerDeps?.getCapability()).toEqual({
+      audio: "unsupported",
+      camera: "unsupported",
+      selectedAudioDeviceId: null,
+      selectedCameraDeviceId: null,
+    });
+    expect(recorderPageMock.mediaRecorder.start).not.toHaveBeenCalled();
+    expect(recorderPageMock.cameraPreviewProps?.stream).toBeNull();
+    warn.mockRestore();
+  });
+
+  it("delegates active media track toggles to the media producer", async () => {
+    const { RecorderPage } = await import("../RecorderPage");
+
+    render(<RecorderPage />);
+    fireEvent.click(screen.getByRole("button", { name: "开始录制" }));
+    await waitFor(() => expect(recorderPageMock.mediaRecorder.start).toHaveBeenCalledWith(recorderPageMock.stream));
+
+    fireEvent.click(screen.getByRole("button", { name: "关闭麦克风" }));
+    fireEvent.click(screen.getByRole("button", { name: "关闭摄像头" }));
+
+    expect(recorderPageMock.devices.setTrackEnabled).not.toHaveBeenCalled();
+    expect(recorderPageMock.mediaProducer.setMicrophoneEnabled).toHaveBeenCalledWith(false);
+    expect(recorderPageMock.mediaProducer.setCameraEnabled).toHaveBeenCalledWith(false);
+  });
+
+  it("syncs real media tracks directly while paused", async () => {
+    const { RecorderPage } = await import("../RecorderPage");
+
+    render(<RecorderPage />);
+    fireEvent.click(screen.getByRole("button", { name: "开始录制" }));
+    await waitFor(() => expect(recorderPageMock.mediaRecorder.start).toHaveBeenCalledWith(recorderPageMock.stream));
+
+    fireEvent.click(screen.getByRole("button", { name: "暂停录制" }));
+    await waitFor(() => expect(screen.getByRole("button", { name: "继续录制" })).not.toBeDisabled());
+    fireEvent.click(screen.getByRole("button", { name: "关闭麦克风" }));
+    fireEvent.click(screen.getByRole("button", { name: "关闭摄像头" }));
+
+    expect(recorderPageMock.devices.setTrackEnabled).toHaveBeenCalledWith("audio", false);
+    expect(recorderPageMock.devices.setTrackEnabled).toHaveBeenCalledWith("camera", false);
+    expect(recorderPageMock.mediaProducer.setMicrophoneEnabled).toHaveBeenCalledWith(false);
+    expect(recorderPageMock.mediaProducer.setCameraEnabled).toHaveBeenCalledWith(false);
+  });
+
+  it("pauses event producers before pausing the media recorder", async () => {
+    const { RecorderPage } = await import("../RecorderPage");
+
+    render(<RecorderPage />);
+    fireEvent.click(screen.getByRole("button", { name: "开始录制" }));
+    await waitFor(() => expect(recorderPageMock.mediaRecorder.start).toHaveBeenCalledWith(recorderPageMock.stream));
+
+    fireEvent.click(screen.getByRole("button", { name: "暂停录制" }));
+
+    expect(recorderPageMock.editorProducer.pause).toHaveBeenCalledTimes(1);
+    expect(recorderPageMock.mediaRecorder.pause).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(recorderPageMock.editorProducer.pause).mock.invocationCallOrder[0]).toBeLessThan(
+      recorderPageMock.mediaRecorder.pause.mock.invocationCallOrder[0],
+    );
+  });
+
+  it("rolls event producers back to recording when media pause fails", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    recorderPageMock.mediaRecorder.pause.mockImplementationOnce(() => {
+      throw new Error("pause failed");
+    });
+    const { RecorderPage } = await import("../RecorderPage");
+
+    render(<RecorderPage />);
+    fireEvent.click(screen.getByRole("button", { name: "开始录制" }));
+    await waitFor(() => expect(recorderPageMock.mediaRecorder.start).toHaveBeenCalledWith(recorderPageMock.stream));
+
+    fireEvent.click(screen.getByRole("button", { name: "暂停录制" }));
+
+    await waitFor(() => expect(recorderPageMock.editorProducer.resume).toHaveBeenCalledTimes(1));
+    expect(screen.getByRole("button", { name: "暂停录制" })).not.toBeDisabled();
+    expect(screen.getByRole("button", { name: "继续录制" })).toBeDisabled();
+    warn.mockRestore();
+  });
+
+  it("keeps event producers paused when media resume fails", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    recorderPageMock.mediaRecorder.resume.mockImplementationOnce(() => {
+      throw new Error("resume failed");
+    });
+    const { RecorderPage } = await import("../RecorderPage");
+
+    render(<RecorderPage />);
+    fireEvent.click(screen.getByRole("button", { name: "开始录制" }));
+    await waitFor(() => expect(recorderPageMock.mediaRecorder.start).toHaveBeenCalledWith(recorderPageMock.stream));
+    fireEvent.click(screen.getByRole("button", { name: "暂停录制" }));
+    await waitFor(() => expect(screen.getByRole("button", { name: "继续录制" })).not.toBeDisabled());
+
+    fireEvent.click(screen.getByRole("button", { name: "继续录制" }));
+
+    expect(recorderPageMock.mediaRecorder.resume).toHaveBeenCalledTimes(1);
+    expect(recorderPageMock.editorProducer.resume).not.toHaveBeenCalled();
+    expect(screen.getByRole("button", { name: "继续录制" })).not.toBeDisabled();
+    expect(screen.getByRole("button", { name: "暂停录制" })).toBeDisabled();
+    warn.mockRestore();
+  });
+
+  it("releases media resources when the recorder page unmounts", async () => {
+    const { RecorderPage } = await import("../RecorderPage");
+
+    const { unmount } = render(<RecorderPage />);
+    fireEvent.click(screen.getByRole("button", { name: "开始录制" }));
+    await waitFor(() => expect(recorderPageMock.mediaRecorder.start).toHaveBeenCalledWith(recorderPageMock.stream));
+
+    unmount();
+
+    expect(recorderPageMock.mediaRecorder.stop).toHaveBeenCalledTimes(1);
+    expect(recorderPageMock.devices.release).toHaveBeenCalledTimes(1);
+    expect(recorderPageMock.editorProducer.stop).toHaveBeenCalledTimes(1);
+    expect(recorderPageMock.editorProducer.dispose).toHaveBeenCalledTimes(1);
+    expect(recorderPageMock.pointerProducer.stop).toHaveBeenCalledTimes(1);
+    expect(recorderPageMock.pointerProducer.dispose).toHaveBeenCalledTimes(1);
+    expect(recorderPageMock.shortcutProducer.stop).toHaveBeenCalledTimes(1);
+    expect(recorderPageMock.shortcutProducer.dispose).toHaveBeenCalledTimes(1);
+    expect(recorderPageMock.mediaProducer.stop).toHaveBeenCalledTimes(1);
+    expect(recorderPageMock.mediaProducer.dispose).toHaveBeenCalledTimes(1);
+    expect(recorderPageMock.runtimeProducer.stop).toHaveBeenCalledTimes(1);
+    expect(recorderPageMock.runtimeProducer.dispose).toHaveBeenCalledTimes(1);
+  });
+
+  it("disposes producers when the recorder page unmounts after completion", async () => {
+    const { RecorderPage } = await import("../RecorderPage");
+
+    const { unmount } = render(<RecorderPage />);
+    fireEvent.click(screen.getByRole("button", { name: "开始录制" }));
+    await waitFor(() => expect(recorderPageMock.mediaRecorder.start).toHaveBeenCalledWith(recorderPageMock.stream));
+    await waitFor(() => expect(screen.getByRole("button", { name: "停止录制" })).not.toBeDisabled());
+    fireEvent.click(screen.getByRole("button", { name: "停止录制" }));
+    await waitFor(() => expect(recorderPageMock.navigate).toHaveBeenCalledWith(expect.stringMatching(/^\/replay\/rec-/)));
+
+    unmount();
+
+    expect(recorderPageMock.editorProducer.dispose).toHaveBeenCalledTimes(1);
+    expect(recorderPageMock.pointerProducer.dispose).toHaveBeenCalledTimes(1);
+    expect(recorderPageMock.shortcutProducer.dispose).toHaveBeenCalledTimes(1);
+    expect(recorderPageMock.mediaProducer.dispose).toHaveBeenCalledTimes(1);
+    expect(recorderPageMock.runtimeProducer.dispose).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not continue starting recording when media opening resolves after unmount", async () => {
+    const { RecorderPage } = await import("../RecorderPage");
+    let resolveOpenStream!: (result: OpenStreamResult) => void;
+    const openStream = new Promise<OpenStreamResult>((resolve) => {
+      resolveOpenStream = resolve;
+    });
+    recorderPageMock.devices.openStream.mockReturnValueOnce(openStream);
+
+    const { unmount } = render(<RecorderPage />);
+    fireEvent.click(screen.getByRole("button", { name: "开始录制" }));
+    await waitFor(() => expect(recorderPageMock.devices.openStream).toHaveBeenCalledTimes(1));
+
+    unmount();
+    expect(recorderPageMock.devices.release).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      resolveOpenStream({
+        stream: recorderPageMock.stream,
+        warnings: [],
+        capability: {
+          audio: "available",
+          camera: "available",
+          selectedAudioDeviceId: "mic-1",
+          selectedCameraDeviceId: "cam-1",
+        },
+      });
+      await openStream;
+    });
+
+    expect(recorderPageMock.devices.release).toHaveBeenCalledTimes(2);
+    expect(recorderPageMock.mediaRecorder.start).not.toHaveBeenCalled();
+    expect(recorderPageMock.editorProducer.start).not.toHaveBeenCalled();
+    expect(recorderPageMock.mediaProducer.start).not.toHaveBeenCalled();
+  });
+
+  it("ignores repeated starts while media opening is pending", async () => {
+    const { RecorderPage } = await import("../RecorderPage");
+    let resolveOpenStream!: (result: OpenStreamResult) => void;
+    const openStream = new Promise<OpenStreamResult>((resolve) => {
+      resolveOpenStream = resolve;
+    });
+    recorderPageMock.devices.openStream.mockReturnValueOnce(openStream);
+
+    render(<RecorderPage />);
+    const startButton = screen.getByRole("button", { name: "开始录制" });
+    fireEvent.click(startButton);
+    fireEvent.click(startButton);
+
+    await waitFor(() => expect(recorderPageMock.devices.openStream).toHaveBeenCalledTimes(1));
+
+    await act(async () => {
+      resolveOpenStream({
+        stream: recorderPageMock.stream,
+        warnings: [],
+        capability: {
+          audio: "available",
+          camera: "available",
+          selectedAudioDeviceId: "mic-1",
+          selectedCameraDeviceId: "cam-1",
+        },
+      });
+      await openStream;
+    });
+
+    await waitFor(() => expect(recorderPageMock.mediaRecorder.start).toHaveBeenCalledTimes(1));
+    expect(recorderPageMock.editorProducer.start).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not start the controller when media recorder start resolves after unmount", async () => {
+    const { RecorderPage } = await import("../RecorderPage");
+    let resolveStart!: () => void;
+    const recorderStart = new Promise<void>((resolve) => {
+      resolveStart = resolve;
+    });
+    recorderPageMock.mediaRecorder.start.mockReturnValueOnce(recorderStart);
+
+    const { unmount } = render(<RecorderPage />);
+    fireEvent.click(screen.getByRole("button", { name: "开始录制" }));
+    await waitFor(() =>
+      expect(recorderPageMock.mediaRecorder.start).toHaveBeenCalledWith(recorderPageMock.stream),
+    );
+
+    unmount();
+
+    await act(async () => {
+      resolveStart();
+      await recorderStart;
+    });
+
+    expect(recorderPageMock.mediaRecorder.stop).toHaveBeenCalledTimes(1);
+    expect(recorderPageMock.devices.release).toHaveBeenCalled();
+    expect(recorderPageMock.editorProducer.start).not.toHaveBeenCalled();
+    expect(recorderPageMock.mediaProducer.start).not.toHaveBeenCalled();
+  });
+
+  it("saves without navigating when stop finishes after unmount", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const { RecorderPage } = await import("../RecorderPage");
+    let resolveStop!: (result: Awaited<ReturnType<typeof recorderPageMock.mediaRecorder.stop>>) => void;
+    const stopPromise = new Promise<Awaited<ReturnType<typeof recorderPageMock.mediaRecorder.stop>>>(
+      (resolve) => {
+        resolveStop = resolve;
+      },
+    );
+    recorderPageMock.mediaRecorder.stop.mockReturnValueOnce(stopPromise);
+
+    const { unmount } = render(<RecorderPage />);
+    fireEvent.click(screen.getByRole("button", { name: "开始录制" }));
+    await waitFor(() => expect(recorderPageMock.mediaRecorder.start).toHaveBeenCalledWith(recorderPageMock.stream));
+    await waitFor(() => expect(screen.getByRole("button", { name: "停止录制" })).not.toBeDisabled());
+    fireEvent.click(screen.getByRole("button", { name: "停止录制" }));
+    await waitFor(() => expect(recorderPageMock.mediaRecorder.stop).toHaveBeenCalledTimes(1));
+
+    unmount();
+    expect(recorderPageMock.devices.release).not.toHaveBeenCalled();
+    await act(async () => {
+      resolveStop({
+        blob: new Blob(["media"], { type: "video/webm" }),
+        mimeType: "video/webm",
+        durationMs: 1_000,
+        hasAudio: true,
+        hasCamera: true,
+      });
+      await stopPromise;
+    });
+
+    await waitFor(() => expect(recorderPageMock.repository.saveDraft).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(recorderPageMock.repository.commit).toHaveBeenCalledTimes(1));
+    expect(recorderPageMock.devices.release).toHaveBeenCalledTimes(1);
+    expect(recorderPageMock.navigate).not.toHaveBeenCalled();
+    expect(warn).not.toHaveBeenCalledWith("[recorder-page] stop ignored after unmount:", expect.any(Error));
+    warn.mockRestore();
+  });
+
+  it("continues event-only recording when opening media fails", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    recorderPageMock.devices.openStream.mockRejectedValueOnce(new Error("device busy"));
+    const { RecorderPage } = await import("../RecorderPage");
+
+    render(<RecorderPage />);
+    fireEvent.click(screen.getByRole("button", { name: "开始录制" }));
+
+    await waitFor(() => expect(recorderPageMock.devices.release).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(recorderPageMock.mediaProducer.start).toHaveBeenCalledTimes(1));
+    expect(recorderPageMock.mediaProducerDeps?.getCapability()).toEqual({
+      audio: "unsupported",
+      camera: "unsupported",
+      selectedAudioDeviceId: null,
+      selectedCameraDeviceId: null,
+    });
+    expect(recorderPageMock.cameraPreviewProps?.stream).toBeNull();
+    warn.mockRestore();
+  });
+
+  it("continues event-only recording when opening media returns no stream", async () => {
+    recorderPageMock.devices.openStream.mockResolvedValueOnce({
+      stream: null,
+      warnings: [],
+      capability: {
+        audio: "available",
+        camera: "available",
+        selectedAudioDeviceId: "mic-1",
+        selectedCameraDeviceId: "cam-1",
+      },
+    });
+    const { RecorderPage } = await import("../RecorderPage");
+
+    render(<RecorderPage />);
+    fireEvent.click(screen.getByRole("button", { name: "开始录制" }));
+
+    await waitFor(() => expect(recorderPageMock.devices.release).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(recorderPageMock.mediaProducer.start).toHaveBeenCalledTimes(1));
+    expect(recorderPageMock.mediaRecorder.start).not.toHaveBeenCalled();
+    expect(recorderPageMock.mediaProducerDeps?.getCapability()).toEqual({
+      audio: "unsupported",
+      camera: "unsupported",
+      selectedAudioDeviceId: null,
+      selectedCameraDeviceId: null,
+    });
+    expect(recorderPageMock.cameraPreviewProps?.stream).toBeNull();
+  });
+
+  it("continues event-only recording when device enumeration fails", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    recorderPageMock.devices.enumerate.mockRejectedValueOnce(new Error("blocked"));
+    const { RecorderPage } = await import("../RecorderPage");
+
+    render(<RecorderPage />);
+    fireEvent.click(screen.getByRole("button", { name: "开始录制" }));
+
+    await waitFor(() => expect(recorderPageMock.devices.release).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(recorderPageMock.mediaProducer.start).toHaveBeenCalledTimes(1));
+    expect(recorderPageMock.devices.openStream).not.toHaveBeenCalled();
+    expect(recorderPageMock.mediaProducerDeps?.getCapability()).toEqual({
+      audio: "unsupported",
+      camera: "unsupported",
+      selectedAudioDeviceId: null,
+      selectedCameraDeviceId: null,
+    });
+    warn.mockRestore();
+  });
+
+  it("saves the event recording when media finalization fails", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    recorderPageMock.mediaRecorder.stop.mockRejectedValueOnce(new Error("InvalidStateError"));
+    const { RecorderPage } = await import("../RecorderPage");
+
+    render(<RecorderPage />);
+    fireEvent.click(screen.getByRole("button", { name: "开始录制" }));
+    await waitFor(() => expect(recorderPageMock.mediaRecorder.start).toHaveBeenCalledWith(recorderPageMock.stream));
+    await waitFor(() => expect(screen.getByRole("button", { name: "停止录制" })).not.toBeDisabled());
+
+    fireEvent.click(screen.getByRole("button", { name: "停止录制" }));
+
+    await waitFor(() => expect(recorderPageMock.mediaRecorder.stop).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(recorderPageMock.navigate).toHaveBeenCalledWith(expect.stringMatching(/^\/replay\/rec-/)));
+    expect(recorderPageMock.devices.release).toHaveBeenCalled();
+    warn.mockRestore();
   });
 });

--- a/apps/web/src/features/recorder/__tests__/recordingController.test.ts
+++ b/apps/web/src/features/recorder/__tests__/recordingController.test.ts
@@ -5,6 +5,7 @@ import { createPackageBuilder } from "../packageBuilder";
 import { createRecordingController } from "../recordingController";
 import type {
   EventProducer,
+  PackageBuildInput,
   RecordingPackageV1,
   RecordingRepository,
   RecordStartPayload,
@@ -67,7 +68,7 @@ function makeStartPayload(): RecordStartPayload {
   };
 }
 
-function setup() {
+function setup(options: { mediaSource?: () => Promise<PackageBuildInput["media"]> } = {}) {
   let wall = 1_000;
   const clock = createRecordingClock({ nowProvider: () => wall });
   const bus = createEventBus({ clock, wallTimeProvider: () => "T" });
@@ -81,6 +82,7 @@ function setup() {
     repository,
     appVersion: "0.0.0",
     generateTitle: () => "title-x",
+    mediaSource: options.mediaSource,
   });
   return {
     controller,
@@ -152,6 +154,49 @@ describe("createRecordingController", () => {
     expect(repository.commits.length).toBe(1);
   });
 
+  it("includes finalized media from mediaSource in the saved package", async () => {
+    const mediaBlob = new Blob(["media"], { type: "video/webm" });
+    const mediaSource = vi.fn(async () => ({
+      blob: mediaBlob,
+      durationMs: 1_500,
+      mimeType: "video/webm",
+      hasAudio: true,
+      hasCamera: true,
+    }));
+    const { controller, repository } = setup({ mediaSource });
+
+    await controller.start(makeStartPayload());
+    const pkg = await controller.stop("user");
+
+    expect(mediaSource).toHaveBeenCalledTimes(1);
+    expect(pkg.media).toEqual(
+      expect.objectContaining({
+        durationMs: 1_500,
+        mimeType: "video/webm",
+        hasAudio: true,
+        hasCamera: true,
+      }),
+    );
+    expect(repository.drafts[0].mediaBlob).toBe(mediaBlob);
+  });
+
+  it("saves the package without media when mediaSource fails", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const mediaSource = vi.fn(async () => {
+      throw new Error("InvalidStateError");
+    });
+    const { controller, repository } = setup({ mediaSource });
+
+    await controller.start(makeStartPayload());
+    const pkg = await controller.stop("user");
+
+    expect(mediaSource).toHaveBeenCalledTimes(1);
+    expect(pkg.media).toBeNull();
+    expect(repository.drafts[0].mediaBlob).toBeNull();
+    expect(controller.state.status).toBe("completed");
+    warn.mockRestore();
+  });
+
   it("does not complete when saveDraft fails", async () => {
     const { controller, repository } = setup();
     vi.mocked(repository.saveDraft).mockResolvedValueOnce({
@@ -166,6 +211,41 @@ describe("createRecordingController", () => {
     expect(controller.state.status).toBe("failed");
     expect(controller.state.lastError?.code).toBe("save-draft-failed");
     expect(repository.commits.length).toBe(0);
+  });
+
+  it("reuses finalized media when saveDraft fails and stop is retried", async () => {
+    const mediaBlob = new Blob(["media"], { type: "video/webm" });
+    const mediaSource = vi.fn(async () => ({
+      blob: mediaBlob,
+      durationMs: 1_500,
+      mimeType: "video/webm",
+      hasAudio: true,
+      hasCamera: true,
+    }));
+    const { controller, repository } = setup({ mediaSource });
+    vi.mocked(repository.saveDraft).mockResolvedValueOnce({
+      ok: false,
+      reason: "quota-exceeded",
+      message: "IndexedDB quota exceeded",
+    });
+
+    await controller.start(makeStartPayload());
+    await expect(controller.stop("user")).rejects.toThrow(/save-draft-failed/);
+    const pkg = await controller.stop("user");
+
+    expect(mediaSource).toHaveBeenCalledTimes(1);
+    expect(repository.saveDraft).toHaveBeenCalledTimes(2);
+    expect(vi.mocked(repository.saveDraft).mock.calls[0][0].mediaBlob).toBe(mediaBlob);
+    expect(vi.mocked(repository.saveDraft).mock.calls[1][0].mediaBlob).toBe(mediaBlob);
+    expect(repository.drafts).toHaveLength(1);
+    expect(repository.drafts[0].mediaBlob).toBe(mediaBlob);
+    expect(pkg.media).toEqual(
+      expect.objectContaining({
+        durationMs: 1_500,
+        mimeType: "video/webm",
+      }),
+    );
+    expect(controller.state.status).toBe("completed");
   });
 
   it("does not complete when commit fails", async () => {
@@ -188,6 +268,7 @@ describe("createRecordingController", () => {
     await controller.start(makeStartPayload());
     controller.reset();
     expect(controller.state.status).toBe("idle");
+    expect(producers[0].calls).toContain("p1:stop");
     expect(producers[0].calls).toContain("p1:dispose");
   });
 });

--- a/apps/web/src/features/recorder/recordingController.ts
+++ b/apps/web/src/features/recorder/recordingController.ts
@@ -1,6 +1,7 @@
 import { generateId } from "@/shared/util/ids";
 import type {
   EventProducer,
+  PackageBuildInput,
   RecordingController,
   RecordingControllerDeps,
   RecordingControllerState,
@@ -19,6 +20,7 @@ export type RecordingControllerOptions = RecordingControllerDeps & {
    * The recorder's editorProducer is the natural source.
    */
   snapshotSource?: () => Promise<RecordingSnapshot | null>;
+  mediaSource?: () => Promise<PackageBuildInput["media"]>;
 };
 
 const VALID_TRANSITIONS: Record<RecordingControllerStatus, RecordingControllerStatus[]> = {
@@ -29,8 +31,10 @@ const VALID_TRANSITIONS: Record<RecordingControllerStatus, RecordingControllerSt
   stopping: ["processing", "failed"],
   processing: ["completed", "failed"],
   completed: ["idle"],
-  failed: ["idle"],
+  failed: ["idle", "stopping"],
 };
+
+type PendingPackageSave = { pkg: RecordingPackageV1; mediaBlob: Blob | null };
 
 /**
  * RecordingController — central state machine that wires clock + bus + producers
@@ -64,6 +68,8 @@ export function createRecordingController(options: RecordingControllerOptions): 
   };
 
   let startPayload: RecordStartPayload | null = null;
+  let finalizedMedia: PackageBuildInput["media"] | undefined;
+  let pendingPackageSave: PendingPackageSave | null = null;
 
   const publish = () => listeners.forEach((fn) => fn(state));
   const transitionTo = (next: RecordingControllerStatus, patch: Partial<RecordingControllerState> = {}) => {
@@ -138,70 +144,64 @@ export function createRecordingController(options: RecordingControllerOptions): 
       transitionTo("recording", { durationMs: clock.durationMs() });
     },
     async stop(reason): Promise<RecordingPackageV1> {
-      transitionTo("stopping");
+      if (state.status === "failed" && !pendingPackageSave) {
+        throw new Error("No pending recording package is available to retry.");
+      }
+      transitionTo("stopping", { lastError: null });
       try {
-        forEachProducer((p) => p.stop());
-        const durationMs = clock.durationMs();
-        bus.emit({
-          type: "record-stop",
-          source: "recorder",
-          track: "main",
-          payload: { durationMs, reason },
-        });
-        clock.stop();
-        transitionTo("processing", { durationMs });
+        if (!pendingPackageSave) {
+          forEachProducer((p) => p.stop());
+          const durationMs = clock.durationMs();
+          bus.emit({
+            type: "record-stop",
+            source: "recorder",
+            track: "main",
+            payload: { durationMs, reason },
+          });
+          clock.stop();
+          transitionTo("processing", { durationMs });
 
-        const events = bus.drain();
-        const snapshot = options.snapshotSource ? await options.snapshotSource() : null;
-        const snapshots: RecordingSnapshot[] = snapshot ? [snapshot] : [];
+          const events = bus.drain();
+          const snapshot = options.snapshotSource ? await options.snapshotSource() : null;
+          const snapshots: RecordingSnapshot[] = snapshot ? [snapshot] : [];
+          if (!startPayload) {
+            throw new Error("RecordingController.start() must be called before stop().");
+          }
+          if (finalizedMedia === undefined) {
+            finalizedMedia = await resolveMedia(options.mediaSource);
+          }
 
-        if (!startPayload) {
-          throw new Error("RecordingController.start() must be called before stop().");
+          const titleProvider = options.generateTitle ?? (() => `录制 ${new Date().toLocaleString()}`);
+
+          pendingPackageSave = await packageBuilder.build({
+            meta: {
+              id: generateId("rec"),
+              title: titleProvider(),
+              createdAt: state.startedAt ?? new Date().toISOString(),
+              durationMs,
+              appVersion: options.appVersion,
+              ownerId: null,
+              creatorInfo: null,
+              initialLanguage: startPayload.initialLanguage,
+              initialFontSize: startPayload.initialFontSize,
+              initialTheme: startPayload.initialTheme,
+              mediaCapability: startPayload.mediaCapability,
+            },
+            events,
+            snapshots,
+            media: finalizedMedia,
+          });
+        } else {
+          transitionTo("processing", { durationMs: pendingPackageSave.pkg.meta.durationMs });
         }
 
-        const titleProvider = options.generateTitle ?? (() => `录制 ${new Date().toLocaleString()}`);
-
-        const { pkg, mediaBlob } = await packageBuilder.build({
-          meta: {
-            id: generateId("rec"),
-            title: titleProvider(),
-            createdAt: state.startedAt ?? new Date().toISOString(),
-            durationMs,
-            appVersion: options.appVersion,
-            ownerId: null,
-            creatorInfo: null,
-            initialLanguage: startPayload.initialLanguage,
-            initialFontSize: startPayload.initialFontSize,
-            initialTheme: startPayload.initialTheme,
-            mediaCapability: startPayload.mediaCapability,
-          },
-          events,
-          snapshots,
-          media: null,
-        });
-
-        const saveResult = await repository.saveDraft({
-          meta: pkg.meta,
-          events: pkg.events,
-          snapshots: pkg.snapshots,
-          indexes: pkg.indexes ?? {
-            generatedAt: new Date().toISOString(),
-            eventsByType: {} as Record<string, number[]>,
-            snapshotSeqsByTime: [],
-            markers: [],
-          },
-          mediaBlob,
-        });
-        if (!saveResult.ok) {
-          throw persistenceError("save-draft-failed", saveResult.reason, saveResult.message);
-        }
-
-        const commitResult = await repository.commit(pkg.meta.id);
-        if (!commitResult.ok) {
-          throw persistenceError("commit-failed", commitResult.reason, commitResult.message);
-        }
+        await persistPackage(repository, pendingPackageSave);
 
         transitionTo("completed");
+        const pkg = pendingPackageSave.pkg;
+        pendingPackageSave = null;
+        finalizedMedia = undefined;
+        startPayload = null;
         return pkg;
       } catch (err) {
         transitionTo("failed", { lastError: errorToInfo(err) });
@@ -209,6 +209,10 @@ export function createRecordingController(options: RecordingControllerOptions): 
       }
     },
     reset() {
+      if (isActiveStatus(state.status)) {
+        forEachProducer((p) => p.stop());
+        clock.stop();
+      }
       forEachProducer((p) => p.dispose());
       bus.reset();
       state = {
@@ -219,6 +223,8 @@ export function createRecordingController(options: RecordingControllerOptions): 
         lastError: null,
       };
       startPayload = null;
+      finalizedMedia = undefined;
+      pendingPackageSave = null;
       publish();
     },
     subscribe(listener) {
@@ -229,9 +235,58 @@ export function createRecordingController(options: RecordingControllerOptions): 
   } satisfies RecordingController;
 }
 
+async function persistPackage(
+  repository: RecordingControllerDeps["repository"],
+  pending: PendingPackageSave,
+): Promise<void> {
+  const { pkg, mediaBlob } = pending;
+  const saveResult = await repository.saveDraft({
+    meta: pkg.meta,
+    events: pkg.events,
+    snapshots: pkg.snapshots,
+    indexes: pkg.indexes ?? {
+      generatedAt: new Date().toISOString(),
+      eventsByType: {} as Record<string, number[]>,
+      snapshotSeqsByTime: [],
+      markers: [],
+    },
+    mediaBlob,
+  });
+  if (!saveResult.ok) {
+    throw persistenceError("save-draft-failed", saveResult.reason, saveResult.message);
+  }
+
+  const commitResult = await repository.commit(pkg.meta.id);
+  if (!commitResult.ok) {
+    throw persistenceError("commit-failed", commitResult.reason, commitResult.message);
+  }
+}
+
+function isActiveStatus(status: RecordingControllerStatus): boolean {
+  return (
+    status === "requestingPermission" ||
+    status === "recording" ||
+    status === "paused" ||
+    status === "stopping" ||
+    status === "processing"
+  );
+}
+
 function errorToInfo(err: unknown): { code: string; message: string } {
   if (err instanceof Error) return { code: err.name, message: err.message };
   return { code: "unknown", message: String(err) };
+}
+
+async function resolveMedia(
+  mediaSource: RecordingControllerOptions["mediaSource"],
+): Promise<PackageBuildInput["media"]> {
+  if (!mediaSource) return null;
+  try {
+    return await mediaSource();
+  } catch (err) {
+    console.warn("[recording-controller] mediaSource threw:", err);
+    return null;
+  }
 }
 
 function persistenceError(code: string, reason: string, message: string): Error {


### PR DESCRIPTION
## 关联 Issue

无：维护者要求先整合、调优、完善并通过 PR 查看 repo-guard/Copilot 评论，本轮不发布新 issue。

## 变更说明

- CodeEditor 增加回放受控态：`value` / `readOnly` / cursor / selection / scroll 同步，同时保留 `initialValue` 的录制初始化语义。
- ReplayPage 接入 scheduler stable state 到只读编辑器，并增加 runtime console 输出面板。
- RecorderPage 接入真实 media stream / MediaRecorder：开始录制时打开默认设备，暂停/恢复同步 MediaRecorder，停止时把 media blob 交给 package builder。
- RecordingController 支持 stop 阶段 best-effort 收集媒体，媒体失败时继续保存无媒体 package。
- 处理 repo-guard/Copilot 评论：
  - 设备枚举失败、打开媒体流失败、`openStream()` 返回 `stream: null`、MediaRecorder factory 同步抛错、MediaRecorder start 失败都会释放设备并降级为 event-only 录制。
  - MediaRecorder start 失败后会对已创建 wrapper 做 best-effort stop，再清空 ref 和释放设备。
  - MediaRecorder stop / mediaSource 失败不阻断事件包保存。
  - 暂停时先暂停 controller/producers，再暂停 MediaRecorder；若 MediaRecorder pause 抛错，会把 controller/producers 回滚到 recording。
  - 恢复时先恢复 MediaRecorder，再恢复 controller/producers；若 MediaRecorder resume 抛错，会保持 controller/producers paused。
  - 麦克风/摄像头 toggle：recording 态委托 mediaProducer 同步真实 tracks，paused 态由 RecorderPage 直接同步 tracks，避免重复写 track 且保持暂停时的真实设备状态。
  - RecorderPage unmount/路由离开时停止当前 recorder，并通过 controller reset 停止/释放所有 producers；completed 后卸载也会 dispose producers。
  - controller subscribe 增加 mounted guard，避免 unmount cleanup 的 reset publish 触发卸载后的 React state update。
  - `saveDraft` 首次失败后，controller 复用已 finalize 的 pending package/media blob 重试，避免二次 stop 丢失媒体。
  - 设备打开或 MediaRecorder start 处于 pending 时离开页面，会通过 mounted/start-token guard 释放资源并阻止卸载后的 recorder/controller continuation。
  - 重复点击开始录制时通过 start in-flight guard 防重入，避免旧 async 分支释放新录制的媒体资源。
  - 停止保存 pending 时离开页面会通过 stop token / mounted guard 忽略卸载后的 navigation，并避免 cleanup reset 破坏正在 finalize 的 stop 流程。
  - stop/media finalize 期间 unmount 不再由 cleanup 抢先 stop recorder 或 release tracks，统一等 `mediaSource.finally` 在 `MediaRecorder.stop()` resolve 后释放设备。

## GitNexus 影响分析摘要

- 风险等级: CRITICAL
- 关键骨架变更: `contract:local` 判定无 critical contract surface changed，本轮为 advisory。
- `detect_changes(compare origin/main)`: 9 files / 64 touched symbols / 17 affected processes，集中在 RecorderPage、ReplayPage、CodeEditor、RecordingController。
- `impact(RecorderPage)`: LOW；直接到 routes.tsx，再到 App/main。
- `impact(CodeEditor)`: LOW；直接影响 RecorderPage 和 ReplayPage，再到 routes/App。
- `impact(ReplayPage)`: LOW；直接到 routes.tsx，再到 App/main。
- `impact(createRecordingController)`: LOW；直接影响 RecorderPage stack。
- `impact(stop)`: LOW；无上游调用扩散。

## 验证

- `npm run quality:predev` 通过。
- `npm run agent:bootstrap` 通过。
- `npm run test -w apps/web -- src/features/recorder/__tests__/RecorderPage.test.tsx src/features/recorder/__tests__/recordingController.test.ts` 通过：30/30。
- `npm run quality:precommit` 通过：root tests 39/39、web tests 234/234、lint、build。
- `GITNEXUS_ANALYZE_TIMEOUT_MS=120000 npm run quality:local` 通过：contract:local、root tests 39/39、lint、web tests 234/234、build、Playwright e2e 2/2。
- push hook 再次通过：contract:local、root tests 39/39、lint、web tests 234/234、build、Playwright e2e 2/2。

## 自检

- [x] PR author 是该 Issue 的认领者（本轮无 issue，维护者直接要求整合推进）
- [x] 未修改 `docs/progress.json` 或 `docs/progress.md`
- [x] 已运行 `npm run quality:local`，或说明无法运行的原因
- [x] 如果改动关键骨架，已补充契约测试并填写 GitNexus 影响分析摘要
- [ ] 已邀请至少一名非作者同学 CR
