### PR TITLE
#76 ReplayScheduler 接入媒体主时钟

### DIFF
--- a/apps/web/src/features/player/ReplayControls.tsx
+++ b/apps/web/src/features/player/ReplayControls.tsx
@@ -10,7 +10,6 @@ export type ReplayControlsProps = {
   state: ReplaySchedulerState;
   durationMs: number;
   onPlayPause(): void;
-  onPlay(): void;
   onSeek(targetMs: number): Promise<void> | void;
   onRate(rate: ReplayPlaybackRate): void;
   volume: number;
@@ -25,7 +24,6 @@ export function ReplayControls({
   state,
   durationMs,
   onPlayPause,
-  onPlay,
   onSeek,
   onRate,
   volume,
@@ -94,12 +92,8 @@ export function ReplayControls({
   const handleSliderCommit = async (value: number) => {
     if (timelineDisabled) return;
     const targetMs = (value / 100) * safeDuration;
-    const initialStatus = state.status;
     setPendingProgressPercent(null);
     await onSeek(targetMs);
-    if (initialStatus !== "error" && initialStatus !== "loading") {
-      onPlay();
-    }
   };
 
   const handleVolumeChange = (v: number) => {

--- a/apps/web/src/features/player/ReplayControls.tsx
+++ b/apps/web/src/features/player/ReplayControls.tsx
@@ -38,7 +38,7 @@ export function ReplayControls({
   const [pendingProgressPercent, setPendingProgressPercent] = useState<number | null>(null);
   const rateCloseTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const volumeCloseTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const isPlaying = state.status === "playing";
+  const isPlaying = state.status === "playing" || state.status === "buffering";
   const safeDuration = Math.max(0, durationMs);
   const baseCurrentTime = Math.min(Math.max(0, state.timelineTimeMs), safeDuration);
   const baseProgressPercent = safeDuration > 0 ? (baseCurrentTime / safeDuration) * 100 : 0;

--- a/apps/web/src/features/player/ReplayPage.tsx
+++ b/apps/web/src/features/player/ReplayPage.tsx
@@ -64,7 +64,6 @@ type ReplayOverlayState = {
 
 const EMPTY_OVERLAY_STATE: ReplayOverlayState = { pointer: null, shortcut: null };
 const TRANSIENT_OVERLAY_TTL_MS = 900;
-const MEDIA_DRIFT_THRESHOLD_MS = 250;
 
 /**
  * ReplayPage — wires the replay core (scheduler + clock + repository + runtime)
@@ -87,6 +86,31 @@ export function ReplayPage() {
   const pointerTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const shortcutTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const currentMedia = pkg?.media ?? null;
+  const mediaAdapter = useMemo(() => {
+    if (!currentMedia || !mediaBlob) return null;
+    return createMediaClockAdapter({
+      segments: [
+        {
+          blobId: currentMedia.blobId,
+          timelineStartMs: currentMedia.timelineOffsetMs,
+          timelineEndMs: currentMedia.timelineOffsetMs + currentMedia.durationMs,
+          mediaStartMs: 0,
+          mediaEndMs: currentMedia.durationMs,
+        },
+      ],
+      currentTimeProvider: () => recordedMediaVideoRef.current?.currentTime ?? null,
+      metadataReadyProvider: () => isMediaMetadataReady(recordedMediaVideoRef.current),
+      statusProvider: () => readRecordedMediaStatus(recordedMediaVideoRef.current),
+      seekHandler: (_segment, mediaTimeMs) => {
+        const video = recordedMediaVideoRef.current;
+        if (!video) return;
+        video.currentTime = mediaTimeMs / 1000;
+      },
+      rateHandler: (rate) => {
+        if (recordedMediaVideoRef.current) recordedMediaVideoRef.current.playbackRate = rate;
+      },
+    });
+  }, [currentMedia, mediaBlob]);
   const clearOverlayTimers = useCallback(() => {
     if (pointerTimerRef.current) clearTimeout(pointerTimerRef.current);
     if (shortcutTimerRef.current) clearTimeout(shortcutTimerRef.current);
@@ -102,21 +126,22 @@ export function ReplayPage() {
       },
     });
   }, []);
+  const syncSchedulerMediaStatus = useCallback(() => {
+    scheduler.setMediaAdapter(mediaAdapter);
+  }, [mediaAdapter, scheduler]);
   const playRecordedMedia = useCallback(() => {
     const video = recordedMediaVideoRef.current;
     if (!video) return;
-    const targetMs = timelineToRecordedMediaTime(currentMedia, schedulerState.timelineTimeMs);
+    const targetMs = mediaAdapter?.timelineToMediaTime(schedulerState.timelineTimeMs) ?? null;
     if (targetMs === null) {
       video.pause();
       return;
     }
-    if (Math.abs(video.currentTime * 1000 - targetMs) > MEDIA_DRIFT_THRESHOLD_MS) {
-      video.currentTime = targetMs / 1000;
-    }
+    void mediaAdapter?.seek(schedulerState.timelineTimeMs);
     void video.play().catch((err) => {
       console.warn("[replay-page] recorded media play failed:", err);
     });
-  }, [currentMedia, schedulerState.timelineTimeMs]);
+  }, [mediaAdapter, schedulerState.timelineTimeMs]);
   const pauseRecordedMedia = useCallback(() => {
     recordedMediaVideoRef.current?.pause();
   }, []);
@@ -132,6 +157,9 @@ export function ReplayPage() {
   useEffect(() => scheduler.subscribe(setSchedulerState), [scheduler]);
   useEffect(() => () => scheduler.destroy(), [scheduler]);
   useEffect(() => clearOverlayTimers, [clearOverlayTimers]);
+  useEffect(() => {
+    scheduler.setMediaAdapter(mediaAdapter);
+  }, [mediaAdapter, scheduler]);
 
   useEffect(() => {
     if (!id) return;
@@ -197,6 +225,7 @@ export function ReplayPage() {
             schedulerState={schedulerState}
             volume={volume}
             muted={muted}
+            onStatusChange={syncSchedulerMediaStatus}
           />
         </div>
         <div className="flex min-h-0 flex-col">
@@ -208,7 +237,9 @@ export function ReplayPage() {
         state={schedulerState}
         durationMs={pkg?.meta.durationMs ?? 0}
         onPlayPause={() =>
-          schedulerState.status === "playing" ? pauseReplay() : playReplay()
+          schedulerState.status === "playing" || schedulerState.status === "buffering"
+            ? pauseReplay()
+            : playReplay()
         }
         onPlay={playReplay}
         onSeek={(target) => scheduler.seek(target)}
@@ -270,6 +301,21 @@ function timelineToRecordedMediaTime(
   return timelineTimeMs - timelineStartMs;
 }
 
+function isMediaMetadataReady(video: HTMLVideoElement | null): boolean {
+  return Boolean(video && !video.error && video.readyState >= 1);
+}
+
+function readRecordedMediaStatus(
+  video: HTMLVideoElement | null,
+): ReplaySchedulerState["mediaStatus"] {
+  if (!video) return "loading";
+  if (video.error) return "error";
+  if (video.networkState === 3) return "missing";
+  if (video.readyState < 1) return "loading";
+  if (!video.paused && video.readyState < 3) return "stalled";
+  return "ready";
+}
+
 function scheduleOverlayCleanup(
   transientEvents: RecordingEvent[],
   setOverlayState: Dispatch<SetStateAction<ReplayOverlayState>>,
@@ -323,6 +369,7 @@ function RecordedMediaOverlay({
   schedulerState,
   volume,
   muted,
+  onStatusChange,
 }: {
   videoRef: MutableRefObject<HTMLVideoElement | null>;
   media: RecordingPackageV1["media"];
@@ -331,33 +378,12 @@ function RecordedMediaOverlay({
   schedulerState: ReplaySchedulerState;
   volume: number;
   muted: boolean;
+  onStatusChange(): void;
 }) {
   const [src, setSrc] = useState<string | null>(null);
   const hasMedia = Boolean(media && mediaBlob);
   const hasCamera = Boolean(media?.hasCamera);
-  const mediaAdapter = useMemo(() => {
-    if (!media) return null;
-    return createMediaClockAdapter({
-      segments: [
-        {
-          blobId: media.blobId,
-          timelineStartMs: media.timelineOffsetMs,
-          timelineEndMs: media.timelineOffsetMs + media.durationMs,
-          mediaStartMs: 0,
-          mediaEndMs: media.durationMs,
-        },
-      ],
-      seekHandler: (_segment, mediaTimeMs) => {
-        const video = videoRef.current;
-        if (!video) return;
-        video.currentTime = mediaTimeMs / 1000;
-      },
-      rateHandler: (rate) => {
-        if (videoRef.current) videoRef.current.playbackRate = rate;
-      },
-    });
-  }, [media, videoRef]);
-  const activeMediaTimeMs = mediaAdapter?.timelineToMediaTime(schedulerState.timelineTimeMs) ?? null;
+  const activeMediaTimeMs = timelineToRecordedMediaTime(media, schedulerState.timelineTimeMs);
   const isMediaSegmentActive = hasMedia && activeMediaTimeMs !== null;
   const showCamera = isMediaSegmentActive && hasCamera && mediaState.cameraEnabled;
 
@@ -379,28 +405,24 @@ function RecordedMediaOverlay({
   }, [volume, muted, videoRef]);
 
   useEffect(() => {
-    mediaAdapter?.setRate(schedulerState.playbackRate);
-  }, [mediaAdapter, schedulerState.playbackRate]);
-
-  useEffect(() => {
     const video = videoRef.current;
-    if (!video || !mediaAdapter) return;
-    const targetMs = mediaAdapter.timelineToMediaTime(schedulerState.timelineTimeMs);
-    if (targetMs === null) {
+    if (!video) return;
+    if (!isMediaSegmentActive) {
       video.pause();
       return;
     }
-    if (Math.abs(video.currentTime * 1000 - targetMs) > MEDIA_DRIFT_THRESHOLD_MS) {
-      video.currentTime = targetMs / 1000;
-    }
-    if (schedulerState.status === "playing") {
+    if (schedulerState.status === "playing" || schedulerState.status === "buffering") {
       void video.play().catch((err) => {
         console.warn("[replay-page] recorded media play failed:", err);
       });
     } else {
       video.pause();
     }
-  }, [mediaAdapter, schedulerState.status, schedulerState.timelineTimeMs, src, videoRef]);
+  }, [isMediaSegmentActive, schedulerState.status, src, videoRef]);
+
+  useEffect(() => {
+    onStatusChange();
+  }, [onStatusChange, src]);
 
   if (!src || !hasMedia) return null;
 
@@ -425,6 +447,12 @@ function RecordedMediaOverlay({
         src={src}
         className="h-full w-full object-cover"
         playsInline
+        onLoadedMetadata={onStatusChange}
+        onCanPlay={onStatusChange}
+        onPlaying={onStatusChange}
+        onWaiting={onStatusChange}
+        onStalled={onStatusChange}
+        onError={onStatusChange}
       />
     </div>
   );

--- a/apps/web/src/features/player/ReplayPage.tsx
+++ b/apps/web/src/features/player/ReplayPage.tsx
@@ -250,7 +250,6 @@ export function ReplayPage() {
             ? pauseReplay()
             : playReplay()
         }
-        onPlay={playReplay}
         onSeek={(target) => scheduler.seek(target)}
         onRate={(rate) => scheduler.setRate(rate)}
         volume={volume}

--- a/apps/web/src/features/player/ReplayPage.tsx
+++ b/apps/web/src/features/player/ReplayPage.tsx
@@ -64,6 +64,7 @@ type ReplayOverlayState = {
 
 const EMPTY_OVERLAY_STATE: ReplayOverlayState = { pointer: null, shortcut: null };
 const TRANSIENT_OVERLAY_TTL_MS = 900;
+type RecordedMedia = NonNullable<RecordingPackageV1["media"]>;
 
 /**
  * ReplayPage — wires the replay core (scheduler + clock + repository + runtime)
@@ -86,16 +87,15 @@ export function ReplayPage() {
   const pointerTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const shortcutTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const currentMedia = pkg?.media ?? null;
-  const mediaAdapter = useMemo(() => {
-    if (!currentMedia || !mediaBlob) return null;
+  const createRecordedMediaAdapter = useCallback((media: RecordedMedia) => {
     return createMediaClockAdapter({
       segments: [
         {
-          blobId: currentMedia.blobId,
-          timelineStartMs: currentMedia.timelineOffsetMs,
-          timelineEndMs: currentMedia.timelineOffsetMs + currentMedia.durationMs,
+          blobId: media.blobId,
+          timelineStartMs: media.timelineOffsetMs,
+          timelineEndMs: media.timelineOffsetMs + media.durationMs,
           mediaStartMs: 0,
-          mediaEndMs: currentMedia.durationMs,
+          mediaEndMs: media.durationMs,
         },
       ],
       currentTimeProvider: () => recordedMediaVideoRef.current?.currentTime ?? null,
@@ -110,7 +110,11 @@ export function ReplayPage() {
         if (recordedMediaVideoRef.current) recordedMediaVideoRef.current.playbackRate = rate;
       },
     });
-  }, [currentMedia, mediaBlob]);
+  }, []);
+  const mediaAdapter = useMemo(() => {
+    if (!currentMedia || !mediaBlob) return null;
+    return createRecordedMediaAdapter(currentMedia);
+  }, [createRecordedMediaAdapter, currentMedia, mediaBlob]);
   const clearOverlayTimers = useCallback(() => {
     if (pointerTimerRef.current) clearTimeout(pointerTimerRef.current);
     if (shortcutTimerRef.current) clearTimeout(shortcutTimerRef.current);
@@ -180,6 +184,11 @@ export function ReplayPage() {
         );
         return;
       }
+      const loadedMediaAdapter =
+        result.package.media && result.mediaBlob
+          ? createRecordedMediaAdapter(result.package.media)
+          : null;
+      scheduler.setMediaAdapter(loadedMediaAdapter);
       setPkg(result.package);
       setMediaBlob(result.mediaBlob);
       await scheduler.load(result.package);
@@ -187,7 +196,7 @@ export function ReplayPage() {
     return () => {
       cancelled = true;
     };
-  }, [clearOverlayTimers, id, repository, scheduler]);
+  }, [clearOverlayTimers, createRecordedMediaAdapter, id, repository, scheduler]);
 
   if (loadError) {
     return (

--- a/apps/web/src/features/player/__tests__/ReplayControls.test.tsx
+++ b/apps/web/src/features/player/__tests__/ReplayControls.test.tsx
@@ -75,7 +75,6 @@ function renderControls(overrides: Partial<ReplayControlsProps> = {}) {
     state: state("ready"),
     durationMs: 120_000,
     onPlayPause: vi.fn(),
-    onPlay: vi.fn(),
     onSeek: vi.fn(),
     onRate: vi.fn(),
     volume: 80,
@@ -149,12 +148,10 @@ describe("ReplayControls", () => {
     "disables progress seeking while status is %s",
     (status) => {
       const onSeek = vi.fn();
-      const onPlay = vi.fn();
       renderControls({
         state: state(status, { timelineTimeMs: 20_000 }),
         durationMs: 100_000,
         onSeek,
-        onPlay,
       });
 
       const progressSlider = screen.getByRole("slider", { name: "播放进度" });
@@ -164,15 +161,13 @@ describe("ReplayControls", () => {
       fireEvent.mouseUp(progressSlider);
 
       expect(onSeek).not.toHaveBeenCalled();
-      expect(onPlay).not.toHaveBeenCalled();
     },
   );
 
   describe("handleSliderCommit logic", () => {
-    it("updates preview locally while dragging and seeks only on commit", async () => {
+    it("updates preview locally while dragging and delegates seek without forcing playback", async () => {
       const onSeek = vi.fn();
-      const onPlay = vi.fn();
-      renderControls({ durationMs: 100_000, onSeek, onPlay });
+      renderControls({ durationMs: 100_000, onSeek });
 
       const progressSlider = screen.getByRole("slider", { name: "播放进度" });
       fireEvent.change(progressSlider, { target: { value: "25" } });
@@ -183,10 +178,9 @@ describe("ReplayControls", () => {
       fireEvent.mouseUp(progressSlider);
 
       await waitFor(() => expect(onSeek).toHaveBeenCalledWith(25_000));
-      expect(onPlay).toHaveBeenCalledTimes(1);
     });
 
-    it("waits for async seek before auto-playing", async () => {
+    it("does not issue playback while an async seek is pending", async () => {
       let resolveSeek: () => void = () => {};
       const onSeek = vi.fn(
         () =>
@@ -194,21 +188,17 @@ describe("ReplayControls", () => {
             resolveSeek = resolve;
           }),
       );
-      const onPlay = vi.fn();
-      renderControls({ durationMs: 120_000, onSeek, onPlay });
+      renderControls({ durationMs: 120_000, onSeek });
 
       const progressSlider = screen.getByRole("slider", { name: "播放进度" });
       fireEvent.change(progressSlider, { target: { value: "50" } });
       fireEvent.mouseUp(progressSlider);
 
       expect(onSeek).toHaveBeenCalledWith(60_000);
-      expect(onPlay).not.toHaveBeenCalled();
 
       await act(async () => {
         resolveSeek();
       });
-
-      expect(onPlay).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/apps/web/src/features/player/__tests__/ReplayPage.test.tsx
+++ b/apps/web/src/features/player/__tests__/ReplayPage.test.tsx
@@ -173,30 +173,37 @@ describe("ReplayPage", () => {
   });
 
   it("wires replay control callbacks to scheduler commands", async () => {
+    const play = vi.spyOn(HTMLMediaElement.prototype, "play").mockResolvedValue(undefined);
+    const pause = vi.spyOn(HTMLMediaElement.prototype, "pause").mockImplementation(() => {});
     const { ReplayPage } = await import("../ReplayPage");
 
-    render(<ReplayPage />);
+    try {
+      render(<ReplayPage />);
 
-    await waitFor(() => expect(replayPageMock.scheduler.load).toHaveBeenCalledWith(replayPageMock.packageData));
-    expect(replayPageMock.controlsProps?.durationMs).toBe(120_000);
+      await waitFor(() => expect(replayPageMock.scheduler.load).toHaveBeenCalledWith(replayPageMock.packageData));
+      expect(replayPageMock.controlsProps?.durationMs).toBe(120_000);
 
-    await act(async () => {
-      await replayPageMock.controlsProps?.onSeek(42_000);
-    });
-    act(() => {
-      replayPageMock.controlsProps?.onPlay();
-      replayPageMock.controlsProps?.onRate(1.5);
-      replayPageMock.controlsProps?.onVolume(35);
-      replayPageMock.controlsProps?.onMuted(true);
-    });
+      await act(async () => {
+        await replayPageMock.controlsProps?.onSeek(42_000);
+      });
+      act(() => {
+        replayPageMock.controlsProps?.onPlayPause();
+        replayPageMock.controlsProps?.onRate(1.5);
+        replayPageMock.controlsProps?.onVolume(35);
+        replayPageMock.controlsProps?.onMuted(true);
+      });
 
-    expect(replayPageMock.scheduler.seek).toHaveBeenCalledWith(42_000);
-    expect(replayPageMock.scheduler.play).toHaveBeenCalledTimes(1);
-    expect(replayPageMock.scheduler.setRate).toHaveBeenCalledWith(1.5);
-    expect(replayPageMock.scheduler.setVolume).toHaveBeenCalledWith(35);
-    expect(replayPageMock.scheduler.setMuted).toHaveBeenCalledWith(true);
-    await waitFor(() => expect(replayPageMock.controlsProps?.volume).toBe(35));
-    expect(replayPageMock.controlsProps?.muted).toBe(true);
+      expect(replayPageMock.scheduler.seek).toHaveBeenCalledWith(42_000);
+      expect(replayPageMock.scheduler.play).toHaveBeenCalledTimes(1);
+      expect(replayPageMock.scheduler.setRate).toHaveBeenCalledWith(1.5);
+      expect(replayPageMock.scheduler.setVolume).toHaveBeenCalledWith(35);
+      expect(replayPageMock.scheduler.setMuted).toHaveBeenCalledWith(true);
+      await waitFor(() => expect(replayPageMock.controlsProps?.volume).toBe(35));
+      expect(replayPageMock.controlsProps?.muted).toBe(true);
+    } finally {
+      play.mockRestore();
+      pause.mockRestore();
+    }
   });
 
   it("renders scheduler stable state into the read-only editor and runtime panel", async () => {

--- a/apps/web/src/features/player/__tests__/ReplayPage.test.tsx
+++ b/apps/web/src/features/player/__tests__/ReplayPage.test.tsx
@@ -69,6 +69,7 @@ const replayPageMock = vi.hoisted(() => {
     setRate: vi.fn(),
     setVolume: vi.fn(),
     setMuted: vi.fn(),
+    setMediaAdapter: vi.fn(),
     destroy: vi.fn(),
     subscribe: vi.fn((listener: (state: typeof schedulerState) => void) => {
       listener(schedulerState);
@@ -102,6 +103,7 @@ const replayPageMock = vi.hoisted(() => {
       scheduler.setRate.mockClear();
       scheduler.setVolume.mockClear();
       scheduler.setMuted.mockClear();
+      scheduler.setMediaAdapter.mockClear();
       scheduler.destroy.mockClear();
       scheduler.subscribe.mockClear();
       schedulerState.status = "ready";
@@ -449,6 +451,26 @@ describe("ReplayPage", () => {
 
     createObjectURL.mockRestore();
     revokeObjectURL.mockRestore();
+    play.mockRestore();
+    pause.mockRestore();
+  });
+
+  it("pauses replay from the control gesture while buffering", async () => {
+    replayPageMock.schedulerState.status = "buffering";
+    const play = vi.spyOn(HTMLMediaElement.prototype, "play").mockResolvedValue(undefined);
+    const pause = vi.spyOn(HTMLMediaElement.prototype, "pause").mockImplementation(() => {});
+    const { ReplayPage } = await import("../ReplayPage");
+
+    render(<ReplayPage />);
+    await waitFor(() => expect(replayPageMock.scheduler.load).toHaveBeenCalledWith(replayPageMock.packageData));
+
+    act(() => {
+      replayPageMock.controlsProps?.onPlayPause();
+    });
+
+    expect(replayPageMock.scheduler.pause).toHaveBeenCalledTimes(1);
+    expect(replayPageMock.scheduler.play).not.toHaveBeenCalled();
+
     play.mockRestore();
     pause.mockRestore();
   });

--- a/apps/web/src/features/player/__tests__/ReplayPage.test.tsx
+++ b/apps/web/src/features/player/__tests__/ReplayPage.test.tsx
@@ -356,6 +356,29 @@ describe("ReplayPage", () => {
     pause.mockRestore();
   });
 
+  it("attaches a media adapter before loading a package with a media blob", async () => {
+    const pause = vi.spyOn(HTMLMediaElement.prototype, "pause").mockImplementation(() => {});
+    const { ReplayPage } = await import("../ReplayPage");
+
+    render(<ReplayPage />);
+
+    await waitFor(() =>
+      expect(replayPageMock.scheduler.setMediaAdapter.mock.calls.some(([adapter]) => adapter)).toBe(
+        true,
+      ),
+    );
+    await waitFor(() => expect(replayPageMock.scheduler.load).toHaveBeenCalledWith(replayPageMock.packageData));
+    const firstAdapterCallIndex = replayPageMock.scheduler.setMediaAdapter.mock.calls.findIndex(
+      ([adapter]) => adapter,
+    );
+    const adapterAttachOrder =
+      replayPageMock.scheduler.setMediaAdapter.mock.invocationCallOrder[firstAdapterCallIndex];
+    const loadOrder = replayPageMock.scheduler.load.mock.invocationCallOrder[0];
+
+    expect(adapterAttachOrder).toBeLessThan(loadOrder);
+    pause.mockRestore();
+  });
+
   it("keeps the scheduler subscription alive when the replay id changes", async () => {
     const pause = vi.spyOn(HTMLMediaElement.prototype, "pause").mockImplementation(() => {});
     const { ReplayPage } = await import("../ReplayPage");

--- a/apps/web/src/features/player/__tests__/mediaClockAdapter.test.ts
+++ b/apps/web/src/features/player/__tests__/mediaClockAdapter.test.ts
@@ -49,4 +49,29 @@ describe("createMediaClockAdapter", () => {
 
     expect(seek).toHaveBeenCalledWith(segments[1], 1300);
   });
+
+  it("does not flush the same pending seek twice while an async seek is in flight", async () => {
+    let metadataReady = false;
+    let resolveSeek!: () => void;
+    const seek = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveSeek = resolve;
+        }),
+    );
+    const adapter = createMediaClockAdapter({
+      segments,
+      seekHandler: seek,
+      metadataReadyProvider: () => metadataReady,
+    });
+
+    await adapter.seek(1800);
+    metadataReady = true;
+    const firstFlush = adapter.flushPendingSeek();
+    const secondFlush = adapter.flushPendingSeek();
+
+    expect(seek).toHaveBeenCalledTimes(1);
+    resolveSeek();
+    await Promise.all([firstFlush, secondFlush]);
+  });
 });

--- a/apps/web/src/features/player/__tests__/mediaClockAdapter.test.ts
+++ b/apps/web/src/features/player/__tests__/mediaClockAdapter.test.ts
@@ -74,4 +74,21 @@ describe("createMediaClockAdapter", () => {
     resolveSeek();
     await Promise.all([firstFlush, secondFlush]);
   });
+
+  it("cancels a pending seek when the latest seek lands outside media segments", async () => {
+    let metadataReady = false;
+    const seek = vi.fn();
+    const adapter = createMediaClockAdapter({
+      segments,
+      seekHandler: seek,
+      metadataReadyProvider: () => metadataReady,
+    });
+
+    await adapter.seek(500);
+    await adapter.seek(1200);
+    metadataReady = true;
+    await adapter.flushPendingSeek();
+
+    expect(seek).not.toHaveBeenCalled();
+  });
 });

--- a/apps/web/src/features/player/__tests__/mediaClockAdapter.test.ts
+++ b/apps/web/src/features/player/__tests__/mediaClockAdapter.test.ts
@@ -31,4 +31,22 @@ describe("createMediaClockAdapter", () => {
     await adapter.seek(1800);
     expect(seek).toHaveBeenCalledWith(segments[1], 1300);
   });
+
+  it("holds seek until metadata is ready, then flushes the pending media time", async () => {
+    let metadataReady = false;
+    const seek = vi.fn();
+    const adapter = createMediaClockAdapter({
+      segments,
+      seekHandler: seek,
+      metadataReadyProvider: () => metadataReady,
+    });
+
+    await adapter.seek(1800);
+    expect(seek).not.toHaveBeenCalled();
+
+    metadataReady = true;
+    await adapter.flushPendingSeek();
+
+    expect(seek).toHaveBeenCalledWith(segments[1], 1300);
+  });
 });

--- a/apps/web/src/features/player/__tests__/replayScheduler.test.ts
+++ b/apps/web/src/features/player/__tests__/replayScheduler.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
+import { createMediaClockAdapter } from "../mediaClockAdapter";
 import { createReplayScheduler } from "../replayScheduler";
 import { createTimelineClock } from "../timelineClock";
 import { buildInitialState } from "../initialState";
@@ -278,6 +279,38 @@ describe("createReplayScheduler", () => {
     expect(scheduler.getStableState().editor.code).toBe("media-driven");
   });
 
+  it("uses the production media adapter to map HTMLMediaElement seconds to timeline milliseconds", async () => {
+    let wall = 0;
+    const clock = createTimelineClock({ nowProvider: () => wall });
+    const adapter = createMediaClockAdapter({
+      segments: [
+        {
+          blobId: "media-1",
+          timelineStartMs: 0,
+          timelineEndMs: 5000,
+          mediaStartMs: 0,
+          mediaEndMs: 5000,
+        },
+      ],
+      currentTimeProvider: () => 1.2,
+      statusProvider: () => "ready",
+    });
+    const scheduler = createReplayScheduler({
+      clock,
+      mediaAdapter: adapter,
+      tickStrategy: { start: () => {}, stop: () => {} },
+    });
+    const latest = watchState(scheduler);
+    await scheduler.load(makePkg([], [], 5000, true));
+
+    scheduler.play();
+    wall = 1250;
+    scheduler.tick();
+
+    expect(latest().timelineTimeMs).toBe(1200);
+    expect(latest().driftMs).toBe(50);
+  });
+
   it("falls back to the timeline clock when package media is missing", async () => {
     let wall = 0;
     const clock = createTimelineClock({ nowProvider: () => wall });
@@ -375,5 +408,37 @@ describe("createReplayScheduler", () => {
     scheduler.tick();
 
     expect(onMediaFallbackReady).toHaveBeenCalledTimes(1);
+  });
+
+  it("flushes a pending media seek when metadata becomes ready while replay is paused", async () => {
+    let metadataReady = false;
+    const seekHandler = vi.fn();
+    const adapter = createMediaClockAdapter({
+      segments: [
+        {
+          blobId: "media-1",
+          timelineStartMs: 0,
+          timelineEndMs: 5000,
+          mediaStartMs: 0,
+          mediaEndMs: 5000,
+        },
+      ],
+      metadataReadyProvider: () => metadataReady,
+      statusProvider: () => (metadataReady ? "ready" : "loading"),
+      seekHandler,
+    });
+    const scheduler = createReplayScheduler({
+      mediaAdapter: adapter,
+      tickStrategy: { start: () => {}, stop: () => {} },
+    });
+    await scheduler.load(makePkg([], [], 5000, true));
+
+    await scheduler.seek(1800);
+    expect(seekHandler).not.toHaveBeenCalled();
+
+    metadataReady = true;
+    scheduler.setMediaAdapter(adapter);
+
+    expect(seekHandler).toHaveBeenCalledWith(adapter.segments[0], 1800);
   });
 });

--- a/apps/web/src/features/player/__tests__/replayScheduler.test.ts
+++ b/apps/web/src/features/player/__tests__/replayScheduler.test.ts
@@ -311,6 +311,76 @@ describe("createReplayScheduler", () => {
     expect(latest().driftMs).toBe(50);
   });
 
+  it("uses the timeline clock before an offset media segment starts", async () => {
+    let wall = 0;
+    const clock = createTimelineClock({ nowProvider: () => wall });
+    const adapter = createMediaClockAdapter({
+      segments: [
+        {
+          blobId: "media-1",
+          timelineStartMs: 1000,
+          timelineEndMs: 2000,
+          mediaStartMs: 0,
+          mediaEndMs: 1000,
+        },
+      ],
+      currentTimeProvider: () => 0,
+      statusProvider: () => "ready",
+    });
+    const scheduler = createReplayScheduler({
+      clock,
+      mediaAdapter: adapter,
+      tickStrategy: { start: () => {}, stop: () => {} },
+    });
+    const latest = watchState(scheduler);
+    await scheduler.load(
+      makePkg([content(1, 500, "before-media"), content(2, 1000, "media-start")], [], 5000, true),
+    );
+
+    scheduler.play();
+    wall = 500;
+    scheduler.tick();
+
+    expect(latest().mediaStatus).toBe("ready");
+    expect(latest().timelineTimeMs).toBe(500);
+    expect(latest().driftMs).toBe(0);
+    expect(scheduler.getStableState().editor.code).toBe("before-media");
+  });
+
+  it("keeps applying pure events after the media segment ends", async () => {
+    let wall = 0;
+    const clock = createTimelineClock({ nowProvider: () => wall });
+    const adapter = createMediaClockAdapter({
+      segments: [
+        {
+          blobId: "media-1",
+          timelineStartMs: 1000,
+          timelineEndMs: 2000,
+          mediaStartMs: 0,
+          mediaEndMs: 1000,
+        },
+      ],
+      currentTimeProvider: () => 1,
+      statusProvider: () => "ready",
+    });
+    const scheduler = createReplayScheduler({
+      clock,
+      mediaAdapter: adapter,
+      tickStrategy: { start: () => {}, stop: () => {} },
+    });
+    const latest = watchState(scheduler);
+    await scheduler.load(makePkg([content(1, 2400, "after-media")], [], 5000, true));
+
+    scheduler.play();
+    wall = 2500;
+    scheduler.tick();
+
+    expect(latest().mediaStatus).toBe("ready");
+    expect(latest().timelineTimeMs).toBe(2500);
+    expect(latest().driftMs).toBe(0);
+    expect(scheduler.getStableState().editor.code).toBe("after-media");
+  });
+
   it("rolls stable state back when media currentTime moves backward", async () => {
     let wall = 0;
     let mediaCurrentTimeSec = 0;

--- a/apps/web/src/features/player/__tests__/replayScheduler.test.ts
+++ b/apps/web/src/features/player/__tests__/replayScheduler.test.ts
@@ -1,12 +1,14 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { createReplayScheduler } from "../replayScheduler";
 import { createTimelineClock } from "../timelineClock";
 import { buildInitialState } from "../initialState";
 import { replayReducer } from "../replayReducer";
 import type {
+  MediaClockAdapter,
   RecordingEvent,
   RecordingPackageV1,
   RecordingSnapshot,
+  ReplaySchedulerState,
   ReplayStableState,
 } from "@/shared/recording-schema";
 import { RECORDING_SCHEMA_VERSION } from "@/shared/recording-schema";
@@ -44,7 +46,12 @@ function shortcut(seq: number, t: number): RecordingEvent {
   };
 }
 
-function makePkg(events: RecordingEvent[], snapshots: RecordingSnapshot[] = [], durationMs = 10_000): RecordingPackageV1 {
+function makePkg(
+  events: RecordingEvent[],
+  snapshots: RecordingSnapshot[] = [],
+  durationMs = 10_000,
+  withMedia = false,
+): RecordingPackageV1 {
   return {
     schemaVersion: RECORDING_SCHEMA_VERSION,
     manifest: {
@@ -75,7 +82,17 @@ function makePkg(events: RecordingEvent[], snapshots: RecordingSnapshot[] = [], 
     },
     events,
     snapshots,
-    media: null,
+    media: withMedia
+      ? {
+          blobId: "media-1",
+          mimeType: "video/webm",
+          durationMs,
+          sizeBytes: 1024,
+          timelineOffsetMs: 0,
+          hasAudio: true,
+          hasCamera: true,
+        }
+      : null,
   };
 }
 
@@ -86,6 +103,56 @@ function replayFromZeroTo(pkg: RecordingPackageV1, targetMs: number): ReplayStab
     state = replayReducer(state, event);
   }
   return state;
+}
+
+type TestMediaAdapter = MediaClockAdapter & {
+  getStatus(): ReplaySchedulerState["mediaStatus"];
+  getCurrentTimeSec(): number | null;
+  flushPendingSeek?(): Promise<void>;
+};
+
+function testMediaAdapter({
+  currentTimeSec,
+  status = "ready",
+  seek = vi.fn(async () => {}),
+}: {
+  currentTimeSec: () => number | null;
+  status?: ReplaySchedulerState["mediaStatus"];
+  seek?: (targetTimeMs: number) => Promise<void>;
+}): TestMediaAdapter {
+  return {
+    segments: [
+      {
+        blobId: "media-1",
+        timelineStartMs: 0,
+        timelineEndMs: 10_000,
+        mediaStartMs: 0,
+        mediaEndMs: 10_000,
+      },
+    ],
+    timelineToMediaTime(targetTimeMs) {
+      return targetTimeMs;
+    },
+    mediaToTimelineTime(mediaCurrentTimeSec) {
+      return mediaCurrentTimeSec * 1000;
+    },
+    seek,
+    setRate: vi.fn(),
+    getStatus: () => status,
+    getCurrentTimeSec: currentTimeSec,
+    flushPendingSeek: vi.fn(async () => {}),
+  };
+}
+
+function watchState(scheduler: { subscribe(listener: (state: ReplaySchedulerState) => void): () => void }) {
+  let latest: ReplaySchedulerState | null = null;
+  scheduler.subscribe((state) => {
+    latest = state;
+  });
+  return () => {
+    if (!latest) throw new Error("scheduler did not publish state");
+    return latest;
+  };
 }
 
 describe("createReplayScheduler", () => {
@@ -184,5 +251,129 @@ describe("createReplayScheduler", () => {
     scheduler.tick();
     expect(scheduler.getStableState().editor.code).toBe("a");
     expect(seen).toContain("ended");
+  });
+
+  it("uses ready media currentTime as the main replay clock", async () => {
+    let wall = 0;
+    let mediaCurrentTimeSec = 0;
+    const clock = createTimelineClock({ nowProvider: () => wall });
+    const scheduler = createReplayScheduler({
+      clock,
+      mediaAdapter: testMediaAdapter({
+        currentTimeSec: () => mediaCurrentTimeSec,
+      }) as never,
+      tickStrategy: { start: () => {}, stop: () => {} },
+    });
+    const latest = watchState(scheduler);
+    await scheduler.load(makePkg([content(1, 1000, "media-driven")], [], 5000, true));
+
+    scheduler.play();
+    wall = 1250;
+    mediaCurrentTimeSec = 1.2;
+    scheduler.tick();
+
+    expect(latest().mediaStatus).toBe("ready");
+    expect(latest().timelineTimeMs).toBe(1200);
+    expect(latest().driftMs).toBe(50);
+    expect(scheduler.getStableState().editor.code).toBe("media-driven");
+  });
+
+  it("falls back to the timeline clock when package media is missing", async () => {
+    let wall = 0;
+    const clock = createTimelineClock({ nowProvider: () => wall });
+    const scheduler = createReplayScheduler({
+      clock,
+      tickStrategy: { start: () => {}, stop: () => {} },
+    });
+    const latest = watchState(scheduler);
+    await scheduler.load(makePkg([content(1, 300, "timeline-fallback")], [], 5000, true));
+
+    scheduler.play();
+    wall = 400;
+    scheduler.tick();
+
+    expect(latest().mediaStatus).toBe("missing");
+    expect(latest().timelineTimeMs).toBe(400);
+    expect(scheduler.getStableState().editor.code).toBe("timeline-fallback");
+  });
+
+  it("records drift and asks the media adapter to correct large drift", async () => {
+    let wall = 0;
+    let mediaCurrentTimeSec = 0;
+    const seek = vi.fn(async () => {});
+    const clock = createTimelineClock({ nowProvider: () => wall });
+    const scheduler = createReplayScheduler({
+      clock,
+      mediaAdapter: testMediaAdapter({
+        currentTimeSec: () => mediaCurrentTimeSec,
+        seek,
+      }) as never,
+      tickStrategy: { start: () => {}, stop: () => {} },
+    });
+    const latest = watchState(scheduler);
+    await scheduler.load(makePkg([], [], 5000, true));
+
+    scheduler.play();
+    wall = 1600;
+    mediaCurrentTimeSec = 1;
+    scheduler.tick();
+
+    expect(latest().timelineTimeMs).toBe(1000);
+    expect(latest().driftMs).toBe(600);
+    expect(seek).toHaveBeenCalledWith(1600);
+  });
+
+  it("enters buffering and stops applying events after media is stalled for 500ms", async () => {
+    let wall = 0;
+    let schedulerWall = 0;
+    const clock = createTimelineClock({ nowProvider: () => wall });
+    const scheduler = createReplayScheduler({
+      clock,
+      mediaAdapter: testMediaAdapter({
+        currentTimeSec: () => 0,
+        status: "stalled",
+      }) as never,
+      tickStrategy: { start: () => {}, stop: () => {} },
+      wallNow: () => schedulerWall,
+    } as never);
+    const latest = watchState(scheduler);
+    await scheduler.load(makePkg([content(1, 100, "should-not-advance")], [], 5000, true));
+
+    scheduler.play();
+    wall = 700;
+    scheduler.tick();
+    schedulerWall = 600;
+    scheduler.tick();
+
+    expect(latest().mediaStatus).toBe("stalled");
+    expect(latest().status).toBe("buffering");
+    expect(latest().timelineTimeMs).toBe(0);
+    expect(scheduler.getStableState().editor.code).toBe("");
+  });
+
+  it("exposes a pure-event fallback callback after media is stalled for 2s", async () => {
+    const wall = 0;
+    let schedulerWall = 0;
+    const onMediaFallbackReady = vi.fn();
+    const clock = createTimelineClock({ nowProvider: () => wall });
+    const scheduler = createReplayScheduler({
+      clock,
+      mediaAdapter: testMediaAdapter({
+        currentTimeSec: () => 0,
+        status: "stalled",
+      }) as never,
+      tickStrategy: { start: () => {}, stop: () => {} },
+      wallNow: () => schedulerWall,
+      onMediaFallbackReady,
+    } as never);
+    await scheduler.load(makePkg([], [], 5000, true));
+
+    scheduler.play();
+    scheduler.tick();
+    schedulerWall = 2100;
+    scheduler.tick();
+    scheduler.tick();
+
+    expect(onMediaFallbackReady).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/web/src/features/player/__tests__/replayScheduler.test.ts
+++ b/apps/web/src/features/player/__tests__/replayScheduler.test.ts
@@ -311,6 +311,35 @@ describe("createReplayScheduler", () => {
     expect(latest().driftMs).toBe(50);
   });
 
+  it("rolls stable state back when media currentTime moves backward", async () => {
+    let wall = 0;
+    let mediaCurrentTimeSec = 0;
+    const clock = createTimelineClock({ nowProvider: () => wall });
+    const scheduler = createReplayScheduler({
+      clock,
+      mediaAdapter: testMediaAdapter({
+        currentTimeSec: () => mediaCurrentTimeSec,
+      }) as never,
+      tickStrategy: { start: () => {}, stop: () => {} },
+    });
+    const latest = watchState(scheduler);
+    await scheduler.load(makePkg([content(1, 1000, "after-event")], [], 5000, true));
+
+    scheduler.play();
+    wall = 1200;
+    mediaCurrentTimeSec = 1.2;
+    scheduler.tick();
+    expect(scheduler.getStableState().editor.code).toBe("after-event");
+
+    wall = 500;
+    mediaCurrentTimeSec = 0.5;
+    scheduler.tick();
+
+    expect(latest().timelineTimeMs).toBe(500);
+    expect(latest().lastAppliedSeq).toBe(0);
+    expect(scheduler.getStableState().editor.code).toBe("");
+  });
+
   it("falls back to the timeline clock when package media is missing", async () => {
     let wall = 0;
     const clock = createTimelineClock({ nowProvider: () => wall });
@@ -354,6 +383,47 @@ describe("createReplayScheduler", () => {
     expect(latest().timelineTimeMs).toBe(1000);
     expect(latest().driftMs).toBe(600);
     expect(seek).toHaveBeenCalledWith(1600);
+  });
+
+  it("handles rejected async media operations during ready ticks", async () => {
+    let wall = 0;
+    let mediaCurrentTimeSec = 0;
+    const flushError = new Error("flush failed");
+    const seekError = new Error("seek failed");
+    const seek = vi.fn(async () => {
+      throw seekError;
+    });
+    const adapter = testMediaAdapter({
+      currentTimeSec: () => mediaCurrentTimeSec,
+      seek,
+    });
+    adapter.flushPendingSeek = vi.fn(async () => {
+      throw flushError;
+    });
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const clock = createTimelineClock({ nowProvider: () => wall });
+    const scheduler = createReplayScheduler({
+      clock,
+      mediaAdapter: adapter as never,
+      tickStrategy: { start: () => {}, stop: () => {} },
+    });
+
+    await scheduler.load(makePkg([], [], 5000, true));
+    scheduler.play();
+    wall = 500;
+    mediaCurrentTimeSec = 0;
+    scheduler.tick();
+    await Promise.resolve();
+
+    try {
+      expect(warn).toHaveBeenCalledWith(
+        "[replay-scheduler] media operation failed:",
+        flushError,
+      );
+      expect(warn).toHaveBeenCalledWith("[replay-scheduler] media operation failed:", seekError);
+    } finally {
+      warn.mockRestore();
+    }
   });
 
   it("enters buffering and stops applying events after media is stalled for 500ms", async () => {
@@ -410,6 +480,35 @@ describe("createReplayScheduler", () => {
     expect(onMediaFallbackReady).toHaveBeenCalledTimes(1);
   });
 
+  it("resets stalled media timers when loading a new package", async () => {
+    const wall = 0;
+    let schedulerWall = 0;
+    const clock = createTimelineClock({ nowProvider: () => wall });
+    const scheduler = createReplayScheduler({
+      clock,
+      mediaAdapter: testMediaAdapter({
+        currentTimeSec: () => 0,
+        status: "stalled",
+      }) as never,
+      tickStrategy: { start: () => {}, stop: () => {} },
+      wallNow: () => schedulerWall,
+    } as never);
+    const latest = watchState(scheduler);
+
+    await scheduler.load(makePkg([], [], 5000, true));
+    scheduler.play();
+    scheduler.tick();
+    schedulerWall = 700;
+    scheduler.tick();
+    expect(latest().status).toBe("buffering");
+
+    await scheduler.load(makePkg([], [], 5000, true));
+    scheduler.play();
+    scheduler.tick();
+
+    expect(latest().status).toBe("playing");
+  });
+
   it("flushes a pending media seek when metadata becomes ready while replay is paused", async () => {
     let metadataReady = false;
     const seekHandler = vi.fn();
@@ -440,5 +539,23 @@ describe("createReplayScheduler", () => {
     scheduler.setMediaAdapter(adapter);
 
     expect(seekHandler).toHaveBeenCalledWith(adapter.segments[0], 1800);
+  });
+
+  it("applies the current playback rate when a media adapter is attached", async () => {
+    const setRate = vi.fn();
+    const adapter = testMediaAdapter({
+      currentTimeSec: () => 0,
+      status: "ready",
+    });
+    adapter.setRate = setRate;
+    const scheduler = createReplayScheduler({
+      tickStrategy: { start: () => {}, stop: () => {} },
+    });
+    await scheduler.load(makePkg([], [], 5000, true));
+
+    scheduler.setRate(2);
+    scheduler.setMediaAdapter(adapter as never);
+
+    expect(setRate).toHaveBeenCalledWith(2);
   });
 });

--- a/apps/web/src/features/player/__tests__/replayScheduler.test.ts
+++ b/apps/web/src/features/player/__tests__/replayScheduler.test.ts
@@ -340,6 +340,45 @@ describe("createReplayScheduler", () => {
     expect(scheduler.getStableState().editor.code).toBe("");
   });
 
+  it("does not seek media to stale clock time when stalled media becomes ready", async () => {
+    let wall = 0;
+    let schedulerWall = 0;
+    let mediaStatus: ReplaySchedulerState["mediaStatus"] = "ready";
+    let mediaCurrentTimeSec = 1;
+    const seek = vi.fn(async () => {});
+    const adapter = testMediaAdapter({
+      currentTimeSec: () => mediaCurrentTimeSec,
+      seek,
+    });
+    adapter.getStatus = () => mediaStatus;
+    const clock = createTimelineClock({ nowProvider: () => wall });
+    const scheduler = createReplayScheduler({
+      clock,
+      mediaAdapter: adapter as never,
+      tickStrategy: { start: () => {}, stop: () => {} },
+      wallNow: () => schedulerWall,
+    });
+    const latest = watchState(scheduler);
+    await scheduler.load(makePkg([content(1, 1500, "skipped")], [], 5000, true));
+
+    scheduler.play();
+    wall = 1000;
+    scheduler.tick();
+    mediaStatus = "stalled";
+    scheduler.tick();
+    wall = 2000;
+    schedulerWall = 700;
+    scheduler.tick();
+    mediaStatus = "ready";
+    mediaCurrentTimeSec = 1;
+    scheduler.setMediaAdapter(adapter as never);
+    scheduler.tick();
+
+    expect(seek).not.toHaveBeenCalled();
+    expect(latest().timelineTimeMs).toBe(1000);
+    expect(scheduler.getStableState().editor.code).toBe("");
+  });
+
   it("falls back to the timeline clock when package media is missing", async () => {
     let wall = 0;
     const clock = createTimelineClock({ nowProvider: () => wall });
@@ -383,6 +422,26 @@ describe("createReplayScheduler", () => {
     expect(latest().timelineTimeMs).toBe(1000);
     expect(latest().driftMs).toBe(600);
     expect(seek).toHaveBeenCalledWith(1600);
+  });
+
+  it("does not apply events beyond duration when ending after a clock overshoot", async () => {
+    let wall = 0;
+    const clock = createTimelineClock({ nowProvider: () => wall });
+    const scheduler = createReplayScheduler({
+      clock,
+      tickStrategy: { start: () => {}, stop: () => {} },
+    });
+    const latest = watchState(scheduler);
+    await scheduler.load(makePkg([content(1, 1200, "past-duration")], [], 1000));
+
+    scheduler.play();
+    wall = 1500;
+    scheduler.tick();
+
+    expect(latest().status).toBe("ended");
+    expect(latest().timelineTimeMs).toBe(1000);
+    expect(latest().lastAppliedSeq).toBe(0);
+    expect(scheduler.getStableState().editor.code).toBe("");
   });
 
   it("handles rejected async media operations during ready ticks", async () => {

--- a/apps/web/src/features/player/__tests__/replayScheduler.test.ts
+++ b/apps/web/src/features/player/__tests__/replayScheduler.test.ts
@@ -494,6 +494,32 @@ describe("createReplayScheduler", () => {
     expect(seek).toHaveBeenCalledWith(1600);
   });
 
+  it("clears stale drift after seek completes", async () => {
+    let wall = 0;
+    let mediaCurrentTimeSec = 0;
+    const clock = createTimelineClock({ nowProvider: () => wall });
+    const scheduler = createReplayScheduler({
+      clock,
+      mediaAdapter: testMediaAdapter({
+        currentTimeSec: () => mediaCurrentTimeSec,
+      }) as never,
+      tickStrategy: { start: () => {}, stop: () => {} },
+    });
+    const latest = watchState(scheduler);
+    await scheduler.load(makePkg([], [], 5000, true));
+
+    scheduler.play();
+    wall = 1600;
+    mediaCurrentTimeSec = 1;
+    scheduler.tick();
+    expect(latest().driftMs).toBe(600);
+
+    await scheduler.seek(1200);
+
+    expect(latest().timelineTimeMs).toBe(1200);
+    expect(latest().driftMs).toBe(0);
+  });
+
   it("does not apply events beyond duration when ending after a clock overshoot", async () => {
     let wall = 0;
     const clock = createTimelineClock({ nowProvider: () => wall });
@@ -512,6 +538,44 @@ describe("createReplayScheduler", () => {
     expect(latest().timelineTimeMs).toBe(1000);
     expect(latest().lastAppliedSeq).toBe(0);
     expect(scheduler.getStableState().editor.code).toBe("");
+  });
+
+  it("restores playback after seek when replay was playing", async () => {
+    let wall = 0;
+    const start = vi.fn();
+    const stop = vi.fn();
+    const clock = createTimelineClock({ nowProvider: () => wall });
+    const scheduler = createReplayScheduler({
+      clock,
+      tickStrategy: { start, stop },
+    });
+    const latest = watchState(scheduler);
+    await scheduler.load(makePkg([content(1, 1000, "after-seek")], [], 5000));
+
+    scheduler.play();
+    await scheduler.seek(900);
+
+    expect(latest().status).toBe("playing");
+    expect(start).toHaveBeenCalledTimes(2);
+
+    wall = 300;
+    scheduler.tick();
+
+    expect(latest().timelineTimeMs).toBe(1200);
+    expect(scheduler.getStableState().editor.code).toBe("after-seek");
+  });
+
+  it("keeps replay paused after seek when replay was paused", async () => {
+    const scheduler = createReplayScheduler({
+      tickStrategy: { start: vi.fn(), stop: vi.fn() },
+    });
+    const latest = watchState(scheduler);
+    await scheduler.load(makePkg([content(1, 1000, "paused-seek")], [], 5000));
+
+    await scheduler.seek(1200);
+
+    expect(latest().status).toBe("paused");
+    expect(scheduler.getStableState().editor.code).toBe("paused-seek");
   });
 
   it("handles rejected async media operations during ready ticks", async () => {

--- a/apps/web/src/features/player/index.ts
+++ b/apps/web/src/features/player/index.ts
@@ -6,7 +6,11 @@ export {
   findStableEventIndexAtMost,
 } from "./replayIndex";
 export { createTimelineClock, type TimelineClockOptions } from "./timelineClock";
-export { createMediaClockAdapter, type MediaClockAdapterOptions } from "./mediaClockAdapter";
+export {
+  createMediaClockAdapter,
+  type MediaClockAdapterOptions,
+  type ReplayMediaClockAdapter,
+} from "./mediaClockAdapter";
 export {
   createReplayScheduler,
   defaultTickStrategy,

--- a/apps/web/src/features/player/mediaClockAdapter.ts
+++ b/apps/web/src/features/player/mediaClockAdapter.ts
@@ -79,7 +79,10 @@ export function createMediaClockAdapter(options: MediaClockAdapterOptions): Repl
     async seek(targetMs) {
       seekGeneration += 1;
       const seg = findSegmentForTimeline(targetMs);
-      if (!seg) return;
+      if (!seg) {
+        pendingSeek = null;
+        return;
+      }
       const mediaTimeMs = seg.mediaStartMs + (targetMs - seg.timelineStartMs);
       if (!metadataReady()) {
         pendingSeek = { segment: seg, mediaTimeMs, generation: seekGeneration };

--- a/apps/web/src/features/player/mediaClockAdapter.ts
+++ b/apps/web/src/features/player/mediaClockAdapter.ts
@@ -35,7 +35,12 @@ export type ReplayMediaClockAdapter = MediaClockAdapter & {
  */
 export function createMediaClockAdapter(options: MediaClockAdapterOptions): ReplayMediaClockAdapter {
   const segments = options.segments.slice().sort((a, b) => a.timelineStartMs - b.timelineStartMs);
-  let pendingSeek: { segment: MediaTimelineSegment; mediaTimeMs: number } | null = null;
+  let seekGeneration = 0;
+  let pendingSeek: {
+    segment: MediaTimelineSegment;
+    mediaTimeMs: number;
+    generation: number;
+  } | null = null;
 
   const findSegmentForTimeline = (targetMs: number): MediaTimelineSegment | null => {
     let lo = 0;
@@ -72,11 +77,12 @@ export function createMediaClockAdapter(options: MediaClockAdapterOptions): Repl
       return null;
     },
     async seek(targetMs) {
+      seekGeneration += 1;
       const seg = findSegmentForTimeline(targetMs);
       if (!seg) return;
       const mediaTimeMs = seg.mediaStartMs + (targetMs - seg.timelineStartMs);
       if (!metadataReady()) {
-        pendingSeek = { segment: seg, mediaTimeMs };
+        pendingSeek = { segment: seg, mediaTimeMs, generation: seekGeneration };
         return;
       }
       pendingSeek = null;
@@ -96,8 +102,15 @@ export function createMediaClockAdapter(options: MediaClockAdapterOptions): Repl
     async flushPendingSeek() {
       if (!pendingSeek || !metadataReady()) return;
       const currentPending = pendingSeek;
-      await runSeek(currentPending.segment, currentPending.mediaTimeMs);
-      if (pendingSeek === currentPending) pendingSeek = null;
+      pendingSeek = null;
+      try {
+        await runSeek(currentPending.segment, currentPending.mediaTimeMs);
+      } catch (error) {
+        if (pendingSeek === null && seekGeneration === currentPending.generation) {
+          pendingSeek = currentPending;
+        }
+        throw error;
+      }
     },
   };
 }

--- a/apps/web/src/features/player/mediaClockAdapter.ts
+++ b/apps/web/src/features/player/mediaClockAdapter.ts
@@ -1,4 +1,8 @@
-import type { MediaClockAdapter, MediaTimelineSegment } from "@/shared/recording-schema";
+import type {
+  MediaClockAdapter,
+  MediaTimelineSegment,
+  ReplaySchedulerState,
+} from "@/shared/recording-schema";
 
 export type MediaClockAdapterOptions = {
   segments: MediaTimelineSegment[];
@@ -6,6 +10,18 @@ export type MediaClockAdapterOptions = {
   seekHandler?: (segment: MediaTimelineSegment, mediaTimeMs: number) => Promise<void> | void;
   /** Adjust playback rate of the underlying HTMLMediaElement. */
   rateHandler?: (rate: number) => void;
+  /** Read the underlying HTMLMediaElement currentTime in seconds. */
+  currentTimeProvider?: () => number | null;
+  /** True when assigning HTMLMediaElement.currentTime is valid. */
+  metadataReadyProvider?: () => boolean;
+  /** Surface the media element loading/buffering/error status to the scheduler. */
+  statusProvider?: () => ReplaySchedulerState["mediaStatus"];
+};
+
+export type ReplayMediaClockAdapter = MediaClockAdapter & {
+  getStatus(): ReplaySchedulerState["mediaStatus"];
+  getCurrentTimeSec(): number | null;
+  flushPendingSeek(): Promise<void>;
 };
 
 /**
@@ -17,8 +33,9 @@ export type MediaClockAdapterOptions = {
  * accepts multiple segments so a future "concat pause islands" optimization
  * doesn't require an interface bump.
  */
-export function createMediaClockAdapter(options: MediaClockAdapterOptions): MediaClockAdapter {
+export function createMediaClockAdapter(options: MediaClockAdapterOptions): ReplayMediaClockAdapter {
   const segments = options.segments.slice().sort((a, b) => a.timelineStartMs - b.timelineStartMs);
+  let pendingSeek: { segment: MediaTimelineSegment; mediaTimeMs: number } | null = null;
 
   const findSegmentForTimeline = (targetMs: number): MediaTimelineSegment | null => {
     let lo = 0;
@@ -31,6 +48,11 @@ export function createMediaClockAdapter(options: MediaClockAdapterOptions): Medi
       else return seg;
     }
     return null;
+  };
+
+  const metadataReady = () => options.metadataReadyProvider?.() ?? true;
+  const runSeek = async (segment: MediaTimelineSegment, mediaTimeMs: number) => {
+    await options.seekHandler?.(segment, mediaTimeMs);
   };
 
   return {
@@ -53,10 +75,29 @@ export function createMediaClockAdapter(options: MediaClockAdapterOptions): Medi
       const seg = findSegmentForTimeline(targetMs);
       if (!seg) return;
       const mediaTimeMs = seg.mediaStartMs + (targetMs - seg.timelineStartMs);
-      await options.seekHandler?.(seg, mediaTimeMs);
+      if (!metadataReady()) {
+        pendingSeek = { segment: seg, mediaTimeMs };
+        return;
+      }
+      pendingSeek = null;
+      await runSeek(seg, mediaTimeMs);
     },
     setRate(rate) {
       options.rateHandler?.(rate);
+    },
+    getStatus() {
+      if (options.statusProvider) return options.statusProvider();
+      if (segments.length === 0) return "missing";
+      return metadataReady() ? "ready" : "loading";
+    },
+    getCurrentTimeSec() {
+      return options.currentTimeProvider?.() ?? null;
+    },
+    async flushPendingSeek() {
+      if (!pendingSeek || !metadataReady()) return;
+      const currentPending = pendingSeek;
+      await runSeek(currentPending.segment, currentPending.mediaTimeMs);
+      if (pendingSeek === currentPending) pendingSeek = null;
     },
   };
 }

--- a/apps/web/src/features/player/replayScheduler.ts
+++ b/apps/web/src/features/player/replayScheduler.ts
@@ -365,6 +365,8 @@ export function createReplayScheduler(options: ReplaySchedulerOptions = {}): Rep
     },
     async seek(targetMs) {
       if (!pkg) return;
+      const shouldResumePlayback =
+        schedulerState.status === "playing" || schedulerState.status === "buffering";
       tickStrategy.stop();
       driving = false;
       updateState({ status: "seeking" });
@@ -376,9 +378,11 @@ export function createReplayScheduler(options: ReplaySchedulerOptions = {}): Rep
       updateState({
         timelineTimeMs: clamped,
         lastAppliedSeq: lastSeq,
-        status: "paused",
+        status: shouldResumePlayback ? "playing" : "paused",
         mediaStatus: currentMediaStatus(),
+        driftMs: 0,
       });
+      if (shouldResumePlayback) ensureDriving();
       options.onTick?.(stableState, [], clamped);
     },
     setRate(rate: ReplayPlaybackRate) {

--- a/apps/web/src/features/player/replayScheduler.ts
+++ b/apps/web/src/features/player/replayScheduler.ts
@@ -121,6 +121,20 @@ export function createReplayScheduler(options: ReplaySchedulerOptions = {}): Rep
     schedulerState = { ...schedulerState, ...patch };
     publish();
   };
+  const resetMediaBlock = () => {
+    mediaBlockedSinceMs = null;
+    mediaFallbackNotified = false;
+  };
+  const reportMediaOperationError = (error: unknown) => {
+    console.warn("[replay-scheduler] media operation failed:", error);
+  };
+  const runMediaOperation = (operation: () => Promise<void>) => {
+    try {
+      void operation().catch(reportMediaOperationError);
+    } catch (error) {
+      reportMediaOperationError(error);
+    }
+  };
 
   const recomputeFromTime = (targetMs: number): { state: ReplayStableState; lastSeq: number } => {
     const snapshot = findSnapshotAtMost(index.snapshotsByTime, targetMs);
@@ -188,10 +202,13 @@ export function createReplayScheduler(options: ReplaySchedulerOptions = {}): Rep
       };
     }
 
-    void mediaAdapter.flushPendingSeek();
-    const mediaCurrentTimeSec = mediaAdapter.getCurrentTimeSec();
+    const readyMediaAdapter = mediaAdapter;
+    runMediaOperation(() => readyMediaAdapter.flushPendingSeek());
+    const mediaCurrentTimeSec = readyMediaAdapter.getCurrentTimeSec();
     const mediaTimelineMs =
-      mediaCurrentTimeSec === null ? null : mediaAdapter.mediaToTimelineTime(mediaCurrentTimeSec);
+      mediaCurrentTimeSec === null
+        ? null
+        : readyMediaAdapter.mediaToTimelineTime(mediaCurrentTimeSec);
 
     if (mediaTimelineMs === null) {
       return {
@@ -205,7 +222,7 @@ export function createReplayScheduler(options: ReplaySchedulerOptions = {}): Rep
 
     const driftMs = clockTimeMs - mediaTimelineMs;
     if (Math.abs(driftMs) > MEDIA_DRIFT_THRESHOLD_MS) {
-      void mediaAdapter.seek(clockTimeMs);
+      runMediaOperation(() => readyMediaAdapter.seek(clockTimeMs));
     }
 
     return {
@@ -244,6 +261,19 @@ export function createReplayScheduler(options: ReplaySchedulerOptions = {}): Rep
     if (!pkg) return;
     const frame = resolveFrame();
     const now = frame.timelineTimeMs;
+    if (frame.shouldAdvanceEvents && now < schedulerState.timelineTimeMs) {
+      const { state, lastSeq } = recomputeFromTime(now);
+      stableState = state;
+      updateState({
+        timelineTimeMs: Math.max(0, now),
+        lastAppliedSeq: lastSeq,
+        mediaStatus: frame.mediaStatus,
+        driftMs: frame.driftMs,
+        status: frame.status,
+      });
+      options.onTick?.(stableState, [], now);
+      return;
+    }
     if (!frame.shouldAdvanceEvents || now <= schedulerState.timelineTimeMs) {
       updateState({
         timelineTimeMs: Math.max(0, now),
@@ -278,10 +308,13 @@ export function createReplayScheduler(options: ReplaySchedulerOptions = {}): Rep
 
   return {
     setMediaAdapter(adapter) {
+      const adapterChanged = adapter !== mediaAdapter;
       mediaAdapter = adapter;
+      if (adapterChanged) resetMediaBlock();
+      adapter?.setRate(schedulerState.playbackRate);
       const mediaStatus = currentMediaStatus();
-      if (mediaStatus === "ready") {
-        void mediaAdapter?.flushPendingSeek();
+      if (mediaStatus === "ready" && adapter) {
+        runMediaOperation(() => adapter.flushPendingSeek());
       }
       updateState({ mediaStatus });
     },
@@ -292,6 +325,7 @@ export function createReplayScheduler(options: ReplaySchedulerOptions = {}): Rep
       stableState = cloneState(initial);
       tickStrategy.stop();
       driving = false;
+      resetMediaBlock();
       updateState({
         status: "ready",
         timelineTimeMs: 0,

--- a/apps/web/src/features/player/replayScheduler.ts
+++ b/apps/web/src/features/player/replayScheduler.ts
@@ -180,6 +180,7 @@ export function createReplayScheduler(options: ReplaySchedulerOptions = {}): Rep
   } => {
     const clockTimeMs = Math.max(0, clock.now());
     const mediaStatus = currentMediaStatus();
+    const mediaWasBlocked = mediaBlockedSinceMs !== null;
     const blockedMs = noteMediaStatus(mediaStatus);
 
     if (mediaStatus === "stalled") {
@@ -220,13 +221,18 @@ export function createReplayScheduler(options: ReplaySchedulerOptions = {}): Rep
       };
     }
 
-    const driftMs = clockTimeMs - mediaTimelineMs;
-    if (Math.abs(driftMs) > MEDIA_DRIFT_THRESHOLD_MS) {
+    const timelineTimeMs = Math.max(0, mediaTimelineMs);
+    const recoveringFromStalled = mediaWasBlocked;
+    let driftMs = clockTimeMs - timelineTimeMs;
+    if (recoveringFromStalled) {
+      clock.setBase(timelineTimeMs);
+      driftMs = 0;
+    } else if (Math.abs(driftMs) > MEDIA_DRIFT_THRESHOLD_MS) {
       runMediaOperation(() => readyMediaAdapter.seek(clockTimeMs));
     }
 
     return {
-      timelineTimeMs: Math.max(0, mediaTimelineMs),
+      timelineTimeMs,
       driftMs,
       mediaStatus,
       shouldAdvanceEvents: true,
@@ -284,8 +290,9 @@ export function createReplayScheduler(options: ReplaySchedulerOptions = {}): Rep
       options.onTick?.(stableState, [], now);
       return;
     }
-    const { transientEvents, lastSeq } = applyEventsUntil(now);
     const ended = pkg.meta.durationMs > 0 && now >= pkg.meta.durationMs;
+    const eventTargetMs = ended ? pkg.meta.durationMs : now;
+    const { transientEvents, lastSeq } = applyEventsUntil(eventTargetMs);
     updateState({
       timelineTimeMs: ended ? pkg.meta.durationMs : now,
       lastAppliedSeq: lastSeq,

--- a/apps/web/src/features/player/replayScheduler.ts
+++ b/apps/web/src/features/player/replayScheduler.ts
@@ -1,5 +1,4 @@
 import type {
-  MediaClockAdapter,
   RecordingEvent,
   RecordingPackageV1,
   ReplayPlaybackRate,
@@ -8,6 +7,7 @@ import type {
   ReplayStableState,
   TimelineClock,
 } from "@/shared/recording-schema";
+import type { ReplayMediaClockAdapter } from "./mediaClockAdapter";
 import { buildInitialState, cloneState } from "./initialState";
 import { findSnapshotAtMost, buildReplayIndex } from "./replayIndex";
 import { replayReducer } from "./replayReducer";
@@ -21,15 +21,19 @@ export type TickListener = (
 
 export type ReplaySchedulerOptions = {
   clock?: TimelineClock;
-  mediaAdapter?: MediaClockAdapter | null;
+  mediaAdapter?: ReplayMediaClockAdapter | null;
   /**
    * Drives the rendering loop. Tests pass a synchronous ticker; the runtime
    * driver passes a requestAnimationFrame-based ticker.
    */
   tickStrategy?: TickStrategy;
+  /** Wall-clock provider for buffering thresholds. */
+  wallNow?: () => number;
   /** Notify on each tick — receives the new stable state and any transient
    *  events (mouse-move/shortcut flashes) that arrived during the tick. */
   onTick?: TickListener;
+  /** Called once when stalled media has been blocking replay for 2s. */
+  onMediaFallbackReady?: () => void;
 };
 
 export type TickStrategy = {
@@ -38,6 +42,9 @@ export type TickStrategy = {
 };
 
 const DEFAULT_RAF_INTERVAL_MS = 1000 / 60;
+const MEDIA_DRIFT_THRESHOLD_MS = 250;
+const MEDIA_BUFFERING_THRESHOLD_MS = 500;
+const MEDIA_FALLBACK_THRESHOLD_MS = 2000;
 
 export function defaultTickStrategy(): TickStrategy {
   let handle: number | null = null;
@@ -78,6 +85,8 @@ export function defaultTickStrategy(): TickStrategy {
  *   3. Set lastAppliedSeq to the highest event applied (or S.eventSeq if none).
  */
 export function createReplayScheduler(options: ReplaySchedulerOptions = {}): ReplayScheduler & {
+  /** Runtime hook — connects the media element after the replay package loads. */
+  setMediaAdapter(adapter: ReplayMediaClockAdapter | null): void;
   /** Test hook — runs a single tick without the driver loop. */
   tick(): void;
   /** Test hook — exposes the latest stable state. */
@@ -85,19 +94,25 @@ export function createReplayScheduler(options: ReplaySchedulerOptions = {}): Rep
 } {
   const clock = options.clock ?? createTimelineClock();
   const tickStrategy = options.tickStrategy ?? defaultTickStrategy();
+  const wallNow =
+    options.wallNow ??
+    (() => (typeof performance === "undefined" ? Date.now() : performance.now()));
   const stateListeners = new Set<(s: ReplaySchedulerState) => void>();
   let pkg: RecordingPackageV1 | null = null;
   let index = emptyIndex();
   let initial: ReplayStableState = emptyState();
   let stableState: ReplayStableState = emptyState();
   let driving = false;
+  let mediaAdapter = options.mediaAdapter ?? null;
+  let mediaBlockedSinceMs: number | null = null;
+  let mediaFallbackNotified = false;
 
   let schedulerState: ReplaySchedulerState = {
     status: "loading",
     timelineTimeMs: 0,
     playbackRate: 1,
     lastAppliedSeq: 0,
-    mediaStatus: options.mediaAdapter ? "loading" : "none",
+    mediaStatus: "none",
     driftMs: 0,
   };
 
@@ -120,19 +135,96 @@ export function createReplayScheduler(options: ReplaySchedulerOptions = {}): Rep
     return { state, lastSeq };
   };
 
-  const tickOnce = () => {
-    if (!pkg) return;
-    const now = clock.now();
-    if (now <= schedulerState.timelineTimeMs) {
-      updateState({ timelineTimeMs: Math.max(0, now) });
-      options.onTick?.(stableState, [], now);
-      return;
+  const currentMediaStatus = (): ReplaySchedulerState["mediaStatus"] => {
+    if (!pkg?.media) return "none";
+    if (!mediaAdapter) return "missing";
+    return mediaAdapter.getStatus();
+  };
+
+  const noteMediaStatus = (mediaStatus: ReplaySchedulerState["mediaStatus"]) => {
+    if (mediaStatus !== "stalled") {
+      mediaBlockedSinceMs = null;
+      mediaFallbackNotified = false;
+      return 0;
     }
+    const now = wallNow();
+    if (mediaBlockedSinceMs === null) mediaBlockedSinceMs = now;
+    const elapsedMs = now - mediaBlockedSinceMs;
+    if (elapsedMs >= MEDIA_FALLBACK_THRESHOLD_MS && !mediaFallbackNotified) {
+      mediaFallbackNotified = true;
+      options.onMediaFallbackReady?.();
+    }
+    return elapsedMs;
+  };
+
+  const resolveFrame = (): {
+    timelineTimeMs: number;
+    driftMs: number;
+    mediaStatus: ReplaySchedulerState["mediaStatus"];
+    shouldAdvanceEvents: boolean;
+    status: ReplaySchedulerState["status"];
+  } => {
+    const clockTimeMs = Math.max(0, clock.now());
+    const mediaStatus = currentMediaStatus();
+    const blockedMs = noteMediaStatus(mediaStatus);
+
+    if (mediaStatus === "stalled") {
+      return {
+        timelineTimeMs: schedulerState.timelineTimeMs,
+        driftMs: schedulerState.driftMs,
+        mediaStatus,
+        shouldAdvanceEvents: false,
+        status: blockedMs >= MEDIA_BUFFERING_THRESHOLD_MS ? "buffering" : schedulerState.status,
+      };
+    }
+
+    if (mediaStatus !== "ready" || !mediaAdapter) {
+      return {
+        timelineTimeMs: clockTimeMs,
+        driftMs: 0,
+        mediaStatus,
+        shouldAdvanceEvents: true,
+        status: schedulerState.status === "buffering" ? "playing" : schedulerState.status,
+      };
+    }
+
+    void mediaAdapter.flushPendingSeek();
+    const mediaCurrentTimeSec = mediaAdapter.getCurrentTimeSec();
+    const mediaTimelineMs =
+      mediaCurrentTimeSec === null ? null : mediaAdapter.mediaToTimelineTime(mediaCurrentTimeSec);
+
+    if (mediaTimelineMs === null) {
+      return {
+        timelineTimeMs: clockTimeMs,
+        driftMs: 0,
+        mediaStatus,
+        shouldAdvanceEvents: true,
+        status: schedulerState.status === "buffering" ? "playing" : schedulerState.status,
+      };
+    }
+
+    const driftMs = clockTimeMs - mediaTimelineMs;
+    if (Math.abs(driftMs) > MEDIA_DRIFT_THRESHOLD_MS) {
+      void mediaAdapter.seek(clockTimeMs);
+    }
+
+    return {
+      timelineTimeMs: Math.max(0, mediaTimelineMs),
+      driftMs,
+      mediaStatus,
+      shouldAdvanceEvents: true,
+      status: schedulerState.status === "buffering" ? "playing" : schedulerState.status,
+    };
+  };
+
+  const applyEventsUntil = (
+    targetMs: number,
+  ): { transientEvents: RecordingEvent[]; lastSeq: number } => {
     const transientEvents: RecordingEvent[] = [];
     let lastSeq = schedulerState.lastAppliedSeq;
     for (const event of index.eventsBySeq) {
       if (event.seq <= lastSeq) continue;
-      if (event.timestampMs > now) break;
+      if (event.timestampMs > targetMs) break;
       if (
         event.type === "mouse-move" ||
         event.type === "mouse-click" ||
@@ -145,11 +237,31 @@ export function createReplayScheduler(options: ReplaySchedulerOptions = {}): Rep
       }
       lastSeq = event.seq;
     }
+    return { transientEvents, lastSeq };
+  };
+
+  const tickOnce = () => {
+    if (!pkg) return;
+    const frame = resolveFrame();
+    const now = frame.timelineTimeMs;
+    if (!frame.shouldAdvanceEvents || now <= schedulerState.timelineTimeMs) {
+      updateState({
+        timelineTimeMs: Math.max(0, now),
+        mediaStatus: frame.mediaStatus,
+        driftMs: frame.driftMs,
+        status: frame.status,
+      });
+      options.onTick?.(stableState, [], now);
+      return;
+    }
+    const { transientEvents, lastSeq } = applyEventsUntil(now);
     const ended = pkg.meta.durationMs > 0 && now >= pkg.meta.durationMs;
     updateState({
       timelineTimeMs: ended ? pkg.meta.durationMs : now,
       lastAppliedSeq: lastSeq,
-      status: ended ? "ended" : schedulerState.status,
+      mediaStatus: frame.mediaStatus,
+      driftMs: frame.driftMs,
+      status: ended ? "ended" : frame.status,
     });
     if (ended) {
       tickStrategy.stop();
@@ -165,6 +277,10 @@ export function createReplayScheduler(options: ReplaySchedulerOptions = {}): Rep
   };
 
   return {
+    setMediaAdapter(adapter) {
+      mediaAdapter = adapter;
+      updateState({ mediaStatus: currentMediaStatus() });
+    },
     async load(input) {
       pkg = input;
       index = buildReplayIndex(input);
@@ -176,7 +292,8 @@ export function createReplayScheduler(options: ReplaySchedulerOptions = {}): Rep
         status: "ready",
         timelineTimeMs: 0,
         lastAppliedSeq: 0,
-        mediaStatus: input.media ? "loading" : "none",
+        mediaStatus: currentMediaStatus(),
+        driftMs: 0,
       });
     },
     play() {
@@ -200,17 +317,18 @@ export function createReplayScheduler(options: ReplaySchedulerOptions = {}): Rep
       const { state, lastSeq } = recomputeFromTime(clamped);
       stableState = state;
       clock.setBase(clamped);
-      if (options.mediaAdapter) await options.mediaAdapter.seek(clamped);
+      if (mediaAdapter) await mediaAdapter.seek(clamped);
       updateState({
         timelineTimeMs: clamped,
         lastAppliedSeq: lastSeq,
         status: "paused",
+        mediaStatus: currentMediaStatus(),
       });
       options.onTick?.(stableState, [], clamped);
     },
     setRate(rate: ReplayPlaybackRate) {
       clock.setRate(rate);
-      options.mediaAdapter?.setRate(rate);
+      mediaAdapter?.setRate(rate);
       updateState({ playbackRate: rate });
     },
     setVolume(_volume) {

--- a/apps/web/src/features/player/replayScheduler.ts
+++ b/apps/web/src/features/player/replayScheduler.ts
@@ -279,7 +279,11 @@ export function createReplayScheduler(options: ReplaySchedulerOptions = {}): Rep
   return {
     setMediaAdapter(adapter) {
       mediaAdapter = adapter;
-      updateState({ mediaStatus: currentMediaStatus() });
+      const mediaStatus = currentMediaStatus();
+      if (mediaStatus === "ready") {
+        void mediaAdapter?.flushPendingSeek();
+      }
+      updateState({ mediaStatus });
     },
     async load(input) {
       pkg = input;

--- a/apps/web/src/features/player/replayScheduler.ts
+++ b/apps/web/src/features/player/replayScheduler.ts
@@ -210,6 +210,7 @@ export function createReplayScheduler(options: ReplaySchedulerOptions = {}): Rep
       mediaCurrentTimeSec === null
         ? null
         : readyMediaAdapter.mediaToTimelineTime(mediaCurrentTimeSec);
+    const recoveringFromStalled = mediaWasBlocked;
 
     if (mediaTimelineMs === null) {
       return {
@@ -221,8 +222,17 @@ export function createReplayScheduler(options: ReplaySchedulerOptions = {}): Rep
       };
     }
 
+    if (!recoveringFromStalled && readyMediaAdapter.timelineToMediaTime(clockTimeMs) === null) {
+      return {
+        timelineTimeMs: clockTimeMs,
+        driftMs: 0,
+        mediaStatus,
+        shouldAdvanceEvents: true,
+        status: schedulerState.status === "buffering" ? "playing" : schedulerState.status,
+      };
+    }
+
     const timelineTimeMs = Math.max(0, mediaTimelineMs);
-    const recoveringFromStalled = mediaWasBlocked;
     let driftMs = clockTimeMs - timelineTimeMs;
     if (recoveringFromStalled) {
       clock.setBase(timelineTimeMs);


### PR DESCRIPTION
## 关联 Issue

Closes #76

## 变更说明

- 让 ReplayScheduler 在媒体 ready 且当前 replay 时间位于媒体 segment 内时，以 MediaClockAdapter.mediaToTimelineTime(media.currentTime) 作为主时间源；无媒体、缺媒体、未 ready、或当前时间位于媒体 segment 外时，继续使用 TimelineClock 降级。
- 扩展 MediaClockAdapter，支持 mediaStatus、currentTimeProvider、metadata 未 ready 时 pending seek，以及 metadata ready 后 flush。
- 接入 ReplayPage 的真实 HTMLMediaElement 状态，覆盖 buffering/stalled、drift 纠偏、pause/play 控制和媒体 overlay 展示。
- 修复 CR 反馈：pending seek 异步 flush 防重入、无媒体区间 seek 取消旧 pending、ready tick 媒体 Promise rejection 捕获、adapter attach 同步 playbackRate、load/adapter swap 重置 stalled/fallback 状态、stalled 恢复时重锚 TimelineClock、媒体时间倒退时回滚 stable state、结束 overshoot 时按 duration clamp 事件应用。
- 修复 repo-guard 反馈：ready 媒体只覆盖部分 timeline 或存在 timelineOffsetMs 时，segment 前/后不再被 video currentTime 拉到媒体段起止点，媒体段后的纯事件仍能继续应用。
- 调整 ReplayPage 加载顺序，在 `scheduler.load()` 前预先 attach media adapter，避免有媒体包被短暂标记为 missing。
- 按技术方案收敛 seek 语义：seek 前处于 playing/buffering 时恢复播放，暂停态 seek 后保持暂停；控制条不再自行触发播放，scheduler seek 完成时清理旧 drift。
- 补充 replayScheduler、mediaClockAdapter、ReplayPage、ReplayControls 相关测试，覆盖 ready、missing、pending seek、drift、stalled/buffering、2s fallback 回调、真实 adapter 秒到毫秒映射、异步 seek 重入、媒体时间倒退、stalled→ready 恢复、duration clamp、load 前 adapter attach、offset media segment 前/后的 TimelineClock 降级，以及 seek 后按 seek 前状态恢复。

## Issue #76 验收对照

- 无媒体或媒体 Blob 缺失时仍走纯事件流：`replayScheduler.test.ts` 覆盖 missing fallback，`ReplayPage.test.tsx` 覆盖缺失媒体加载路径。
- 有媒体且 ready 时，`timelineTimeMs` 来自媒体时间映射：覆盖 fake adapter 主时钟与 production `createMediaClockAdapter` 秒到毫秒集成测试。
- drift 超过 250ms 会触发纠偏并暴露 `driftMs`：`records drift and asks the media adapter to correct large drift` 覆盖。
- metadata 未 ready 时 pending seek，ready 后 flush：`mediaClockAdapter.test.ts` 与 scheduler paused metadata-ready 测试覆盖，并补了异步 flush 防重入。
- stalled/buffering 超过 500ms 暂停事件推进，2s fallback 可观测：scheduler buffering 与 fallback callback 测试覆盖，并补了 stalled→ready 恢复不跳帧。
- 不做 P1 分段媒体、后端、云端或 WebRTC；本 PR 只处理 P0 单 WebM 轨与现有 segment 边界。

## GitNexus 影响分析摘要

- 风险等级: HIGH
- 关键骨架变更: replay-core 中 apps/web/src/features/player/replayScheduler.ts 的 seek 恢复语义，以及 ReplayControls/ReplayPage 的 seek 控制入口收敛。
- GitNexus 影响面: detect_changes(scope=all) 显示 3 个变更符号、6 个文件、9 条受影响流程，集中在 TickOnce/seek 相关流程；impact(createReplayScheduler, upstream, depth=2) 和 impact(ReplayControls, upstream, depth=2) 均为 LOW，直接消费者集中在 ReplayPage/Player。
- 验证结果: npm run quality:predev 通过；npm run quality:precommit 通过；npm run test:web -- replayScheduler.test.ts ReplayControls.test.tsx ReplayPage.test.tsx 通过；npm run quality:local 已在本地通过，push hook quality:local 也已通过。

## 自检

- [x] PR author 是该 Issue 的认领者
- [x] 未修改 `docs/progress.json` 或 `docs/progress.md`
- [x] 已运行 `npm run quality:local`，或说明无法运行的原因
- [x] 如果改动关键骨架，已补充契约测试并填写 GitNexus 影响分析摘要
- [x] 已邀请至少一名非作者同学 CR


