### PR TITLE
Improve recording save reliability

### DIFF
--- a/apps/web/src/features/library/__tests__/recordingStore.test.ts
+++ b/apps/web/src/features/library/__tests__/recordingStore.test.ts
@@ -1,6 +1,6 @@
 import "fake-indexeddb/auto";
 import JSZip from "jszip";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createRecordingStore } from "../recordingStore";
 import type {
   RecordingEvent,
@@ -167,6 +167,21 @@ describe("createRecordingStore — two-phase commit", () => {
     expect(result.mediaBlob).toBeInstanceOf(Blob);
     const buffer = await result.mediaBlob!.arrayBuffer();
     expect(new TextDecoder().decode(buffer)).toBe("binary");
+  });
+
+  it("returns media-write-failed when media blob cannot be prepared", async () => {
+    const store = createRecordingStore({ databaseName: uniqueDbName() });
+    const input = makeInput("rec-media-fail");
+    vi.spyOn(input.mediaBlob!, "arrayBuffer").mockRejectedValueOnce(new Error("blob read failed"));
+
+    const result = await store.saveDraft(input);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toBe("media-write-failed");
+      expect(result.message).toContain("blob read failed");
+    }
+    expect(await store.list()).toEqual([]);
   });
 
   it("load on a draft returns incomplete-package", async () => {

--- a/apps/web/src/features/library/__tests__/recordingStore.test.ts
+++ b/apps/web/src/features/library/__tests__/recordingStore.test.ts
@@ -184,6 +184,24 @@ describe("createRecordingStore — two-phase commit", () => {
     expect(await store.list()).toEqual([]);
   });
 
+  it("returns a useful media-write-failed message when blob preparation throws an empty message", async () => {
+    const store = createRecordingStore({ databaseName: uniqueDbName() });
+    const input = makeInput("rec-media-empty-error");
+    vi.spyOn(input.mediaBlob!, "arrayBuffer").mockRejectedValueOnce({
+      name: "NotReadableError",
+      message: "",
+    });
+
+    const result = await store.saveDraft(input);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toBe("media-write-failed");
+      expect(result.message).toContain("NotReadableError");
+      expect(result.message).toContain("media blob could not be prepared");
+    }
+  });
+
   it("load on a draft returns incomplete-package", async () => {
     const store = createRecordingStore({ databaseName: uniqueDbName() });
     await store.saveDraft(makeInput("rec-1"));

--- a/apps/web/src/features/library/recordingStore.ts
+++ b/apps/web/src/features/library/recordingStore.ts
@@ -120,10 +120,20 @@ export function createRecordingStore(options: RecordingStoreOptions = {}): Recor
       // Materialize the blob to ArrayBuffer BEFORE opening the transaction so
       // IDB sees a structured-clone-safe value (some engines lose Blob prototype
       // through structured clone, breaking later .arrayBuffer() reads).
-      const bufferToStore = input.mediaBlob ? await input.mediaBlob.arrayBuffer() : null;
-      const mediaSha256 = bufferToStore
-        ? await sha256Blob(new Blob([bufferToStore], { type: input.mediaBlob?.type }))
-        : undefined;
+      let bufferToStore: ArrayBuffer | null = null;
+      let mediaSha256: string | undefined;
+      try {
+        bufferToStore = input.mediaBlob ? await input.mediaBlob.arrayBuffer() : null;
+        mediaSha256 = bufferToStore
+          ? await sha256Blob(new Blob([bufferToStore], { type: input.mediaBlob?.type }))
+          : undefined;
+      } catch (err) {
+        return {
+          ok: false,
+          reason: "media-write-failed",
+          message: (err as Error).message ?? "media blob could not be prepared for storage",
+        };
+      }
 
       const stored: StoredRecording = {
         id: recordingId,
@@ -173,8 +183,9 @@ export function createRecordingStore(options: RecordingStoreOptions = {}): Recor
         await awaitTransaction(tx);
         return { ok: true, recordingId };
       } catch (err) {
-        const message = (err as Error).message ?? "unknown";
-        const isQuota = /QuotaExceededError/i.test(message);
+        const error = err as Error;
+        const message = error.message ?? "unknown";
+        const isQuota = /QuotaExceededError/i.test(`${error.name}:${message}`);
         return {
           ok: false,
           reason: isQuota ? "quota-exceeded" : "media-write-failed",

--- a/apps/web/src/features/library/recordingStore.ts
+++ b/apps/web/src/features/library/recordingStore.ts
@@ -131,7 +131,7 @@ export function createRecordingStore(options: RecordingStoreOptions = {}): Recor
         return {
           ok: false,
           reason: "media-write-failed",
-          message: (err as Error).message ?? "media blob could not be prepared for storage",
+          message: formatErrorMessage(err, "media blob could not be prepared for storage"),
         };
       }
 
@@ -429,6 +429,17 @@ function base64ToArrayBuffer(base64: string): ArrayBuffer {
     bytes[i] = binary.charCodeAt(i);
   }
   return bytes.buffer;
+}
+
+function formatErrorMessage(err: unknown, fallback: string): string {
+  const error = err as { name?: unknown; message?: unknown };
+  const name = typeof error.name === "string" ? error.name.trim() : "";
+  const message = typeof error.message === "string" ? error.message.trim() : "";
+  if (name && message) return `${name}: ${message}`;
+  if (name) return `${name}: ${fallback}`;
+  if (message) return message;
+  const text = typeof err === "string" ? err.trim() : "";
+  return text || fallback;
 }
 
 function emptyIndexes(): RecordingIndexes {

--- a/apps/web/src/features/player/__tests__/replayScheduler.test.ts
+++ b/apps/web/src/features/player/__tests__/replayScheduler.test.ts
@@ -47,6 +47,22 @@ function shortcut(seq: number, t: number): RecordingEvent {
   };
 }
 
+function mediaWarning(seq: number, t: number): RecordingEvent {
+  return {
+    id: `e-${seq}`,
+    seq,
+    timestampMs: t,
+    source: "media",
+    track: "media",
+    type: "media-warning",
+    payload: {
+      target: "recorder",
+      code: "recorder-error",
+      message: "Media could not be saved. Event timeline was preserved.",
+    },
+  };
+}
+
 function makePkg(
   events: RecordingEvent[],
   snapshots: RecordingSnapshot[] = [],
@@ -466,6 +482,25 @@ describe("createReplayScheduler", () => {
     expect(latest().mediaStatus).toBe("missing");
     expect(latest().timelineTimeMs).toBe(400);
     expect(scheduler.getStableState().editor.code).toBe("timeline-fallback");
+  });
+
+  it("plays an event-only package with media-warning using the timeline clock", async () => {
+    let wall = 0;
+    const clock = createTimelineClock({ nowProvider: () => wall });
+    const scheduler = createReplayScheduler({
+      clock,
+      tickStrategy: { start: () => {}, stop: () => {} },
+    });
+    const latest = watchState(scheduler);
+    await scheduler.load(makePkg([mediaWarning(1, 0), content(2, 300, "event-only")], [], 5000, false));
+
+    scheduler.play();
+    wall = 400;
+    scheduler.tick();
+
+    expect(latest().mediaStatus).toBe("none");
+    expect(latest().timelineTimeMs).toBe(400);
+    expect(scheduler.getStableState().editor.code).toBe("event-only");
   });
 
   it("records drift and asks the media adapter to correct large drift", async () => {

--- a/apps/web/src/features/recorder/RecorderPage.tsx
+++ b/apps/web/src/features/recorder/RecorderPage.tsx
@@ -76,6 +76,7 @@ export function RecorderPage() {
   const startTokenRef = useRef(0);
   const stopTokenRef = useRef(0);
   const [mediaStream, setMediaStream] = useState<MediaStream | null>(null);
+  const [persistenceNotice, setPersistenceNotice] = useState<string | null>(null);
 
   const stack = useMemo(() => {
     const clock = createRecordingClock();
@@ -149,6 +150,11 @@ export function RecorderPage() {
         console.warn("[recorder-page] persistence failed, downloading fallback package:", error);
         const zipBlob = await buildRecordingZip(pkg, mediaBlob);
         downloadBlob(zipBlob, `${safeFilenameStem(pkg.meta.title, pkg.meta.id)}.zip`);
+        if (mountedRef.current) {
+          setPersistenceNotice(
+            "保存未进入本地回放中心，已为你导出 ZIP 兜底文件。请保留该文件以便后续导入回放。",
+          );
+        }
       },
     });
     return {
@@ -280,6 +286,7 @@ export function RecorderPage() {
   const handleStart = async () => {
     if (startInFlightRef.current) return;
     startInFlightRef.current = true;
+    setPersistenceNotice(null);
     const startToken = (startTokenRef.current += 1);
     try {
       const currentDeviceOptions = deviceOptionsRef.current;
@@ -368,6 +375,7 @@ export function RecorderPage() {
     try {
       const pkg = await stack.controller.stop("user");
       if (mountedRef.current && stopTokenRef.current === stopToken) {
+        setPersistenceNotice(null);
         navigate(`/replay/${pkg.meta.id}`);
       } else {
         stack.controller.reset();
@@ -470,6 +478,14 @@ export function RecorderPage() {
         }}
         onRun={handleRun}
       />
+      {persistenceNotice ? (
+        <div
+          role="alert"
+          className="border-b border-warning/40 bg-warning/10 px-4 py-2 text-sm text-foreground"
+        >
+          {persistenceNotice}
+        </div>
+      ) : null}
       <RecorderSetupToolbar
         language={editorLanguage}
         fontSize={editorFontSize}

--- a/apps/web/src/features/recorder/__tests__/RecorderPage.test.tsx
+++ b/apps/web/src/features/recorder/__tests__/RecorderPage.test.tsx
@@ -138,7 +138,10 @@ const recorderPageMock = vi.hoisted(() => {
     exportZip: vi.fn(),
     importZip: vi.fn(),
     sweep: vi.fn(),
-    estimateQuota: vi.fn(),
+    estimateQuota: vi.fn<RecordingRepository["estimateQuota"]>(async () => ({
+      usageBytes: 0,
+      quotaBytes: 1024 * 1024 * 1024,
+    })),
   };
   let editorProducerDeps: EditorProducerDeps | null = null;
   let mediaProducerDeps: MediaProducerDeps | null = null;
@@ -224,6 +227,7 @@ const recorderPageMock = vi.hoisted(() => {
       mediaRecorder.stop.mockClear();
       repository.saveDraft.mockClear();
       repository.commit.mockClear();
+      repository.estimateQuota.mockClear();
       this.codeEditorProps = null;
       this.cameraPreviewProps = null;
       editorProducerDeps = null;
@@ -892,10 +896,38 @@ describe("RecorderPage", () => {
 
     await waitFor(() => expect(downloadApis.createObjectURL).toHaveBeenCalledWith(expect.any(Blob)));
     expect(downloadApis.click).toHaveBeenCalledTimes(1);
+    expect(screen.getByRole("alert")).toHaveTextContent("保存未进入本地回放中心");
     expect(recorderPageMock.navigate).not.toHaveBeenCalled();
     await waitFor(() => expect(screen.getByRole("button", { name: "开始录制" })).not.toBeDisabled());
     expect(screen.getByRole("button", { name: "停止录制" })).toBeDisabled();
     expect(recorderPageMock.devices.release).toHaveBeenCalled();
+
+    warn.mockRestore();
+    downloadApis.click.mockRestore();
+    if ("mockRestore" in downloadApis.createObjectURL) downloadApis.createObjectURL.mockRestore();
+    if ("mockRestore" in downloadApis.revokeObjectURL) downloadApis.revokeObjectURL.mockRestore();
+  });
+
+  it("shows fallback guidance when quota preflight blocks local save", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const downloadApis = mockDownloadApis();
+    recorderPageMock.repository.estimateQuota.mockResolvedValueOnce({
+      usageBytes: 1020 * 1024,
+      quotaBytes: 1024 * 1024,
+    });
+    const { RecorderPage } = await import("../RecorderPage");
+
+    render(<RecorderPage />);
+    fireEvent.click(screen.getByRole("button", { name: "开始录制" }));
+    await waitFor(() => expect(recorderPageMock.mediaRecorder.start).toHaveBeenCalledWith(recorderPageMock.stream));
+    await waitFor(() => expect(screen.getByRole("button", { name: "停止录制" })).not.toBeDisabled());
+
+    fireEvent.click(screen.getByRole("button", { name: "停止录制" }));
+
+    await waitFor(() => expect(downloadApis.click).toHaveBeenCalledTimes(1));
+    expect(recorderPageMock.repository.saveDraft).not.toHaveBeenCalled();
+    expect(screen.getByRole("alert")).toHaveTextContent("ZIP 兜底文件");
+    expect(recorderPageMock.navigate).not.toHaveBeenCalled();
 
     warn.mockRestore();
     downloadApis.click.mockRestore();

--- a/apps/web/src/features/recorder/__tests__/recordingController.test.ts
+++ b/apps/web/src/features/recorder/__tests__/recordingController.test.ts
@@ -219,6 +219,29 @@ describe("createRecordingController", () => {
     expect(repository.commits.length).toBe(0);
   });
 
+  it("preflights quota before saveDraft and downloads fallback when storage is too low", async () => {
+    const onPersistenceFailure = vi.fn();
+    const { controller, repository } = setup({ onPersistenceFailure });
+    vi.mocked(repository.estimateQuota).mockResolvedValueOnce({
+      usageBytes: 950 * 1024,
+      quotaBytes: 1024 * 1024,
+    });
+
+    await controller.start(makeStartPayload());
+    await expect(controller.stop("user")).rejects.toThrow(/quota-precheck-failed/);
+
+    expect(repository.estimateQuota).toHaveBeenCalledTimes(1);
+    expect(repository.saveDraft).not.toHaveBeenCalled();
+    expect(repository.commits.length).toBe(0);
+    expect(onPersistenceFailure).toHaveBeenCalledWith(
+      expect.objectContaining({
+        pkg: expect.objectContaining({ events: expect.any(Array) }),
+        mediaBlob: null,
+        error: expect.any(Error),
+      }),
+    );
+  });
+
   it("passes the finalized package to the persistence failure fallback", async () => {
     const onPersistenceFailure = vi.fn();
     const { controller, repository } = setup({ onPersistenceFailure });
@@ -278,6 +301,40 @@ describe("createRecordingController", () => {
     expect(controller.state.status).toBe("completed");
   });
 
+  it("falls back to an event-only package when media write fails", async () => {
+    const mediaBlob = new Blob(["media"], { type: "video/webm" });
+    const mediaSource = vi.fn(async () => ({
+      blob: mediaBlob,
+      durationMs: 1_500,
+      mimeType: "video/webm",
+      hasAudio: true,
+      hasCamera: true,
+    }));
+    const { controller, repository } = setup({ mediaSource });
+    vi.mocked(repository.saveDraft).mockResolvedValueOnce({
+      ok: false,
+      reason: "media-write-failed",
+      message: "blob store failed",
+    });
+
+    await controller.start(makeStartPayload());
+    const pkg = await controller.stop("user");
+
+    expect(repository.saveDraft).toHaveBeenCalledTimes(2);
+    expect(vi.mocked(repository.saveDraft).mock.calls[0][0].mediaBlob).toBe(mediaBlob);
+    expect(vi.mocked(repository.saveDraft).mock.calls[1][0].mediaBlob).toBeNull();
+    expect(repository.commits).toHaveLength(1);
+    expect(pkg.media).toBeNull();
+    expect(pkg.events.at(-1)).toMatchObject({
+      type: "media-warning",
+      payload: {
+        target: "recorder",
+        code: "recorder-error",
+      },
+    });
+    expect(controller.state.status).toBe("completed");
+  });
+
   it("does not complete when commit fails", async () => {
     const { controller, repository } = setup();
     vi.mocked(repository.commit).mockResolvedValueOnce({
@@ -291,6 +348,27 @@ describe("createRecordingController", () => {
 
     expect(controller.state.status).toBe("failed");
     expect(controller.state.lastError?.code).toBe("commit-failed");
+  });
+
+  it("downloads fallback when commit fails", async () => {
+    const onPersistenceFailure = vi.fn();
+    const { controller, repository } = setup({ onPersistenceFailure });
+    vi.mocked(repository.commit).mockResolvedValueOnce({
+      ok: false,
+      reason: "unknown",
+      message: "transaction failed",
+    });
+
+    await controller.start(makeStartPayload());
+    await expect(controller.stop("user")).rejects.toThrow(/commit-failed/);
+
+    expect(onPersistenceFailure).toHaveBeenCalledWith(
+      expect.objectContaining({
+        pkg: expect.objectContaining({ meta: expect.objectContaining({ title: "title-x" }) }),
+        mediaBlob: null,
+        error: expect.any(Error),
+      }),
+    );
   });
 
   it("reset returns the controller to idle and disposes producers", async () => {

--- a/apps/web/src/features/recorder/__tests__/recordingController.test.ts
+++ b/apps/web/src/features/recorder/__tests__/recordingController.test.ts
@@ -326,6 +326,7 @@ describe("createRecordingController", () => {
     expect(repository.commits).toHaveLength(1);
     expect(pkg.media).toBeNull();
     expect(pkg.events.at(-1)).toMatchObject({
+      id: expect.stringMatching(/^e-/),
       type: "media-warning",
       payload: {
         target: "recorder",
@@ -333,6 +334,114 @@ describe("createRecordingController", () => {
       },
     });
     expect(controller.state.status).toBe("completed");
+  });
+
+  it("downloads an event-only fallback when media save fallback also fails", async () => {
+    const onPersistenceFailure = vi.fn();
+    const mediaBlob = new Blob(["media"], { type: "video/webm" });
+    const mediaSource = vi.fn(async () => ({
+      blob: mediaBlob,
+      durationMs: 1_500,
+      mimeType: "video/webm",
+      hasAudio: true,
+      hasCamera: true,
+    }));
+    const { controller, repository } = setup({ mediaSource, onPersistenceFailure });
+    vi.mocked(repository.saveDraft)
+      .mockResolvedValueOnce({
+        ok: false,
+        reason: "media-write-failed",
+        message: "blob store failed",
+      })
+      .mockResolvedValueOnce({
+        ok: false,
+        reason: "quota-exceeded",
+        message: "quota failed for event-only draft",
+      });
+
+    await controller.start(makeStartPayload());
+    await expect(controller.stop("user")).rejects.toThrow(/save-draft-failed/);
+
+    expect(controller.state.status).toBe("failed");
+    expect(controller.state.lastError?.code).toBe("save-draft-failed");
+    expect(repository.commit).not.toHaveBeenCalled();
+    expect(onPersistenceFailure).toHaveBeenCalledWith(
+      expect.objectContaining({
+        mediaBlob: null,
+        pkg: expect.objectContaining({
+          media: null,
+          events: expect.arrayContaining([
+            expect.objectContaining({
+              id: expect.stringMatching(/^e-/),
+              type: "media-warning",
+            }),
+          ]),
+        }),
+        error: expect.any(Error),
+      }),
+    );
+  });
+
+  it("downloads an event-only fallback when media save fallback commit fails", async () => {
+    const onPersistenceFailure = vi.fn();
+    const mediaBlob = new Blob(["media"], { type: "video/webm" });
+    const mediaSource = vi.fn(async () => ({
+      blob: mediaBlob,
+      durationMs: 1_500,
+      mimeType: "video/webm",
+      hasAudio: true,
+      hasCamera: true,
+    }));
+    const { controller, repository } = setup({ mediaSource, onPersistenceFailure });
+    vi.mocked(repository.saveDraft).mockResolvedValueOnce({
+      ok: false,
+      reason: "media-write-failed",
+      message: "blob store failed",
+    });
+    vi.mocked(repository.commit).mockResolvedValueOnce({
+      ok: false,
+      reason: "unknown",
+      message: "event-only commit failed",
+    });
+
+    await controller.start(makeStartPayload());
+    await expect(controller.stop("user")).rejects.toThrow(/commit-failed/);
+
+    expect(controller.state.status).toBe("failed");
+    expect(controller.state.lastError?.code).toBe("commit-failed");
+    expect(onPersistenceFailure).toHaveBeenCalledWith(
+      expect.objectContaining({
+        mediaBlob: null,
+        pkg: expect.objectContaining({
+          media: null,
+          events: expect.arrayContaining([
+            expect.objectContaining({
+              id: expect.stringMatching(/^e-/),
+              type: "media-warning",
+            }),
+          ]),
+        }),
+        error: expect.any(Error),
+      }),
+    );
+  });
+
+  it("does not re-stringify package arrays during quota preflight", async () => {
+    const { controller, repository } = setup();
+    const stringifySpy = vi.spyOn(JSON, "stringify");
+    vi.mocked(repository.estimateQuota).mockImplementationOnce(async () => {
+      stringifySpy.mockClear();
+      return { usageBytes: 0, quotaBytes: 50 * 1024 * 1024 };
+    });
+
+    try {
+      await controller.start(makeStartPayload());
+      await controller.stop("user");
+
+      expect(stringifySpy).not.toHaveBeenCalled();
+    } finally {
+      stringifySpy.mockRestore();
+    }
   });
 
   it("does not complete when commit fails", async () => {

--- a/apps/web/src/features/recorder/recordingController.ts
+++ b/apps/web/src/features/recorder/recordingController.ts
@@ -6,6 +6,7 @@ import type {
   RecordingControllerDeps,
   RecordingControllerState,
   RecordingControllerStatus,
+  RecordingEvent,
   RecordingPackageV1,
   RecordingSnapshot,
   RecordStartPayload,
@@ -197,7 +198,7 @@ export function createRecordingController(options: RecordingControllerOptions): 
           transitionTo("processing", { durationMs: pendingPackageSave.pkg.meta.durationMs });
         }
 
-        await persistPackage(repository, pendingPackageSave);
+        pendingPackageSave = await persistPackage(repository, packageBuilder, pendingPackageSave);
 
         transitionTo("completed");
         const pkg = pendingPackageSave.pkg;
@@ -246,8 +247,10 @@ export function createRecordingController(options: RecordingControllerOptions): 
 
 async function persistPackage(
   repository: RecordingControllerDeps["repository"],
+  packageBuilder: RecordingControllerDeps["packageBuilder"],
   pending: PendingPackageSave,
-): Promise<void> {
+): Promise<PendingPackageSave> {
+  await assertSufficientQuota(repository, pending);
   const { pkg, mediaBlob } = pending;
   const saveResult = await repository.saveDraft({
     meta: pkg.meta,
@@ -262,6 +265,30 @@ async function persistPackage(
     mediaBlob,
   });
   if (!saveResult.ok) {
+    if (saveResult.reason === "media-write-failed" && mediaBlob) {
+      const eventOnlyPending = await buildMediaMissingFallback(packageBuilder, pending, saveResult.message);
+      await assertSufficientQuota(repository, eventOnlyPending);
+      const eventOnlySave = await repository.saveDraft({
+        meta: eventOnlyPending.pkg.meta,
+        events: eventOnlyPending.pkg.events,
+        snapshots: eventOnlyPending.pkg.snapshots,
+        indexes: eventOnlyPending.pkg.indexes ?? {
+          generatedAt: new Date().toISOString(),
+          eventsByType: {} as Record<string, number[]>,
+          snapshotSeqsByTime: [],
+          markers: [],
+        },
+        mediaBlob: null,
+      });
+      if (!eventOnlySave.ok) {
+        throw persistenceError("save-draft-failed", eventOnlySave.reason, eventOnlySave.message);
+      }
+      const eventOnlyCommit = await repository.commit(eventOnlyPending.pkg.meta.id);
+      if (!eventOnlyCommit.ok) {
+        throw persistenceError("commit-failed", eventOnlyCommit.reason, eventOnlyCommit.message);
+      }
+      return eventOnlyPending;
+    }
     throw persistenceError("save-draft-failed", saveResult.reason, saveResult.message);
   }
 
@@ -269,6 +296,75 @@ async function persistPackage(
   if (!commitResult.ok) {
     throw persistenceError("commit-failed", commitResult.reason, commitResult.message);
   }
+  return pending;
+}
+
+async function assertSufficientQuota(
+  repository: RecordingControllerDeps["repository"],
+  pending: PendingPackageSave,
+): Promise<void> {
+  let estimate: { usageBytes: number; quotaBytes: number };
+  try {
+    estimate = await repository.estimateQuota();
+  } catch (err) {
+    console.warn("[recording-controller] quota estimate failed:", err);
+    return;
+  }
+  if (estimate.quotaBytes <= 0) return;
+  const availableBytes = Math.max(0, estimate.quotaBytes - estimate.usageBytes);
+  const requiredBytes = estimateRequiredSaveBytes(pending);
+  if (availableBytes < requiredBytes) {
+    throw persistenceError(
+      "quota-precheck-failed",
+      "quota-exceeded",
+      `Local storage has ${(availableBytes / 1024 / 1024).toFixed(1)} MB available; recording needs about ${(requiredBytes / 1024 / 1024).toFixed(1)} MB.`,
+    );
+  }
+}
+
+function estimateRequiredSaveBytes({ pkg, mediaBlob }: PendingPackageSave): number {
+  const jsonBytes = new Blob([
+    JSON.stringify(pkg.manifest),
+    JSON.stringify(pkg.meta),
+    JSON.stringify(pkg.events),
+    JSON.stringify(pkg.snapshots),
+    JSON.stringify(pkg.indexes ?? {}),
+    JSON.stringify(pkg.media ?? null),
+  ]).size;
+  const mediaBytes = mediaBlob ? Math.ceil(mediaBlob.size * 1.4) : 0;
+  return jsonBytes + mediaBytes + 512 * 1024;
+}
+
+async function buildMediaMissingFallback(
+  packageBuilder: RecordingControllerDeps["packageBuilder"],
+  pending: PendingPackageSave,
+  message: string,
+): Promise<PendingPackageSave> {
+  const warning = mediaMissingWarningEvent(pending.pkg, message);
+  return packageBuilder.build({
+    meta: pending.pkg.meta,
+    events: [...pending.pkg.events, warning],
+    snapshots: pending.pkg.snapshots,
+    media: null,
+  });
+}
+
+function mediaMissingWarningEvent(pkg: RecordingPackageV1, message: string): RecordingEvent {
+  const lastSeq = pkg.events.reduce((max, event) => Math.max(max, event.seq), -1);
+  return {
+    id: generateId("event"),
+    seq: lastSeq + 1,
+    timestampMs: pkg.meta.durationMs,
+    wallTime: new Date().toISOString(),
+    source: "media",
+    track: "media",
+    type: "media-warning",
+    payload: {
+      target: "recorder",
+      code: "recorder-error",
+      message: `Media could not be saved. Event timeline was preserved. ${message}`,
+    },
+  };
 }
 
 function isActiveStatus(status: RecordingControllerStatus): boolean {

--- a/apps/web/src/features/recorder/recordingController.ts
+++ b/apps/web/src/features/recorder/recordingController.ts
@@ -198,7 +198,9 @@ export function createRecordingController(options: RecordingControllerOptions): 
           transitionTo("processing", { durationMs: pendingPackageSave.pkg.meta.durationMs });
         }
 
-        pendingPackageSave = await persistPackage(repository, packageBuilder, pendingPackageSave);
+        pendingPackageSave = await persistPackage(repository, packageBuilder, pendingPackageSave, (fallback) => {
+          pendingPackageSave = fallback;
+        });
 
         transitionTo("completed");
         const pkg = pendingPackageSave.pkg;
@@ -249,6 +251,7 @@ async function persistPackage(
   repository: RecordingControllerDeps["repository"],
   packageBuilder: RecordingControllerDeps["packageBuilder"],
   pending: PendingPackageSave,
+  setFallbackPending?: (pending: PendingPackageSave) => void,
 ): Promise<PendingPackageSave> {
   await assertSufficientQuota(repository, pending);
   const { pkg, mediaBlob } = pending;
@@ -267,6 +270,7 @@ async function persistPackage(
   if (!saveResult.ok) {
     if (saveResult.reason === "media-write-failed" && mediaBlob) {
       const eventOnlyPending = await buildMediaMissingFallback(packageBuilder, pending, saveResult.message);
+      setFallbackPending?.(eventOnlyPending);
       await assertSufficientQuota(repository, eventOnlyPending);
       const eventOnlySave = await repository.saveDraft({
         meta: eventOnlyPending.pkg.meta,
@@ -323,16 +327,34 @@ async function assertSufficientQuota(
 }
 
 function estimateRequiredSaveBytes({ pkg, mediaBlob }: PendingPackageSave): number {
-  const jsonBytes = new Blob([
-    JSON.stringify(pkg.manifest),
-    JSON.stringify(pkg.meta),
-    JSON.stringify(pkg.events),
-    JSON.stringify(pkg.snapshots),
-    JSON.stringify(pkg.indexes ?? {}),
-    JSON.stringify(pkg.media ?? null),
-  ]).size;
+  const jsonBytes = estimateValueBytes(pkg.manifest)
+    + estimateValueBytes(pkg.meta)
+    + estimateValueBytes(pkg.events)
+    + estimateValueBytes(pkg.snapshots)
+    + estimateValueBytes(pkg.indexes ?? {})
+    + estimateValueBytes(pkg.media ?? null);
   const mediaBytes = mediaBlob ? Math.ceil(mediaBlob.size * 1.4) : 0;
   return jsonBytes + mediaBytes + 512 * 1024;
+}
+
+function estimateValueBytes(value: unknown): number {
+  if (value === null || typeof value === "undefined") return 4;
+  if (typeof value === "string") return estimateStringBytes(value);
+  if (typeof value === "number" || typeof value === "boolean") return 16;
+  if (Array.isArray(value)) {
+    return value.reduce((sum, item) => sum + estimateValueBytes(item) + 1, 2);
+  }
+  if (typeof value === "object") {
+    return Object.entries(value as Record<string, unknown>).reduce(
+      (sum, [key, item]) => sum + estimateStringBytes(key) + estimateValueBytes(item) + 2,
+      2,
+    );
+  }
+  return estimateStringBytes(String(value));
+}
+
+function estimateStringBytes(value: string): number {
+  return value.length * 2 + 2;
 }
 
 async function buildMediaMissingFallback(
@@ -352,7 +374,7 @@ async function buildMediaMissingFallback(
 function mediaMissingWarningEvent(pkg: RecordingPackageV1, message: string): RecordingEvent {
   const lastSeq = pkg.events.reduce((max, event) => Math.max(max, event.seq), -1);
   return {
-    id: generateId("event"),
+    id: generateId("e"),
     seq: lastSeq + 1,
     timestampMs: pkg.meta.durationMs,
     wallTime: new Date().toISOString(),


### PR DESCRIPTION
## 关联 Issue

Closes #77 

## 变更说明

recordingController 停止保存前会先调用 repository.estimateQuota() 做保守容量预检。
quota 明显不足时不调用 saveDraft()，避免半成品进本地回放中心，并触发 ZIP fallback。
saveDraft() 失败、commit() 失败仍走现有 fallback ZIP 下载。
媒体写入失败时，会重建一个“事件流 + media-warning + 无 media”的录制包并尝试保存，避免代码事件流丢失。
media 写入失败后，event-only 二次 saveDraft/commit 失败时也会把 event-only 包交给 ZIP fallback，避免回退到已失败的媒体包。
quota 预检改为轻量字节估算，不再在 stop() 持久化阶段重复 JSON.stringify 完整事件/快照数组。
recordingStore.saveDraft() 现在会把媒体 Blob 读取/准备失败转成 media-write-failed，并对空 message 的 DOMException 保留 name 和兜底诊断。
RecorderPage 增加保存失败提示，明确告诉用户“未进入本地回放中心，已导出 ZIP 兜底文件”。
补了单测覆盖 quota 预检、saveDraft 失败、commit 失败、media write 失败、event-only 二次失败、页面 fallback 提示、无媒体 media-warning 回放兼容。

## GitNexus 影响分析摘要

- 风险等级: CRITICAL
- 关键骨架变更: apps/web/src/features/library/recordingStore.ts、apps/web/src/features/recorder/recordingController.ts 保存 fallback 路径，以及 apps/web/src/features/player/__tests__/replayScheduler.test.ts 的 event-only 兼容验证
- GitNexus 影响面: detect_changes 报告 39 个 changed symbols、16 个 affected processes、risk_level critical；impact(persistPackage) 为 LOW，仅直接影响 stop；impact(saveDraft) 为 LOW，直接影响 importZip；query 覆盖 load/integrity/replay 对 media-warning 与 media null 的消费者路径。
- 验证结果: npm run quality:local 通过；定向 Vitest recordingController、recordingStore、replayScheduler 共 52 tests 通过。

## 自检

- [X] PR author 是该 Issue 的认领者
- [X] 未修改 `docs/progress.json` 或 `docs/progress.md`
- [X] 已运行 `npm run quality:local`，或说明无法运行的原因
- [X] 如果改动关键骨架，已补充契约测试并填写 GitNexus 影响分析摘要
- [X] 已邀请至少一名非作者同学 CR