### PR TITLE
feat: add event-only replay notice for missing media in ReplayPage

### DIFF
--- a/apps/web/src/features/player/ReplayPage.tsx
+++ b/apps/web/src/features/player/ReplayPage.tsx
@@ -66,7 +66,7 @@ type ReplayOverlayState = {
 
 const EMPTY_OVERLAY_STATE: ReplayOverlayState = { pointer: null, shortcut: null };
 const TRANSIENT_OVERLAY_TTL_MS = 900;
-const MEDIA_DRIFT_THRESHOLD_MS = 250;
+type RecordedMedia = NonNullable<RecordingPackageV1["media"]>;
 const EVENT_ONLY_REPLAY_NOTICE = "音视频不可用，已切换为纯事件流回放";
 
 function isEventOnlyMediaDegraded(
@@ -77,7 +77,6 @@ function isEventOnlyMediaDegraded(
   if (!pkg.media || mediaBlob) return false;
   return warnings.some((warning) => warning.code === "media-missing");
 }
-type RecordedMedia = NonNullable<RecordingPackageV1["media"]>;
 
 /**
  * ReplayPage — wires the replay core (scheduler + clock + repository + runtime)

--- a/apps/web/src/features/player/ReplayPage.tsx
+++ b/apps/web/src/features/player/ReplayPage.tsx
@@ -9,6 +9,7 @@ import {
   type SetStateAction,
 } from "react";
 import { Link, useParams } from "react-router-dom";
+import { CircleAlert } from "lucide-react";
 import { createReplayScheduler, defaultTickStrategy } from "./replayScheduler";
 import { createTimelineClock } from "./timelineClock";
 import { ReplayControls } from "./ReplayControls";
@@ -18,6 +19,7 @@ import { PreviewPane } from "@/features/runtime-preview/PreviewPane";
 import { createIframeRuntime } from "@/features/runtime-preview/iframeRuntime";
 import { createRecordingStore } from "@/features/library/recordingStore";
 import type {
+  PackageWarning,
   RecordingEvent,
   RecordingPackageV1,
   ReplaySchedulerState,
@@ -65,6 +67,16 @@ type ReplayOverlayState = {
 const EMPTY_OVERLAY_STATE: ReplayOverlayState = { pointer: null, shortcut: null };
 const TRANSIENT_OVERLAY_TTL_MS = 900;
 const MEDIA_DRIFT_THRESHOLD_MS = 250;
+const EVENT_ONLY_REPLAY_NOTICE = "音视频不可用，已切换为纯事件流回放";
+
+function isEventOnlyMediaDegraded(
+  pkg: RecordingPackageV1,
+  mediaBlob: Blob | null,
+  warnings: PackageWarning[],
+): boolean {
+  if (!pkg.media || mediaBlob) return false;
+  return warnings.some((warning) => warning.code === "media-missing");
+}
 
 /**
  * ReplayPage — wires the replay core (scheduler + clock + repository + runtime)
@@ -81,6 +93,7 @@ export function ReplayPage() {
   const [pkg, setPkg] = useState<RecordingPackageV1 | null>(null);
   const [mediaBlob, setMediaBlob] = useState<Blob | null>(null);
   const [loadError, setLoadError] = useState<string | null>(null);
+  const [eventOnlyNotice, setEventOnlyNotice] = useState(false);
   const [volume, setVolume] = useState(100);
   const [muted, setMuted] = useState(false);
   const recordedMediaVideoRef = useRef<HTMLVideoElement | null>(null);
@@ -137,6 +150,7 @@ export function ReplayPage() {
     if (!id) return;
     let cancelled = false;
     setLoadError(null);
+    setEventOnlyNotice(false);
     setPkg(null);
     setMediaBlob(null);
     setStableState(INITIAL_STABLE_STATE);
@@ -154,6 +168,9 @@ export function ReplayPage() {
       }
       setPkg(result.package);
       setMediaBlob(result.mediaBlob);
+      setEventOnlyNotice(
+        isEventOnlyMediaDegraded(result.package, result.mediaBlob, result.warnings),
+      );
       await scheduler.load(result.package);
     })();
     return () => {
@@ -174,6 +191,18 @@ export function ReplayPage() {
 
   return (
     <div className="flex h-full flex-col">
+      {eventOnlyNotice ? (
+        <div
+          role="status"
+          aria-live="polite"
+          className="border-b border-warning/40 bg-warning/10 px-4 py-2 text-sm text-foreground"
+        >
+          <div className="flex items-center gap-2">
+            <CircleAlert aria-hidden size={16} className="shrink-0 text-warning" />
+            <span>{EVENT_ONLY_REPLAY_NOTICE}</span>
+          </div>
+        </div>
+      ) : null}
       <div className="grid flex-1 grid-cols-1 md:grid-cols-[1fr_minmax(320px,420px)]">
         <div className="relative border-r border-border">
           <CodeEditor

--- a/apps/web/src/features/player/__tests__/ReplayPage.test.tsx
+++ b/apps/web/src/features/player/__tests__/ReplayPage.test.tsx
@@ -370,6 +370,69 @@ describe("ReplayPage", () => {
     pause.mockRestore();
   });
 
+  it("shows a non-blocking notice when media is missing but the event stream loads", async () => {
+    replayPageMock.repository.load.mockResolvedValueOnce({
+      ok: true,
+      package: replayPageMock.packageData,
+      mediaBlob: null,
+      warnings: [{ code: "media-missing", blobId: "blob-1" }],
+    });
+    const { ReplayPage } = await import("../ReplayPage");
+
+    render(<ReplayPage />);
+
+    await waitFor(() => expect(replayPageMock.scheduler.load).toHaveBeenCalledWith(replayPageMock.packageData));
+    expect(screen.getByText("音视频不可用，已切换为纯事件流回放")).toBeInTheDocument();
+    expect(screen.queryByText(/加载失败/)).not.toBeInTheDocument();
+    expect(screen.getByLabelText("Mock code editor")).toBeInTheDocument();
+    expect(screen.getByLabelText("Mock replay controls")).toBeInTheDocument();
+  });
+
+  it("blocks replay when media checksum mismatches", async () => {
+    replayPageMock.repository.load.mockResolvedValueOnce({
+      ok: false,
+      error: { code: "checksum-mismatch", target: "media" },
+    });
+    const { ReplayPage } = await import("../ReplayPage");
+    const { MemoryRouter } = await import("react-router-dom");
+
+    render(
+      <MemoryRouter future={{ v7_relativeSplatPath: true, v7_startTransition: true }}>
+        <ReplayPage />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => expect(screen.getByText(/加载失败：checksum-mismatch/)).toBeInTheDocument());
+    expect(replayPageMock.scheduler.load).not.toHaveBeenCalled();
+    expect(screen.queryByText("音视频不可用，已切换为纯事件流回放")).not.toBeInTheDocument();
+  });
+
+  it("keeps replay controls usable in event-only mode when media is missing", async () => {
+    replayPageMock.repository.load.mockResolvedValueOnce({
+      ok: true,
+      package: replayPageMock.packageData,
+      mediaBlob: null,
+      warnings: [{ code: "media-missing", blobId: "blob-1" }],
+    });
+    const { ReplayPage } = await import("../ReplayPage");
+
+    render(<ReplayPage />);
+
+    await waitFor(() => expect(replayPageMock.controlsProps).not.toBeNull());
+
+    await act(async () => {
+      await replayPageMock.controlsProps?.onSeek(10_000);
+    });
+    act(() => {
+      replayPageMock.controlsProps?.onPlayPause();
+      replayPageMock.controlsProps?.onRate(2);
+    });
+
+    expect(replayPageMock.scheduler.seek).toHaveBeenCalledWith(10_000);
+    expect(replayPageMock.scheduler.play).toHaveBeenCalled();
+    expect(replayPageMock.scheduler.setRate).toHaveBeenCalledWith(2);
+  });
+
   it("clears a load error when navigating to another replay id", async () => {
     const pause = vi.spyOn(HTMLMediaElement.prototype, "pause").mockImplementation(() => {});
     replayPageMock.repository.load.mockResolvedValueOnce({

--- a/apps/web/src/features/player/__tests__/ReplayPage.test.tsx
+++ b/apps/web/src/features/player/__tests__/ReplayPage.test.tsx
@@ -439,6 +439,30 @@ describe("ReplayPage", () => {
     expect(screen.queryByText("音视频不可用，已切换为纯事件流回放")).not.toBeInTheDocument();
   });
 
+  it.each([
+    ["invalid-manifest", { code: "invalid-manifest" as const, message: "manifest missing" }],
+    ["unsupported-schema", { code: "unsupported-schema" as const, schemaVersion: "9.9.9" }],
+  ])("blocks replay when package load fails with %s", async (expectedCode, error) => {
+    replayPageMock.repository.load.mockResolvedValueOnce({
+      ok: false,
+      error,
+    });
+    const { ReplayPage } = await import("../ReplayPage");
+    const { MemoryRouter } = await import("react-router-dom");
+
+    render(
+      <MemoryRouter future={{ v7_relativeSplatPath: true, v7_startTransition: true }}>
+        <ReplayPage />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() =>
+      expect(screen.getByText(new RegExp(`加载失败：${expectedCode}`))).toBeInTheDocument(),
+    );
+    expect(replayPageMock.scheduler.load).not.toHaveBeenCalled();
+    expect(screen.queryByText("音视频不可用，已切换为纯事件流回放")).not.toBeInTheDocument();
+  });
+
   it("keeps replay controls usable in event-only mode when media is missing", async () => {
     replayPageMock.repository.load.mockResolvedValueOnce({
       ok: true,


### PR DESCRIPTION
## 关联 Issue

Closes #79

## 变更说明

ReplayPage 在 repository.load() 返回 media-missing 且 pkg.media 存在、mediaBlob === null 时，展示非阻塞提示「音视频不可用，已切换为纯事件流回放」。
ok: false（含 checksum-mismatch / manifest / schema）仍全页阻断，不误降级。
纯事件流下 ReplayControls 的 play/pause/seek/倍速行为不变（由现有 scheduler + 单测保证）。

本次补充：
- 移除 ReplayPage 合并 main 后遗留的未使用 `MEDIA_DRIFT_THRESHOLD_MS`，恢复 CI build。
- 增加 invalid-manifest / unsupported-schema 的阻断回归测试，覆盖 repo-guard 建议的 manifest/schema 路径。

## GitNexus 影响分析摘要

- 风险等级: 低（GitNexus upstream impact 为 LOW；detect_changes 命中 ReplayPage 内部加载/渲染相关流程，未发现公共 API、route、schema 或关键契约变更）
- 关键骨架变更: 无；仅消费既有 `PackageLoadResult.warnings` 并补充 ReplayPage 测试
- GitNexus 影响面: ReplayPage 加载录制包、media-missing 降级提示、ok:false 加载失败阻断、event-only ReplayControls 调度
- 影响调用方: `apps/web/src/app/routes.tsx` 直接挂载 ReplayPage，二阶为 `apps/web/src/app/App.tsx`
- 验证结果: `npm run quality:local` 通过；ReplayPage 定向测试 19 passed；build 通过

## 自检

- [x] PR author 是该 Issue 的认领者
- [x] 未修改 `docs/progress.json` 或 `docs/progress.md`
- [x] 已运行 `npm run quality:local`，或说明无法运行的原因
- [x] 如果改动关键骨架，已补充契约测试并填写 GitNexus 影响分析摘要
- [x] 已邀请至少一名非作者同学 CR
