### PR TITLE
#78 录制到回放主链路 Playwright e2e

### DIFF
--- a/apps/web/e2e/record-replay.spec.ts
+++ b/apps/web/e2e/record-replay.spec.ts
@@ -134,8 +134,12 @@ function recordingIdFromUrl(url: string): string {
 async function readStoredRecording(page: Page, recordingId: string): Promise<StoredRecording | null> {
   return page.evaluate(
     async ({ databaseName, id }) => {
-      const openRequest = indexedDB.open(databaseName, 1);
+      const openRequest = indexedDB.open(databaseName);
       const db = await new Promise<IDBDatabase>((resolve, reject) => {
+        openRequest.onupgradeneeded = () => {
+          openRequest.transaction?.abort();
+          reject(new Error(`IndexedDB ${databaseName} unexpectedly required an upgrade`));
+        };
         openRequest.onerror = () => reject(openRequest.error);
         openRequest.onsuccess = () => resolve(openRequest.result);
       });

--- a/apps/web/e2e/record-replay.spec.ts
+++ b/apps/web/e2e/record-replay.spec.ts
@@ -1,0 +1,180 @@
+import { expect, test, type Page } from "@playwright/test";
+
+type StoredRecording = {
+  meta: {
+    durationMs: number;
+  };
+  events: Array<{
+    type: string;
+    timestampMs: number;
+    payload: Record<string, unknown>;
+  }>;
+};
+
+const DB_NAME = "code-tape";
+const FIRST_OUTPUT = "run:seek-before";
+const LONG_INPUT = "abcdefghijklmnopqrstuvwxyz1234";
+const FINAL_OUTPUT = `run:seek-after:${LONG_INPUT.length}`;
+
+test("records, saves, replays, seeks, and keeps content-change events debounced", async ({
+  page,
+}) => {
+  const runtimeErrors = collectRuntimeErrors(page);
+
+  await page.goto("/record", { waitUntil: "domcontentloaded" });
+  await expect(page.locator("[data-code-editor] .monaco-editor")).toBeVisible();
+
+  await page.getByLabel("麦克风设备").selectOption("");
+  await page.getByLabel("摄像头设备").selectOption("");
+
+  await page.getByRole("button", { name: "开始录制" }).click();
+  await expect(page.getByLabel("录制状态：录制中")).toBeVisible();
+
+  await typeInEditor(
+    page,
+    `document.body.textContent = "seek-before";\nconsole.log("${FIRST_OUTPUT}");\n`,
+  );
+  await runCodeAndWaitForPreview(page, "seek-before");
+
+  await page.waitForTimeout(250);
+  await page.getByRole("button", { name: "暂停录制" }).click();
+  await expect(page.getByLabel("录制状态：已暂停")).toBeVisible();
+  await page.waitForTimeout(100);
+  await page.getByRole("button", { name: "继续录制" }).click();
+  await expect(page.getByLabel("录制状态：录制中")).toBeVisible();
+
+  await typeInEditor(
+    page,
+    `const typed = "${LONG_INPUT}";\ndocument.body.textContent = "seek-after:" + typed.length;\nconsole.log("run:seek-after:" + typed.length);\n`,
+  );
+  await runCodeAndWaitForPreview(page, `seek-after:${LONG_INPUT.length}`);
+  await page.waitForTimeout(250);
+
+  await page.getByRole("button", { name: "停止录制" }).click();
+  await page.waitForURL(/\/replay\/[^/]+$/);
+  await expect(page.getByRole("button", { name: "播放" })).toBeEnabled();
+
+  const recordingId = recordingIdFromUrl(page.url());
+  const stored = await readStoredRecording(page, recordingId);
+  expect(stored).not.toBeNull();
+
+  const recording = stored!;
+  const contentChanges = recording.events.filter((event) => event.type === "content-change");
+  const runOutputs = recording.events.filter((event) => event.type === "run-output");
+  const firstRunOutput = runOutputs.find((event) =>
+    Array.isArray(event.payload.stdout)
+    && event.payload.stdout.includes(FIRST_OUTPUT),
+  );
+  const finalRunOutput = runOutputs.find((event) =>
+    Array.isArray(event.payload.stdout)
+    && event.payload.stdout.includes(FINAL_OUTPUT),
+  );
+
+  expect(recording.events.some((event) => event.type === "record-pause")).toBe(true);
+  expect(recording.events.some((event) => event.type === "record-resume")).toBe(true);
+  expect(recording.events.some((event) => event.type === "record-stop")).toBe(true);
+  expect(contentChanges.length).toBeGreaterThan(0);
+  expect(contentChanges.length).toBeLessThan(30);
+  expect(contentChanges.at(-1)?.payload.code).toContain(LONG_INPUT);
+  expect(firstRunOutput).toBeTruthy();
+  expect(finalRunOutput).toBeTruthy();
+
+  await page.getByRole("button", { name: "播放" }).click();
+  await expect(page.getByRole("button", { name: "暂停" })).toBeEnabled();
+  await page.getByRole("button", { name: "暂停" }).click();
+  await expect(page.getByRole("button", { name: "播放" })).toBeEnabled();
+
+  await page.getByRole("button", { name: "倍速" }).click();
+  await page.getByRole("option", { name: "2x" }).click();
+  await expect(page.getByRole("option", { name: "2x" })).toHaveAttribute("aria-selected", "true");
+
+  const runtimeOutput = page.getByRole("region", { name: "Runtime output" });
+  await seekByProgress(page, firstRunOutput!.timestampMs + 20, recording.meta.durationMs);
+  await expect(page.locator("[data-code-editor]")).toContainText("seek-before");
+  await expect(page.locator("[data-code-editor]")).not.toContainText(LONG_INPUT);
+  await expect(runtimeOutput.getByText(FIRST_OUTPUT, { exact: true })).toBeVisible();
+  await expect(runtimeOutput.getByText(FINAL_OUTPUT, { exact: true })).toHaveCount(0);
+
+  await seekByProgress(page, finalRunOutput!.timestampMs + 20, recording.meta.durationMs);
+  await expect(page.locator("[data-code-editor]")).toContainText(LONG_INPUT);
+  await expect(runtimeOutput.getByText(FINAL_OUTPUT, { exact: true })).toBeVisible();
+
+  expect(runtimeErrors.filter((message) => /monaco|worker|indexeddb/i.test(message))).toEqual([]);
+});
+
+function collectRuntimeErrors(page: Page): string[] {
+  const runtimeErrors: string[] = [];
+  page.on("console", (message) => {
+    if (message.type() === "error") runtimeErrors.push(message.text());
+  });
+  page.on("pageerror", (error) => runtimeErrors.push(error.message));
+  return runtimeErrors;
+}
+
+async function typeInEditor(page: Page, source: string): Promise<void> {
+  await page.locator("[data-code-editor] .monaco-editor").click();
+  await page.keyboard.type(source, { delay: 2 });
+  await expect(page.locator("[data-code-editor]")).toContainText(source.split("\n")[0] ?? source);
+}
+
+async function runCodeAndWaitForPreview(page: Page, expectedText: string): Promise<void> {
+  await page.getByRole("button", { name: "运行代码" }).click();
+  await expect(
+    page.frameLocator('iframe[title="code-tape preview"]').locator("body"),
+  ).toContainText(expectedText);
+}
+
+function recordingIdFromUrl(url: string): string {
+  const parsed = new URL(url);
+  const match = parsed.pathname.match(/\/replay\/([^/]+)$/);
+  if (!match) throw new Error(`Could not read replay id from ${url}`);
+  return decodeURIComponent(match[1]);
+}
+
+async function readStoredRecording(page: Page, recordingId: string): Promise<StoredRecording | null> {
+  return page.evaluate(
+    async ({ databaseName, id }) => {
+      const openRequest = indexedDB.open(databaseName, 1);
+      const db = await new Promise<IDBDatabase>((resolve, reject) => {
+        openRequest.onerror = () => reject(openRequest.error);
+        openRequest.onsuccess = () => resolve(openRequest.result);
+      });
+      try {
+        const tx = db.transaction("recordings", "readonly");
+        const request = tx.objectStore("recordings").get(id);
+        const stored = await new Promise<StoredRecording | null>((resolve, reject) => {
+          request.onerror = () => reject(request.error);
+          request.onsuccess = () => resolve((request.result as StoredRecording | undefined) ?? null);
+        });
+        await new Promise<void>((resolve, reject) => {
+          tx.oncomplete = () => resolve();
+          tx.onabort = () => reject(tx.error ?? new Error("transaction aborted"));
+          tx.onerror = () => reject(tx.error ?? new Error("transaction errored"));
+        });
+        return stored;
+      } finally {
+        db.close();
+      }
+    },
+    { databaseName: DB_NAME, id: recordingId },
+  );
+}
+
+async function seekByProgress(page: Page, targetMs: number, durationMs: number): Promise<void> {
+  const percent = durationMs > 0 ? Math.max(0, Math.min(targetMs / durationMs, 1)) : 0;
+  const sliderThumb = page.locator('[aria-label="播放进度"]').first();
+  await expect(sliderThumb).toBeEnabled();
+  const box = await sliderThumb.evaluate((thumb) => {
+    const root = thumb.parentElement;
+    const rect = root?.getBoundingClientRect();
+    if (!rect) return null;
+    return {
+      x: rect.x,
+      y: rect.y,
+      width: rect.width,
+      height: rect.height,
+    };
+  });
+  if (!box) throw new Error("Replay progress slider is not visible");
+  await page.mouse.click(box.x + box.width * percent, box.y + box.height / 2);
+}

--- a/apps/web/src/features/recorder/RecorderPage.tsx
+++ b/apps/web/src/features/recorder/RecorderPage.tsx
@@ -54,6 +54,7 @@ const INITIAL_CAMERA_POSITION: CameraPositionPayload = { x: 0.85, y: 0.85 };
 
 const APP_VERSION = "0.0.0";
 const FONT_SIZE_OPTIONS = [12, 14, 16, 18, 20] as const;
+const IDLE_CLEANUP_GRACE_MS = 50;
 
 type DeviceOptions = {
   audio: DeviceInfo[];
@@ -75,6 +76,8 @@ export function RecorderPage() {
   const startInFlightRef = useRef(false);
   const startTokenRef = useRef(0);
   const stopTokenRef = useRef(0);
+  const idleCleanupTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const resourcesCleanedUpRef = useRef(false);
   const [mediaStream, setMediaStream] = useState<MediaStream | null>(null);
   const [persistenceNotice, setPersistenceNotice] = useState<string | null>(null);
 
@@ -253,16 +256,22 @@ export function RecorderPage() {
   useEffect(
     () => {
       mountedRef.current = true;
+      resourcesCleanedUpRef.current = false;
+      if (idleCleanupTimerRef.current) {
+        clearTimeout(idleCleanupTimerRef.current);
+        idleCleanupTimerRef.current = null;
+      }
       return () => {
         mountedRef.current = false;
+        const wasStarting = startInFlightRef.current;
         startInFlightRef.current = false;
         startTokenRef.current += 1;
         stopTokenRef.current += 1;
         const status = stack.controller.state.status;
         const isFinalizing = isFinalizingRecordingStatus(status);
-        if (status === "idle") {
-          stack.devices.release();
-        } else if (!isFinalizing) {
+        const cleanupRecordingResources = () => {
+          if (resourcesCleanedUpRef.current) return;
+          resourcesCleanedUpRef.current = true;
           stack.controller.reset();
           const recorder = mediaRecorderRef.current;
           mediaRecorderRef.current = null;
@@ -270,6 +279,14 @@ export function RecorderPage() {
             console.warn("[recorder-page] cleanup media stop failed:", err);
           });
           stack.devices.release();
+        };
+        if (status === "idle" && !wasStarting) {
+          idleCleanupTimerRef.current = setTimeout(() => {
+            idleCleanupTimerRef.current = null;
+            cleanupRecordingResources();
+          }, IDLE_CLEANUP_GRACE_MS);
+        } else if (!isFinalizing) {
+          cleanupRecordingResources();
         }
       };
     },

--- a/apps/web/src/features/recorder/RecorderPage.tsx
+++ b/apps/web/src/features/recorder/RecorderPage.tsx
@@ -258,8 +258,11 @@ export function RecorderPage() {
         startInFlightRef.current = false;
         startTokenRef.current += 1;
         stopTokenRef.current += 1;
-        const isFinalizing = isFinalizingRecordingStatus(stack.controller.state.status);
-        if (!isFinalizing) {
+        const status = stack.controller.state.status;
+        const isFinalizing = isFinalizingRecordingStatus(status);
+        if (status === "idle") {
+          stack.devices.release();
+        } else if (!isFinalizing) {
           stack.controller.reset();
           const recorder = mediaRecorderRef.current;
           mediaRecorderRef.current = null;

--- a/apps/web/src/features/recorder/__tests__/RecorderPage.test.tsx
+++ b/apps/web/src/features/recorder/__tests__/RecorderPage.test.tsx
@@ -344,7 +344,9 @@ describe("RecorderPage", () => {
 
   afterEach(async () => {
     cleanup();
-    await new Promise((resolve) => setTimeout(resolve, 60));
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 60));
+    });
   });
 
   it("runs with the current editor language after producer-driven language changes", async () => {
@@ -380,9 +382,13 @@ describe("RecorderPage", () => {
         <RecorderPage />
       </StrictMode>,
     );
+
     fireEvent.click(screen.getByRole("button", { name: "开始录制" }));
 
     await waitFor(() => expect(recorderPageMock.mediaRecorder.start).toHaveBeenCalledWith(recorderPageMock.stream));
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 60));
+    });
     expect(recorderPageMock.runtimeProducer.dispose).not.toHaveBeenCalled();
 
     fireEvent.click(screen.getByRole("button", { name: "运行代码" }));

--- a/apps/web/src/features/recorder/__tests__/RecorderPage.test.tsx
+++ b/apps/web/src/features/recorder/__tests__/RecorderPage.test.tsx
@@ -1,6 +1,6 @@
-import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { StrictMode, forwardRef, useImperativeHandle } from "react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type {
   EditorProducerDeps,
   EditorProducerHandle,
@@ -340,6 +340,11 @@ function mockDownloadApis() {
 describe("RecorderPage", () => {
   beforeEach(() => {
     recorderPageMock.reset();
+  });
+
+  afterEach(async () => {
+    cleanup();
+    await new Promise((resolve) => setTimeout(resolve, 60));
   });
 
   it("runs with the current editor language after producer-driven language changes", async () => {

--- a/apps/web/src/features/recorder/__tests__/RecorderPage.test.tsx
+++ b/apps/web/src/features/recorder/__tests__/RecorderPage.test.tsx
@@ -1,5 +1,5 @@
 import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { forwardRef, useImperativeHandle } from "react";
+import { StrictMode, forwardRef, useImperativeHandle } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type {
   EditorProducerDeps,
@@ -363,6 +363,30 @@ describe("RecorderPage", () => {
     expect(recorderPageMock.flushPending).toHaveBeenCalledTimes(1);
     expect(recorderPageMock.flushPending.mock.invocationCallOrder[0]).toBeLessThan(
       recorderPageMock.trigger.mock.invocationCallOrder[0],
+    );
+  });
+
+  it("keeps producers reusable after StrictMode idle cleanup", async () => {
+    const { RecorderPage } = await import("../RecorderPage");
+    recorderPageMock.editorValue.current = "console.log('strict-mode-ready');";
+
+    render(
+      <StrictMode>
+        <RecorderPage />
+      </StrictMode>,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "开始录制" }));
+
+    await waitFor(() => expect(recorderPageMock.mediaRecorder.start).toHaveBeenCalledWith(recorderPageMock.stream));
+    expect(recorderPageMock.runtimeProducer.dispose).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole("button", { name: "运行代码" }));
+
+    await waitFor(() =>
+      expect(recorderPageMock.trigger).toHaveBeenCalledWith({
+        language: "javascript",
+        source: "console.log('strict-mode-ready');",
+      }),
     );
   });
 

--- a/apps/web/src/features/recorder/__tests__/RecorderPage.test.tsx
+++ b/apps/web/src/features/recorder/__tests__/RecorderPage.test.tsx
@@ -390,6 +390,19 @@ describe("RecorderPage", () => {
     );
   });
 
+  it("disposes producers when the recorder page unmounts before recording starts", async () => {
+    const { RecorderPage } = await import("../RecorderPage");
+
+    const { unmount } = render(<RecorderPage />);
+    unmount();
+
+    await waitFor(() => expect(recorderPageMock.runtimeProducer.dispose).toHaveBeenCalled());
+    expect(recorderPageMock.editorProducer.dispose).toHaveBeenCalled();
+    expect(recorderPageMock.pointerProducer.dispose).toHaveBeenCalled();
+    expect(recorderPageMock.shortcutProducer.dispose).toHaveBeenCalled();
+    expect(recorderPageMock.mediaProducer.dispose).toHaveBeenCalled();
+  });
+
   it("reports camera preview position changes to the media producer", async () => {
     const { RecorderPage } = await import("../RecorderPage");
 


### PR DESCRIPTION
## Summary
- Add a Playwright e2e for `/record -> /replay/:id` covering event-only recording, run output, pause/resume, stop/save, play/pause, 2x rate, and progress seek.
- Verify persisted `content-change` events stay debounced for a continuous 30-character input while the final runtime state remains complete.
- Fix `RecorderPage` idle cleanup so React StrictMode dev cleanup does not permanently dispose reusable producers before recording starts; add a focused unit test.

## GitNexus Impact
- `detect_changes` risk: medium.
- Touched symbol: `RecorderPage` in `apps/web/src/features/recorder/RecorderPage.tsx`.
- Affected processes reported by GitNexus: `RecorderPage -> Cn`, `RecorderPage -> Pad`, `RecorderPage -> CapabilityLabel`.
- Risk is limited to recorder page lifecycle cleanup; covered by StrictMode unit coverage and the new record-to-replay e2e.

## Test Plan
- `npm run quality:predev`
- `npm run agent:bootstrap`
- `npm run test:web -- --run src/features/recorder/__tests__/RecorderPage.test.tsx`
- `npm run e2e:web -- --project=chromium apps/web/e2e/record-replay.spec.ts`
- `npm run quality:local`
- Commit and push hooks also ran the repository quality gates for this committed diff.

Closes #78