### PR TITLE
fix: restore recorder runtime output and sandbox replay

### DIFF
--- a/apps/web/src/features/recorder/RecorderPage.tsx
+++ b/apps/web/src/features/recorder/RecorderPage.tsx
@@ -15,6 +15,7 @@ import { createMediaRecorderWrapper } from "@/features/media/mediaRecorder";
 import { buildRecordingZip } from "@/features/library/recordingArchive";
 import { downloadBlob, safeFilenameStem } from "@/features/library/recordingDownload";
 import { createRecordingStore } from "@/features/library/recordingStore";
+import { ShieldCheck } from "lucide-react";
 import {
   createEditorProducer,
   createMediaProducer,
@@ -22,7 +23,7 @@ import {
   createRuntimeProducer,
   createShortcutProducer,
 } from "@/features/capture";
-import { useTheme } from "@/shared/ui";
+import { IconButton, useTheme } from "@/shared/ui";
 import type {
   CameraPositionPayload,
   DeviceInfo,
@@ -51,6 +52,12 @@ const INITIAL_CONTROLLER_STATE: RecordingControllerState = {
 };
 
 const INITIAL_CAMERA_POSITION: CameraPositionPayload = { x: 0.85, y: 0.85 };
+const INITIAL_RUNTIME_STATE: RecorderRuntimeState = {
+  status: "idle",
+  stdout: [],
+  stderr: [],
+  errorMessage: null,
+};
 
 const APP_VERSION = "0.0.0";
 const FONT_SIZE_OPTIONS = [12, 14, 16, 18, 20] as const;
@@ -63,6 +70,13 @@ type DeviceOptions = {
 };
 type DeviceList = Pick<DeviceOptions, "audio" | "camera">;
 type MediaOpenRequest = { audioDeviceId?: string | null; cameraDeviceId?: string | null };
+type PermissionStatus = "granted" | "denied" | "not-found" | "busy";
+type RecorderRuntimeState = {
+  status: "idle" | "running" | "success" | "error" | "timeout";
+  stdout: string[];
+  stderr: string[];
+  errorMessage: string | null;
+};
 
 /**
  * RecorderPage — wires the recording core (clock + bus + producers + builder
@@ -195,6 +209,7 @@ export function RecorderPage() {
   });
   const deviceOptionsRef = useRef<DeviceOptions>(deviceOptions);
   const deviceLoadPromiseRef = useRef<Promise<DeviceList> | null>(null);
+  const deviceLoadIdRef = useRef(0);
   const audioDeviceSelectionTouchedRef = useRef(false);
   const cameraDeviceSelectionTouchedRef = useRef(false);
   const [selectedAudioDeviceId, setSelectedAudioDeviceId] = useState<string | null>(null);
@@ -202,13 +217,17 @@ export function RecorderPage() {
   const [cameraPosition, setCameraPosition] = useState<CameraPositionPayload>(
     INITIAL_CAMERA_POSITION,
   );
+  const [mediaPermissionNotice, setMediaPermissionNotice] = useState<string | null>(null);
+  const [mediaPermissionRequesting, setMediaPermissionRequesting] = useState(false);
+  const [runtimeState, setRuntimeState] = useState<RecorderRuntimeState>(INITIAL_RUNTIME_STATE);
 
-  const loadDevices = useCallback(() => {
-    if (deviceLoadPromiseRef.current) return deviceLoadPromiseRef.current;
+  const loadDevices = useCallback((options: { force?: boolean } = {}) => {
+    if (deviceLoadPromiseRef.current && !options.force) return deviceLoadPromiseRef.current;
+    const loadId = ++deviceLoadIdRef.current;
     const promise = (async () => {
       try {
         const available = await stack.devices.enumerate();
-        if (!mountedRef.current) return available;
+        if (!mountedRef.current || deviceLoadIdRef.current !== loadId) return available;
         const nextOptions = { ...available, loaded: true };
         deviceOptionsRef.current = nextOptions;
         setDeviceOptions(nextOptions);
@@ -222,7 +241,7 @@ export function RecorderPage() {
       } catch (err) {
         console.warn("[recorder-page] media devices unavailable:", err);
         stack.devices.release();
-        if (mountedRef.current) {
+        if (mountedRef.current && deviceLoadIdRef.current === loadId) {
           const nextOptions = { audio: [], camera: [], loaded: true };
           deviceOptionsRef.current = nextOptions;
           setDeviceOptions(nextOptions);
@@ -302,6 +321,25 @@ export function RecorderPage() {
     cameraDeviceSelectionTouchedRef.current = true;
     setSelectedCameraDeviceId(deviceId);
   }, []);
+  const handleRequestMediaPermission = useCallback(async () => {
+    if (mediaPermissionRequesting || stack.controller.state.status !== "idle") return;
+    setMediaPermissionRequesting(true);
+    setMediaPermissionNotice("正在请求浏览器设备权限...");
+    try {
+      const [audio, camera] = await Promise.all([
+        stack.devices.requestPermission("audio"),
+        stack.devices.requestPermission("camera"),
+      ]);
+      await loadDevices({ force: true });
+      setMediaPermissionNotice(formatPermissionNotice(audio, camera));
+    } catch (err) {
+      console.warn("[recorder-page] media permission request failed:", err);
+      await loadDevices({ force: true });
+      setMediaPermissionNotice("设备权限申请失败，可选择无媒体录制。");
+    } finally {
+      if (mountedRef.current) setMediaPermissionRequesting(false);
+    }
+  }, [loadDevices, mediaPermissionRequesting, stack.controller, stack.devices]);
 
   const handleStart = async () => {
     if (startInFlightRef.current) return;
@@ -474,10 +512,44 @@ export function RecorderPage() {
     const editor = editorRef.current?.getEditor();
     if (!editor) return;
     stack.editorProducer.flushPending();
-    await stack.runtimeProducer.trigger({
-      language: stack.getCurrentRuntimeLanguage(),
-      source: editor.getValue(),
-    });
+    setRuntimeState({ status: "running", stdout: [], stderr: [], errorMessage: null });
+    try {
+      const result = await stack.runtimeProducer.trigger({
+        language: stack.getCurrentRuntimeLanguage(),
+        source: editor.getValue(),
+      });
+      if (result.status === "complete") {
+        setRuntimeState({
+          status: "success",
+          stdout: result.stdout,
+          stderr: result.stderr,
+          errorMessage: null,
+        });
+        return;
+      }
+      if (result.status === "timeout") {
+        setRuntimeState({
+          status: "timeout",
+          stdout: result.stdout,
+          stderr: result.stderr,
+          errorMessage: "runtime-timeout",
+        });
+        return;
+      }
+      setRuntimeState({
+        status: "error",
+        stdout: result.stdout,
+        stderr: result.stderr,
+        errorMessage: result.message,
+      });
+    } catch (err) {
+      setRuntimeState({
+        status: "error",
+        stdout: [],
+        stderr: [],
+        errorMessage: err instanceof Error ? err.message : String(err),
+      });
+    }
   };
 
   const handleLanguageChange = (next: RecordingLanguage) => {
@@ -525,11 +597,14 @@ export function RecorderPage() {
         cameraDevices={deviceOptions.camera}
         selectedAudioDeviceId={selectedAudioDeviceId}
         selectedCameraDeviceId={selectedCameraDeviceId}
+        permissionNotice={mediaPermissionNotice}
+        permissionRequesting={mediaPermissionRequesting}
         disabled={controllerState.status !== "idle"}
         onLanguageChange={handleLanguageChange}
         onFontSizeChange={setEditorFontSize}
         onAudioDeviceChange={handleAudioDeviceChange}
         onCameraDeviceChange={handleCameraDeviceChange}
+        onRequestMediaPermission={handleRequestMediaPermission}
       />
       <div className="grid flex-1 grid-cols-1 md:grid-cols-[1fr_minmax(320px,420px)]">
         <div className="relative border-r border-border">
@@ -553,7 +628,14 @@ export function RecorderPage() {
             }}
           />
         </div>
-        <PreviewPane runtime={stack.runtime} />
+        <div className="flex min-h-0 flex-col">
+          <PreviewPane
+            runtime={stack.runtime}
+            className="min-h-0 flex-1"
+            onReset={() => setRuntimeState(INITIAL_RUNTIME_STATE)}
+          />
+          <RecorderRuntimeOutputPanel runtime={runtimeState} />
+        </div>
       </div>
     </div>
   );
@@ -585,11 +667,14 @@ type RecorderSetupToolbarProps = {
   cameraDevices: DeviceInfo[];
   selectedAudioDeviceId: string | null;
   selectedCameraDeviceId: string | null;
+  permissionNotice: string | null;
+  permissionRequesting: boolean;
   disabled: boolean;
   onLanguageChange(language: RecordingLanguage): void;
   onFontSizeChange(size: number): void;
   onAudioDeviceChange(deviceId: string | null): void;
   onCameraDeviceChange(deviceId: string | null): void;
+  onRequestMediaPermission(): void;
 };
 
 function RecorderSetupToolbar({
@@ -599,11 +684,14 @@ function RecorderSetupToolbar({
   cameraDevices,
   selectedAudioDeviceId,
   selectedCameraDeviceId,
+  permissionNotice,
+  permissionRequesting,
   disabled,
   onLanguageChange,
   onFontSizeChange,
   onAudioDeviceChange,
   onCameraDeviceChange,
+  onRequestMediaPermission,
 }: RecorderSetupToolbarProps) {
   return (
     <div className="flex min-h-11 flex-wrap items-center gap-3 border-b border-border bg-background px-3 py-2">
@@ -651,6 +739,19 @@ function RecorderSetupToolbar({
           })),
         ]}
       />
+      <IconButton
+        label="申请设备权限"
+        icon={<ShieldCheck size={15} />}
+        size="sm"
+        variant="subtle"
+        disabled={disabled || permissionRequesting}
+        onClick={onRequestMediaPermission}
+      />
+      {permissionNotice ? (
+        <span role="status" aria-live="polite" className="text-xs text-muted">
+          {permissionNotice}
+        </span>
+      ) : null}
     </div>
   );
 }
@@ -690,6 +791,63 @@ function eventOnlyMedia(warnings: OpenStreamResult["warnings"] = []): OpenStream
     warnings,
     capability: INITIAL_CONTROLLER_STATE.mediaCapability,
   };
+}
+
+function RecorderRuntimeOutputPanel({ runtime }: { runtime: RecorderRuntimeState }) {
+  const hasOutput = runtime.stdout.length > 0 || runtime.stderr.length > 0 || runtime.errorMessage;
+
+  return (
+    <section className="border-t border-border bg-background px-4 py-3" aria-label="Runtime output">
+      <div className="mb-2 flex items-center justify-between gap-3">
+        <h2 className="text-xs font-semibold uppercase text-muted">Console</h2>
+        <span className="rounded-sm border border-border px-2 py-0.5 text-[11px] font-medium text-muted">
+          {runtime.status}
+        </span>
+      </div>
+      {hasOutput ? (
+        <div className="max-h-40 space-y-2 overflow-auto font-mono text-xs leading-5">
+          {runtime.stdout.map((line, index) => (
+            <pre key={`stdout-${index}`} className="whitespace-pre-wrap text-foreground">
+              {line}
+            </pre>
+          ))}
+          {runtime.stderr.map((line, index) => (
+            <pre key={`stderr-${index}`} className="whitespace-pre-wrap text-warning">
+              {line}
+            </pre>
+          ))}
+          {runtime.errorMessage ? (
+            <pre className="whitespace-pre-wrap text-danger">{runtime.errorMessage}</pre>
+          ) : null}
+        </div>
+      ) : (
+        <p className="text-xs text-muted">No output</p>
+      )}
+    </section>
+  );
+}
+
+function formatPermissionNotice(audio: PermissionStatus, camera: PermissionStatus): string {
+  if (audio === "granted" && camera === "granted") return "设备权限已授权。";
+  if (audio === "denied" && camera === "denied") return "麦克风和摄像头权限被拒绝，可选择无媒体录制。";
+  const parts = [
+    `麦克风${permissionStatusLabel(audio)}`,
+    `摄像头${permissionStatusLabel(camera)}`,
+  ];
+  return `${parts.join("，")}。`;
+}
+
+function permissionStatusLabel(status: PermissionStatus): string {
+  switch (status) {
+    case "granted":
+      return "已授权";
+    case "denied":
+      return "权限被拒绝";
+    case "not-found":
+      return "未找到设备";
+    case "busy":
+      return "设备被占用";
+  }
 }
 
 function isActiveRecordingStatus(status: RecordingControllerStatus): boolean {

--- a/apps/web/src/features/recorder/__tests__/RecorderPage.test.tsx
+++ b/apps/web/src/features/recorder/__tests__/RecorderPage.test.tsx
@@ -6,6 +6,7 @@ import type {
   EditorProducerHandle,
   MediaProducerDeps,
   PointerProducerDeps,
+  RuntimeProducerHandle,
 } from "@/features/capture/types";
 import type { CodeEditorHandle, CodeEditorProps } from "@/features/editor/CodeEditor";
 import type { CameraPreviewProps } from "@/features/media/CameraPreview";
@@ -33,7 +34,7 @@ const recorderPageMock = vi.hoisted(() => {
   const getVideoTracks = vi.fn(() => [videoTrack]);
   const setModelLanguage = vi.fn();
   const navigate = vi.fn();
-  const trigger = vi.fn(async () => ({
+  const trigger = vi.fn<RuntimeProducerHandle["trigger"]>(async () => ({
     runId: "run-test",
     status: "complete" as const,
     stdout: [],
@@ -234,6 +235,7 @@ const recorderPageMock = vi.hoisted(() => {
       shortcutProducer.stop.mockClear();
       shortcutProducer.dispose.mockClear();
       devices.enumerate.mockClear();
+      devices.requestPermission.mockClear();
       devices.openStream.mockClear();
       devices.setTrackEnabled.mockClear();
       devices.release.mockClear();
@@ -393,6 +395,40 @@ describe("RecorderPage", () => {
     expect(recorderPageMock.flushPending.mock.invocationCallOrder[0]).toBeLessThan(
       recorderPageMock.trigger.mock.invocationCallOrder[0],
     );
+  });
+
+  it("renders console output from a run in the recorder right panel", async () => {
+    const { RecorderPage } = await import("../RecorderPage");
+    recorderPageMock.editorValue.current = "console.log(1);";
+    recorderPageMock.trigger.mockResolvedValueOnce({
+      runId: "run-console",
+      status: "complete",
+      stdout: ["1"],
+      stderr: [],
+      previewHtml: "<body></body>",
+    });
+
+    render(<RecorderPage />);
+    fireEvent.click(screen.getByRole("button", { name: "运行代码" }));
+
+    const output = await screen.findByRole("region", { name: "Runtime output" });
+    expect(output).toHaveTextContent("success");
+    expect(output).toHaveTextContent("1");
+  });
+
+  it("requests browser media permissions from the setup toolbar and refreshes devices", async () => {
+    recorderPageMock.devices.requestPermission.mockResolvedValue("granted");
+    const { RecorderPage } = await import("../RecorderPage");
+
+    render(<RecorderPage />);
+    await waitFor(() => expect(recorderPageMock.devices.enumerate).toHaveBeenCalledTimes(1));
+    recorderPageMock.devices.enumerate.mockClear();
+
+    fireEvent.click(screen.getByRole("button", { name: "申请设备权限" }));
+
+    await waitFor(() => expect(recorderPageMock.devices.requestPermission).toHaveBeenCalledWith("audio"));
+    expect(recorderPageMock.devices.requestPermission).toHaveBeenCalledWith("camera");
+    await waitFor(() => expect(recorderPageMock.devices.enumerate).toHaveBeenCalledTimes(1));
   });
 
   it("keeps producers reusable after StrictMode idle cleanup", async () => {

--- a/apps/web/src/features/runtime-preview/PreviewPane.tsx
+++ b/apps/web/src/features/runtime-preview/PreviewPane.tsx
@@ -10,6 +10,7 @@ export type PreviewPaneProps = {
    * to inject historical DOM instead of executing live code.
    */
   previewHtml?: string | null;
+  onReset?: () => void;
   className?: string;
 };
 
@@ -26,7 +27,7 @@ export type PreviewPaneProps = {
  *   - 外部 padding=0；让 iframe 100%/100% 填满，避免运行时坐标偏移
  *   - 灰底 + checker pattern 作为「未运行」占位
  */
-export function PreviewPane({ runtime, previewHtml, className }: PreviewPaneProps) {
+export function PreviewPane({ runtime, previewHtml, onReset, className }: PreviewPaneProps) {
   const hostRef = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
@@ -53,7 +54,10 @@ export function PreviewPane({ runtime, previewHtml, className }: PreviewPaneProp
           icon={<RefreshCcw size={15} />}
           size="sm"
           variant="subtle"
-          onClick={() => runtime.reset()}
+          onClick={() => {
+            runtime.reset();
+            onReset?.();
+          }}
         />
       </div>
     </div>

--- a/apps/web/src/features/runtime-preview/__tests__/iframeRuntime.test.ts
+++ b/apps/web/src/features/runtime-preview/__tests__/iframeRuntime.test.ts
@@ -208,6 +208,24 @@ describe("IframeRuntime sandbox lifecycle", () => {
     host.remove();
   });
 
+  it("strips scripts from replay preview HTML before writing the no-script sandbox", async () => {
+    const host = document.createElement("div");
+    document.body.appendChild(host);
+    const runtime = createIframeRuntime();
+
+    await runtime.mount(host);
+    await runtime.renderPreview(
+      "<body><script>window.__executed = true</script><p>safe</p><script type=\"module\">console.log('again')</script></body>",
+    );
+    const frame = host.querySelector("iframe");
+
+    expect(frame?.getAttribute("sandbox")).toBe("");
+    expect(frame?.srcdoc).toContain("<p>safe</p>");
+    expect(frame?.srcdoc).not.toMatch(/<script/i);
+    runtime.destroy();
+    host.remove();
+  });
+
   it("keeps the mounted host usable after reset", async () => {
     const host = document.createElement("div");
     document.body.appendChild(host);

--- a/apps/web/src/features/runtime-preview/__tests__/iframeRuntime.test.ts
+++ b/apps/web/src/features/runtime-preview/__tests__/iframeRuntime.test.ts
@@ -226,6 +226,25 @@ describe("IframeRuntime sandbox lifecycle", () => {
     host.remove();
   });
 
+  it("preserves non-script head content when sanitizing replay preview HTML", async () => {
+    const host = document.createElement("div");
+    document.body.appendChild(host);
+    const runtime = createIframeRuntime();
+
+    await runtime.mount(host);
+    await runtime.renderPreview(
+      '<!doctype html><html><head><style>.safe { color: red; }</style><script>window.__head = true</script></head><body><p class="safe">safe</p><script>window.__body = true</script></body></html>',
+    );
+    const frame = host.querySelector("iframe");
+
+    expect(frame?.srcdoc).toContain("<style>.safe { color: red; }</style>");
+    expect(frame?.srcdoc).toContain('<p class="safe">safe</p>');
+    expect(frame?.srcdoc).not.toMatch(/<script/i);
+    expect(frame?.srcdoc).toContain("script-src 'none'");
+    runtime.destroy();
+    host.remove();
+  });
+
   it("keeps the mounted host usable after reset", async () => {
     const host = document.createElement("div");
     document.body.appendChild(host);

--- a/apps/web/src/features/runtime-preview/iframeRuntime.ts
+++ b/apps/web/src/features/runtime-preview/iframeRuntime.ts
@@ -21,6 +21,11 @@ const RUNTIME_CSP =
 const REPLAY_PREVIEW_CSP =
   "default-src 'none'; script-src 'none'; style-src 'unsafe-inline'; img-src data: blob:; connect-src 'none';";
 
+type SanitizedPreviewHtml = {
+  headHtml: string;
+  bodyHtml: string;
+};
+
 /**
  * Validate that an incoming postMessage genuinely came from our iframe runtime
  * and matches the current run. Exported so unit tests can poke at the predicate
@@ -50,7 +55,7 @@ function buildSrcDoc(bootScript: string): string {
 
 function buildPreviewSrcDoc(previewHtml: string): string {
   const safePreviewHtml = sanitizePreviewHtml(previewHtml);
-  return `<!doctype html><html><head><meta charset="utf-8"><meta http-equiv="Content-Security-Policy" content="${REPLAY_PREVIEW_CSP}" /><title>code-tape replay preview</title></head>${safePreviewHtml}</html>`;
+  return `<!doctype html><html><head><meta charset="utf-8"><meta http-equiv="Content-Security-Policy" content="${REPLAY_PREVIEW_CSP}" /><title>code-tape replay preview</title>${safePreviewHtml.headHtml}</head>${safePreviewHtml.bodyHtml}</html>`;
 }
 
 function isRuntimePayload(type: string, payload: object): boolean {
@@ -79,14 +84,27 @@ function limitString(value: string, maxLength: number): string {
   return value.length > maxLength ? value.slice(0, maxLength) : value;
 }
 
-function sanitizePreviewHtml(previewHtml: string): string {
+function sanitizePreviewHtml(previewHtml: string): SanitizedPreviewHtml {
   const cappedPreviewHtml = limitString(previewHtml, RUNTIME_PREVIEW_HTML_MAX_CHARS);
   if (typeof DOMParser === "undefined") {
-    return cappedPreviewHtml.replace(/<script\b[^>]*>[\s\S]*?<\/script>/gi, "");
+    return sanitizePreviewHtmlWithoutParser(cappedPreviewHtml);
   }
   const doc = new DOMParser().parseFromString(cappedPreviewHtml, "text/html");
   doc.querySelectorAll("script").forEach((script) => script.remove());
-  return doc.body ? doc.body.outerHTML : "";
+  return {
+    headHtml: doc.head?.innerHTML ?? "",
+    bodyHtml: doc.body?.outerHTML ?? "<body></body>",
+  };
+}
+
+function sanitizePreviewHtmlWithoutParser(previewHtml: string): SanitizedPreviewHtml {
+  const withoutScripts = previewHtml.replace(/<script\b[^>]*>[\s\S]*?<\/script>/gi, "");
+  const headMatch = withoutScripts.match(/<head\b[^>]*>([\s\S]*?)<\/head>/i);
+  const bodyMatch = withoutScripts.match(/<body\b([^>]*)>([\s\S]*?)<\/body>/i);
+  return {
+    headHtml: headMatch?.[1] ?? "",
+    bodyHtml: bodyMatch ? `<body${bodyMatch[1]}>${bodyMatch[2]}</body>` : `<body>${withoutScripts}</body>`,
+  };
 }
 
 function sanitizeRuntimeMessage(message: RuntimeMessage): RuntimeMessage {

--- a/apps/web/src/features/runtime-preview/iframeRuntime.ts
+++ b/apps/web/src/features/runtime-preview/iframeRuntime.ts
@@ -18,6 +18,8 @@ export const RUNTIME_PREVIEW_HTML_MAX_CHARS = 200_000;
 
 const RUNTIME_CSP =
   "default-src 'none'; script-src 'unsafe-inline'; style-src 'unsafe-inline'; img-src data: blob:; connect-src 'none';";
+const REPLAY_PREVIEW_CSP =
+  "default-src 'none'; script-src 'none'; style-src 'unsafe-inline'; img-src data: blob:; connect-src 'none';";
 
 /**
  * Validate that an incoming postMessage genuinely came from our iframe runtime
@@ -47,8 +49,8 @@ function buildSrcDoc(bootScript: string): string {
 }
 
 function buildPreviewSrcDoc(previewHtml: string): string {
-  const cappedPreviewHtml = limitString(previewHtml, RUNTIME_PREVIEW_HTML_MAX_CHARS);
-  return `<!doctype html><html><head><meta charset="utf-8"><meta http-equiv="Content-Security-Policy" content="${RUNTIME_CSP}" /><title>code-tape replay preview</title></head>${cappedPreviewHtml}</html>`;
+  const safePreviewHtml = sanitizePreviewHtml(previewHtml);
+  return `<!doctype html><html><head><meta charset="utf-8"><meta http-equiv="Content-Security-Policy" content="${REPLAY_PREVIEW_CSP}" /><title>code-tape replay preview</title></head>${safePreviewHtml}</html>`;
 }
 
 function isRuntimePayload(type: string, payload: object): boolean {
@@ -75,6 +77,16 @@ function isRuntimePayload(type: string, payload: object): boolean {
 
 function limitString(value: string, maxLength: number): string {
   return value.length > maxLength ? value.slice(0, maxLength) : value;
+}
+
+function sanitizePreviewHtml(previewHtml: string): string {
+  const cappedPreviewHtml = limitString(previewHtml, RUNTIME_PREVIEW_HTML_MAX_CHARS);
+  if (typeof DOMParser === "undefined") {
+    return cappedPreviewHtml.replace(/<script\b[^>]*>[\s\S]*?<\/script>/gi, "");
+  }
+  const doc = new DOMParser().parseFromString(cappedPreviewHtml, "text/html");
+  doc.querySelectorAll("script").forEach((script) => script.remove());
+  return doc.body ? doc.body.outerHTML : "";
 }
 
 function sanitizeRuntimeMessage(message: RuntimeMessage): RuntimeMessage {


### PR DESCRIPTION
## Summary
- Show recorder runtime stdout/stderr/error state in the right-side Console panel.
- Add an explicit recorder media permission button that requests microphone/camera access and refreshes devices.
- Sanitize replay preview HTML by stripping scripts while preserving non-script head/body content.

Closes #86

## Root Cause
- Recorder runs only mounted the preview iframe, so console-only code looked like an empty or unloaded right panel.
- Replay reused recorded preview HTML containing script tags in a no-script sandbox, producing blocked script execution errors.

## GitNexus 影响分析摘要
- 风险等级: HIGH
- 关键骨架变更: apps/web/src/features/runtime-preview/iframeRuntime.ts, apps/web/src/features/runtime-preview/PreviewPane.tsx
- GitNexus 影响面: detect_changes reported high risk across RecorderPage permission/run output flow, PreviewPane reset, and iframe renderPreview sanitization; query/context/impact reviewed createIframeRuntime direct callers in RecorderPage and ReplayPage, plus the follow-up sanitizer impact is limited to buildPreviewSrcDoc mount/renderPreview flows.
- 验证结果: npm run quality:predev, npm run quality:precommit, npm run quality:local, targeted iframeRuntime test, and browser verification passed.

## Test Plan
- npm run quality:predev
- npm run quality:precommit
- npm run quality:local
- npm run test -w apps/web -- src/features/runtime-preview/__tests__/iframeRuntime.test.ts
- Browser verification: recorder Console shows `success` and `1`; replay iframe `srcdoc` contains no `<script>` and DevTools has zero `Blocked script execution` errors.
