### PR TITLE
fix: 录制时间没有逐秒变化 - RecordingClock 本身会持续计算有效时长，但 RecorderControls 只渲染 R…

### DIFF
--- a/apps/web/src/features/recorder/RecorderPage.tsx
+++ b/apps/web/src/features/recorder/RecorderPage.tsx
@@ -62,6 +62,7 @@ const INITIAL_RUNTIME_STATE: RecorderRuntimeState = {
 const APP_VERSION = "0.0.0";
 const FONT_SIZE_OPTIONS = [12, 14, 16, 18, 20] as const;
 const IDLE_CLEANUP_GRACE_MS = 50;
+const LIVE_DURATION_REFRESH_MS = 1000;
 
 type DeviceOptions = {
   audio: DeviceInfo[];
@@ -192,12 +193,14 @@ export function RecorderPage() {
       },
       getCurrentEditorLanguage: () => currentEditorLanguage,
       getCurrentRuntimeLanguage,
+      getCurrentDurationMs: () => clock.durationMs(),
     };
   }, []);
 
   const [controllerState, setControllerState] = useState<RecordingControllerState>(
     INITIAL_CONTROLLER_STATE,
   );
+  const [displayDurationMs, setDisplayDurationMs] = useState(0);
   const [microphoneEnabled, setMicrophoneEnabled] = useState(false);
   const [cameraEnabled, setCameraEnabled] = useState(false);
   const [editorLanguage, setEditorLanguage] = useState<RecordingLanguage>("javascript");
@@ -269,6 +272,20 @@ export function RecorderPage() {
     },
     [stack.controller],
   );
+  useEffect(() => {
+    if (controllerState.status !== "recording") {
+      setDisplayDurationMs(controllerState.durationMs);
+      return;
+    }
+
+    const refreshDuration = () => {
+      setDisplayDurationMs(stack.getCurrentDurationMs());
+    };
+
+    refreshDuration();
+    const timer = window.setInterval(refreshDuration, LIVE_DURATION_REFRESH_MS);
+    return () => window.clearInterval(timer);
+  }, [controllerState.durationMs, controllerState.status, stack]);
   useEffect(() => {
     void loadDevices();
   }, [loadDevices]);
@@ -559,11 +576,15 @@ export function RecorderPage() {
       stack.editorProducer.setLanguage(next);
     }
   };
+  const displayControllerState = useMemo(
+    () => ({ ...controllerState, durationMs: displayDurationMs }),
+    [controllerState, displayDurationMs],
+  );
 
   return (
     <div className="flex h-full flex-col" data-recorder-host>
       <RecorderControls
-        state={controllerState}
+        state={displayControllerState}
         microphoneEnabled={microphoneEnabled}
         cameraEnabled={cameraEnabled}
         onStart={handleStart}

--- a/apps/web/src/features/recorder/__tests__/RecorderPage.test.tsx
+++ b/apps/web/src/features/recorder/__tests__/RecorderPage.test.tsx
@@ -361,6 +361,12 @@ function mockDownloadApis() {
   return { createObjectURL, revokeObjectURL, click };
 }
 
+async function flushAsyncWork(turns = 6): Promise<void> {
+  for (let index = 0; index < turns; index += 1) {
+    await Promise.resolve();
+  }
+}
+
 describe("RecorderPage", () => {
   beforeEach(() => {
     recorderPageMock.reset();
@@ -520,6 +526,35 @@ describe("RecorderPage", () => {
         selectedCameraDeviceId: "cam-1",
       }),
     );
+  });
+
+  it("refreshes the elapsed duration while recording", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-27T00:00:00.000Z"));
+    try {
+      const { RecorderPage } = await import("../RecorderPage");
+
+      render(<RecorderPage />);
+      await act(async () => {
+        await flushAsyncWork();
+      });
+      fireEvent.click(screen.getByRole("button", { name: "开始录制" }));
+      await act(async () => {
+        await flushAsyncWork();
+      });
+
+      expect(screen.getByText("录制中")).toBeInTheDocument();
+      expect(screen.getByText("00:00")).toBeInTheDocument();
+
+      await act(async () => {
+        vi.advanceTimersByTime(1_250);
+        await flushAsyncWork();
+      });
+
+      expect(screen.getByText("00:01")).toBeInTheDocument();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("primes initial media state and camera position after recording starts", async () => {


### PR DESCRIPTION
…ecordingControllerState.durationMs，而 controller 只在开始/暂停/继续/停止这些状态切换时发布新 state

## 关联 Issue

Closes #

## 变更说明

-

## GitNexus 影响分析摘要

- 风险等级: -
- 关键骨架变更: -
- GitNexus 影响面: -
- 验证结果: -

## 自检

- [ ] PR author 是该 Issue 的认领者
- [ ] 未修改 `docs/progress.json` 或 `docs/progress.md`
- [ ] 已运行 `npm run quality:local`，或说明无法运行的原因
- [ ] 如果改动关键骨架，已补充契约测试并填写 GitNexus 影响分析摘要
- [ ] 已邀请至少一名非作者同学 CR
