### PR TITLE
fix: complete P0 shortcut replay coverage

### DIFF
--- a/apps/web/e2e/record-replay.spec.ts
+++ b/apps/web/e2e/record-replay.spec.ts
@@ -34,7 +34,16 @@ test("records, saves, replays, seeks, and keeps content-change events debounced"
     page,
     `document.body.textContent = "seek-before";\nconsole.log("${FIRST_OUTPUT}");\n`,
   );
-  await runCodeAndWaitForPreview(page, "seek-before");
+  await moveAndClickInsideEditor(page);
+  await selectRecentEditorText(page);
+  await pressRecordedShortcut(page, "Control+/");
+  await page.waitForTimeout(550);
+  await pressRecordedShortcut(page, "Control+/");
+  await page.waitForTimeout(550);
+  await pressRecordedShortcut(page, "Shift+Alt+F");
+  await pressRecordedShortcut(page, "Control+G");
+  await page.keyboard.press("Escape");
+  await runCodeWithShortcutAndWaitForPreview(page, "seek-before");
 
   await page.waitForTimeout(250);
   await page.getByRole("button", { name: "暂停录制" }).click();
@@ -61,6 +70,8 @@ test("records, saves, replays, seeks, and keeps content-change events debounced"
   const recording = stored!;
   const contentChanges = recording.events.filter((event) => event.type === "content-change");
   const runOutputs = recording.events.filter((event) => event.type === "run-output");
+  const shortcutEvents = recording.events.filter((event) => event.type === "shortcut");
+  const shortcutCommands = shortcutEvents.map((event) => event.payload.command);
   const firstRunOutput = runOutputs.find((event) =>
     Array.isArray(event.payload.stdout)
     && event.payload.stdout.includes(FIRST_OUTPUT),
@@ -73,22 +84,41 @@ test("records, saves, replays, seeks, and keeps content-change events debounced"
   expect(recording.events.some((event) => event.type === "record-pause")).toBe(true);
   expect(recording.events.some((event) => event.type === "record-resume")).toBe(true);
   expect(recording.events.some((event) => event.type === "record-stop")).toBe(true);
+  expect(recording.events.some((event) => event.type === "mouse-move")).toBe(true);
+  expect(recording.events.some((event) => event.type === "mouse-click")).toBe(true);
+  expect(
+    recording.events.some((event) => event.type === "selection-change" && event.payload.selection),
+  ).toBe(true);
+  expect(shortcutCommands).toEqual(expect.arrayContaining(["comment", "format", "go-to-line", "run"]));
   expect(contentChanges.length).toBeGreaterThan(0);
   expect(contentChanges.length).toBeLessThan(30);
   expect(contentChanges.at(-1)?.payload.code).toContain(LONG_INPUT);
   expect(firstRunOutput).toBeTruthy();
   expect(finalRunOutput).toBeTruthy();
+  const runShortcut = shortcutEvents.find((event) => event.payload.command === "run");
+  const clickEvent = recording.events.find((event) => event.type === "mouse-click");
+  expect(runShortcut).toBeTruthy();
+  expect(clickEvent).toBeTruthy();
 
   await page.getByRole("button", { name: "播放" }).click();
   await expect(page.getByRole("button", { name: "暂停" })).toBeEnabled();
   await page.getByRole("button", { name: "暂停" }).click();
   await expect(page.getByRole("button", { name: "播放" })).toBeEnabled();
+  await page.getByRole("button", { name: "静音" }).click();
+  await expect(page.getByRole("button", { name: "取消静音" })).toBeVisible();
+  await page.locator("[data-replay-volume-control]").hover();
+  await page.waitForTimeout(250);
+  await expect(page.getByRole("slider", { name: "音量" })).toBeVisible();
 
   await page.getByRole("button", { name: "倍速" }).click();
   await page.getByRole("option", { name: "2x" }).click();
   await expect(page.getByRole("option", { name: "2x" })).toHaveAttribute("aria-selected", "true");
 
   const runtimeOutput = page.getByRole("region", { name: "Runtime output" });
+  await seekByProgress(page, clickEvent!.timestampMs + 20, recording.meta.durationMs);
+  await expect(page.getByLabel("回放鼠标位置")).toBeVisible();
+  await seekByProgress(page, runShortcut!.timestampMs + 20, recording.meta.durationMs);
+  await expect(page.getByLabel("回放快捷键")).toContainText("Run");
   await seekByProgress(page, firstRunOutput!.timestampMs + 20, recording.meta.durationMs);
   await expect(page.locator("[data-code-editor]")).toContainText("seek-before");
   await expect(page.locator("[data-code-editor]")).not.toContainText(LONG_INPUT);
@@ -117,8 +147,36 @@ async function typeInEditor(page: Page, source: string): Promise<void> {
   await expect(page.locator("[data-code-editor]")).toContainText(source.split("\n")[0] ?? source);
 }
 
+async function moveAndClickInsideEditor(page: Page): Promise<void> {
+  const editor = page.locator("[data-code-editor]").first();
+  const box = await editor.boundingBox();
+  if (!box) throw new Error("Code editor surface is not visible");
+  const x = box.x + Math.min(120, box.width / 2);
+  const y = box.y + Math.min(120, box.height / 2);
+  await page.mouse.move(x, y);
+  await page.mouse.click(x, y);
+}
+
+async function selectRecentEditorText(page: Page): Promise<void> {
+  await page.locator("[data-code-editor] .monaco-editor").click();
+  await page.keyboard.press("Shift+ArrowLeft");
+  await page.keyboard.press("Shift+ArrowLeft");
+}
+
+async function pressRecordedShortcut(page: Page, shortcut: string): Promise<void> {
+  await page.locator("[data-code-editor] .monaco-editor").click();
+  await page.keyboard.press(shortcut);
+}
+
 async function runCodeAndWaitForPreview(page: Page, expectedText: string): Promise<void> {
   await page.getByRole("button", { name: "运行代码" }).click();
+  await expect(
+    page.frameLocator('iframe[title="code-tape preview"]').locator("body"),
+  ).toContainText(expectedText);
+}
+
+async function runCodeWithShortcutAndWaitForPreview(page: Page, expectedText: string): Promise<void> {
+  await pressRecordedShortcut(page, "Control+Enter");
   await expect(
     page.frameLocator('iframe[title="code-tape preview"]').locator("body"),
   ).toContainText(expectedText);

--- a/apps/web/src/features/capture/__tests__/shortcutProducer.test.ts
+++ b/apps/web/src/features/capture/__tests__/shortcutProducer.test.ts
@@ -58,12 +58,14 @@ describe("createShortcutProducer", () => {
     keydown(window, { key: "f", shiftKey: true, altKey: true, timeStamp: 600 });
     keydown(window, { key: "/", ctrlKey: true, timeStamp: 1200 });
     keydown(window, { key: "Enter", ctrlKey: true, timeStamp: 1800 });
+    keydown(window, { key: "g", ctrlKey: true, timeStamp: 2400 });
 
     expect(bus.drain().map((event) => event.payload)).toEqual([
       { keys: ["Cmd", "S"], label: "Save", command: "save" },
       { keys: ["Shift", "Alt", "F"], label: "Format", command: "format" },
       { keys: ["Ctrl", "/"], label: "Comment", command: "comment" },
       { keys: ["Ctrl", "Enter"], label: "Run", command: "run" },
+      { keys: ["Ctrl", "G"], label: "Go to Line", command: "go-to-line" },
     ]);
   });
 

--- a/apps/web/src/features/capture/shortcutProducer.ts
+++ b/apps/web/src/features/capture/shortcutProducer.ts
@@ -144,6 +144,8 @@ const KNOWN_SHORTCUTS: Record<string, { label: string; command: string }> = {
   "Ctrl+Y": { label: "Redo", command: "redo" },
   "Cmd+Enter": { label: "Run", command: "run" },
   "Ctrl+Enter": { label: "Run", command: "run" },
+  "Cmd+G": { label: "Go to Line", command: "go-to-line" },
+  "Ctrl+G": { label: "Go to Line", command: "go-to-line" },
 };
 
 function isControlShortcut(event: KeyboardEvent): boolean {

--- a/apps/web/src/features/editor/CodeEditor.tsx
+++ b/apps/web/src/features/editor/CodeEditor.tsx
@@ -8,6 +8,8 @@ export type CodeEditorHandle = {
   setModelLanguage(language: RecordingLanguage): void;
 };
 
+export type CodeEditorCommand = "run" | "format" | "comment" | "go-to-line";
+
 export type CodeEditorProps = {
   language: RecordingLanguage;
   initialValue: string;
@@ -20,6 +22,7 @@ export type CodeEditorProps = {
   scrollTop?: number;
   scrollLeft?: number;
   onMount?(editor: Monaco.editor.IStandaloneCodeEditor): void;
+  onCommand?(command: CodeEditorCommand): void;
 };
 
 type MonacoModule = typeof Monaco;
@@ -142,6 +145,7 @@ export const CodeEditor = forwardRef<CodeEditorHandle, CodeEditorProps>(function
     scrollTop,
     scrollLeft,
     onMount,
+    onCommand,
   },
   ref,
 ) {
@@ -162,6 +166,7 @@ export const CodeEditor = forwardRef<CodeEditorHandle, CodeEditorProps>(function
     scrollLeft,
   });
   const onMountRef = useRef(onMount);
+  const onCommandRef = useRef(onCommand);
   const [loadError, setLoadError] = useState<unknown>(null);
 
   latestPropsRef.current = {
@@ -176,6 +181,7 @@ export const CodeEditor = forwardRef<CodeEditorHandle, CodeEditorProps>(function
     scrollLeft,
   };
   onMountRef.current = onMount;
+  onCommandRef.current = onCommand;
 
   useImperativeHandle(
     ref,
@@ -216,6 +222,7 @@ export const CodeEditor = forwardRef<CodeEditorHandle, CodeEditorProps>(function
         monacoRef.current = monaco;
         modelRef.current = model;
         editorRef.current = editor;
+        registerEditorCommands(monaco, editor, (command) => onCommandRef.current?.(command));
         applyControlledEditorState(editor, currentProps);
         onMountRef.current?.(editor);
       })
@@ -299,6 +306,28 @@ export const CodeEditor = forwardRef<CodeEditorHandle, CodeEditorProps>(function
     </div>
   );
 });
+
+function registerEditorCommands(
+  monaco: MonacoModule,
+  editor: Monaco.editor.IStandaloneCodeEditor,
+  onCommand: (command: CodeEditorCommand) => void,
+) {
+  editor.addCommand(monaco.KeyMod.CtrlCmd | monaco.KeyCode.Enter, () => {
+    onCommand("run");
+  });
+  editor.addCommand(monaco.KeyMod.Shift | monaco.KeyMod.Alt | monaco.KeyCode.KeyF, () => {
+    editor.trigger("keyboard", "editor.action.formatDocument", null);
+    onCommand("format");
+  });
+  editor.addCommand(monaco.KeyMod.CtrlCmd | monaco.KeyCode.Slash, () => {
+    editor.trigger("keyboard", "editor.action.commentLine", null);
+    onCommand("comment");
+  });
+  editor.addCommand(monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyG, () => {
+    editor.trigger("keyboard", "editor.action.gotoLine", null);
+    onCommand("go-to-line");
+  });
+}
 
 function applyControlledEditorState(
   editor: Monaco.editor.IStandaloneCodeEditor,

--- a/apps/web/src/features/editor/__tests__/CodeEditor.test.tsx
+++ b/apps/web/src/features/editor/__tests__/CodeEditor.test.tsx
@@ -30,6 +30,7 @@ const monacoMock = vi.hoisted(() => {
 
   class MockEditor {
     disposed = false;
+    commands: Array<{ keybinding: number; handler: () => void }> = [];
     updateOptions = vi.fn((nextOptions: Record<string, unknown>) => {
       Object.assign(this.options, nextOptions);
     });
@@ -40,6 +41,11 @@ const monacoMock = vi.hoisted(() => {
     setSelection = vi.fn();
     setScrollTop = vi.fn();
     setScrollLeft = vi.fn();
+    trigger = vi.fn();
+    addCommand = vi.fn((keybinding: number, handler: () => void) => {
+      this.commands.push({ keybinding, handler });
+      return `command-${this.commands.length}`;
+    });
 
     constructor(
       public host: HTMLElement,
@@ -92,10 +98,25 @@ const monacoMock = vi.hoisted(() => {
       setTheme,
       setModelLanguage,
     },
+    KeyMod: {
+      CtrlCmd: 1 << 11,
+      Shift: 1 << 10,
+      Alt: 1 << 9,
+    },
+    KeyCode: {
+      Enter: 3,
+      Slash: 85,
+      KeyF: 36,
+      KeyG: 37,
+    },
   };
 });
 
-vi.mock("monaco-editor/esm/vs/editor/editor.api", () => ({ editor: monacoMock.editor }));
+vi.mock("monaco-editor/esm/vs/editor/editor.api", () => ({
+  editor: monacoMock.editor,
+  KeyMod: monacoMock.KeyMod,
+  KeyCode: monacoMock.KeyCode,
+}));
 vi.mock("monaco-editor/esm/vs/basic-languages/javascript/javascript.contribution", () => ({}));
 vi.mock("monaco-editor/esm/vs/basic-languages/typescript/typescript.contribution", () => ({}));
 vi.mock("monaco-editor/esm/vs/language/typescript/monaco.contribution", () => ({}));
@@ -130,6 +151,12 @@ describe("CodeEditor", () => {
   afterEach(() => {
     vi.clearAllMocks();
   });
+
+  function runCommand(editor: { commands: Array<{ keybinding: number; handler: () => void }> }, keybinding: number) {
+    const command = editor.commands.find((candidate) => candidate.keybinding === keybinding);
+    if (!command) throw new Error(`Missing command for keybinding ${keybinding}`);
+    command.handler();
+  }
 
   it("lazy-loads Monaco, creates the editor with initial props, and exposes it", async () => {
     const { CodeEditor } = await import("../CodeEditor");
@@ -248,6 +275,32 @@ describe("CodeEditor", () => {
     });
     expect(editor.setScrollTop).toHaveBeenCalledWith(240);
     expect(editor.setScrollLeft).toHaveBeenCalledWith(16);
+  });
+
+  it("registers common editor shortcut commands", async () => {
+    const { CodeEditor } = await import("../CodeEditor");
+    const onCommand = vi.fn();
+    render(
+      <CodeEditor
+        language="javascript"
+        initialValue="console.log('shortcuts');"
+        fontSize={14}
+        theme="dark"
+        onCommand={onCommand}
+      />,
+    );
+    await waitFor(() => expect(monacoMock.editor.create).toHaveBeenCalledTimes(1));
+    const editor = monacoMock.editors[0];
+
+    runCommand(editor, monacoMock.KeyMod.CtrlCmd | monacoMock.KeyCode.Enter);
+    runCommand(editor, monacoMock.KeyMod.Shift | monacoMock.KeyMod.Alt | monacoMock.KeyCode.KeyF);
+    runCommand(editor, monacoMock.KeyMod.CtrlCmd | monacoMock.KeyCode.Slash);
+    runCommand(editor, monacoMock.KeyMod.CtrlCmd | monacoMock.KeyCode.KeyG);
+
+    expect(onCommand).toHaveBeenCalledWith("run");
+    expect(editor.trigger).toHaveBeenCalledWith("keyboard", "editor.action.formatDocument", null);
+    expect(editor.trigger).toHaveBeenCalledWith("keyboard", "editor.action.commentLine", null);
+    expect(editor.trigger).toHaveBeenCalledWith("keyboard", "editor.action.gotoLine", null);
   });
 
   it("configures JS/TS workers and disposes editor resources on unmount", async () => {

--- a/apps/web/src/features/player/ReplayControls.tsx
+++ b/apps/web/src/features/player/ReplayControls.tsx
@@ -188,7 +188,7 @@ export function ReplayControls({
         </RadixPopover.Root>
       </div>
 
-      <div onMouseEnter={openVolumePopover} onMouseLeave={closeVolumePopover}>
+      <div data-replay-volume-control onMouseEnter={openVolumePopover} onMouseLeave={closeVolumePopover}>
         <RadixPopover.Root open={volumePopoverOpen} onOpenChange={setVolumePopoverOpen}>
           <RadixPopover.Trigger asChild>
             <Toggle
@@ -228,7 +228,10 @@ export function ReplayControls({
                   <RadixSlider.Track className="relative w-1 h-full grow rounded-full bg-border">
                     <RadixSlider.Range className="absolute w-full rounded-full bg-primary" />
                   </RadixSlider.Track>
-                  <RadixSlider.Thumb className="block h-3 w-3 rounded-full bg-foreground shadow-elevation-2 transition-transform duration-150 ease-out-soft hover:scale-110 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus focus-visible:ring-offset-2 focus-visible:ring-offset-background" />
+                  <RadixSlider.Thumb
+                    aria-label="音量"
+                    className="block h-3 w-3 rounded-full bg-foreground shadow-elevation-2 transition-transform duration-150 ease-out-soft hover:scale-110 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+                  />
                 </RadixSlider.Root>
               </div>
             </RadixPopover.Content>

--- a/apps/web/src/features/player/ReplayPage.tsx
+++ b/apps/web/src/features/player/ReplayPage.tsx
@@ -330,17 +330,17 @@ function overlayStateFromEvents(
   transientEvents: RecordingEvent[],
 ): ReplayOverlayState {
   let next = current;
+  let pointer: ReplayOverlayState["pointer"] = null;
+  let pointerClicked = false;
   for (const event of transientEvents) {
     if (event.type === "mouse-move" || event.type === "mouse-click") {
       const { x, y, containerWidth, containerHeight } = event.payload;
-      next = {
-        ...next,
-        pointer: {
-          id: event.id,
-          xPercent: containerWidth > 0 ? (x / containerWidth) * 100 : 0,
-          yPercent: containerHeight > 0 ? (y / containerHeight) * 100 : 0,
-          clicked: event.type === "mouse-click",
-        },
+      pointerClicked ||= event.type === "mouse-click";
+      pointer = {
+        id: event.id,
+        xPercent: containerWidth > 0 ? (x / containerWidth) * 100 : 0,
+        yPercent: containerHeight > 0 ? (y / containerHeight) * 100 : 0,
+        clicked: event.type === "mouse-click",
       };
     }
     if (event.type === "shortcut") {
@@ -352,6 +352,12 @@ function overlayStateFromEvents(
         },
       };
     }
+  }
+  if (pointer) {
+    next = {
+      ...next,
+      pointer: { ...pointer, clicked: pointer.clicked || pointerClicked },
+    };
   }
   return next;
 }

--- a/apps/web/src/features/player/ReplayPage.tsx
+++ b/apps/web/src/features/player/ReplayPage.tsx
@@ -21,6 +21,7 @@ import { createRecordingStore } from "@/features/library/recordingStore";
 import { Toggle } from "@/shared/ui";
 import type {
   PackageWarning,
+  MediaTimelineSegment,
   RecordingEvent,
   RecordingPackageV1,
   ReplaySchedulerState,
@@ -116,16 +117,9 @@ export function ReplayPage() {
   const shortcutTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const currentMedia = pkg?.media ?? null;
   const createRecordedMediaAdapter = useCallback((media: RecordedMedia) => {
+    const segment = recordedMediaSegment(media);
     return createMediaClockAdapter({
-      segments: [
-        {
-          blobId: media.blobId,
-          timelineStartMs: media.timelineOffsetMs,
-          timelineEndMs: media.timelineOffsetMs + media.durationMs,
-          mediaStartMs: 0,
-          mediaEndMs: media.durationMs,
-        },
-      ],
+      segments: segment ? [segment] : [],
       currentTimeProvider: () => recordedMediaVideoRef.current?.currentTime ?? null,
       metadataReadyProvider: () => isMediaMetadataReady(recordedMediaVideoRef.current),
       statusProvider: () => readRecordedMediaStatus(recordedMediaVideoRef.current),
@@ -367,10 +361,24 @@ function timelineToRecordedMediaTime(
   timelineTimeMs: number,
 ): number | null {
   if (!media) return null;
-  const timelineStartMs = media.timelineOffsetMs;
-  const timelineEndMs = media.timelineOffsetMs + media.durationMs;
-  if (timelineTimeMs < timelineStartMs || timelineTimeMs > timelineEndMs) return null;
-  return timelineTimeMs - timelineStartMs;
+  const segment = recordedMediaSegment(media);
+  if (!segment) return null;
+  if (timelineTimeMs < segment.timelineStartMs || timelineTimeMs > segment.timelineEndMs) {
+    return null;
+  }
+  return segment.mediaStartMs + (timelineTimeMs - segment.timelineStartMs);
+}
+
+function recordedMediaSegment(media: RecordedMedia): MediaTimelineSegment | null {
+  const mediaStartMs = Math.max(0, media.timelineOffsetMs);
+  if (mediaStartMs >= media.durationMs) return null;
+  return {
+    blobId: media.blobId,
+    timelineStartMs: 0,
+    timelineEndMs: media.durationMs - mediaStartMs,
+    mediaStartMs,
+    mediaEndMs: media.durationMs,
+  };
 }
 
 function isMediaMetadataReady(video: HTMLVideoElement | null): boolean {
@@ -470,7 +478,10 @@ function ReplayVisualOverlays({
         </div>
       ) : null}
       {showShortcut && state.shortcut ? (
-        <div className="absolute bottom-4 right-4 rounded-md border border-border bg-popover px-3 py-2 font-mono text-sm text-popover-foreground shadow-elevation-2">
+        <div
+          aria-label="回放快捷键"
+          className="absolute bottom-4 right-4 rounded-md border border-border bg-popover px-3 py-2 font-mono text-sm text-popover-foreground shadow-elevation-2"
+        >
           {state.shortcut.label}
         </div>
       ) : null}

--- a/apps/web/src/features/player/__tests__/ReplayPage.test.tsx
+++ b/apps/web/src/features/player/__tests__/ReplayPage.test.tsx
@@ -318,6 +318,58 @@ describe("ReplayPage", () => {
     expect(screen.getByText("Comment")).toBeInTheDocument();
   });
 
+  it("keeps click pulse when a later pointer move arrives in the same scheduler tick", async () => {
+    const { ReplayPage } = await import("../ReplayPage");
+
+    render(<ReplayPage />);
+    await waitFor(() => expect(replayPageMock.scheduler.load).toHaveBeenCalledWith(replayPageMock.packageData));
+
+    act(() => {
+      replayPageMock.onTick?.(
+        {
+          editor: {
+            code: "",
+            language: "javascript",
+            cursor: null,
+            selection: null,
+            scrollTop: 0,
+            scrollLeft: 0,
+            fontSize: 14,
+            theme: "dark",
+          },
+          pointer: null,
+          media: { microphoneEnabled: true, cameraEnabled: true, cameraPosition: { x: 0.8, y: 0.75 } },
+          runtime: { status: "idle", stdout: [], stderr: [], previewHtml: null, errorMessage: null },
+        },
+        [
+          {
+            id: "click-1",
+            seq: 1,
+            timestampMs: 100,
+            source: "pointer",
+            track: "ui",
+            type: "mouse-click",
+            payload: { x: 30, y: 16, containerWidth: 100, containerHeight: 80, button: 0 },
+          },
+          {
+            id: "move-2",
+            seq: 2,
+            timestampMs: 120,
+            source: "pointer",
+            track: "ui",
+            type: "mouse-move",
+            payload: { x: 70, y: 40, containerWidth: 100, containerHeight: 80 },
+          },
+        ],
+        120,
+      );
+    });
+
+    const pointer = screen.getByLabelText("回放鼠标位置");
+    expect(pointer).toHaveStyle({ left: "70%", top: "50%" });
+    expect(pointer.querySelector(".animate-ping")).toBeInTheDocument();
+  });
+
   it("defaults display toggles on and hides replay layers when toggled off", async () => {
     const { ReplayPage } = await import("../ReplayPage");
 

--- a/apps/web/src/features/player/__tests__/ReplayPage.test.tsx
+++ b/apps/web/src/features/player/__tests__/ReplayPage.test.tsx
@@ -5,6 +5,7 @@ import type { CodeEditorProps } from "@/features/editor/CodeEditor";
 import type { PreviewPaneProps } from "@/features/runtime-preview/PreviewPane";
 import type {
   RecordingEvent,
+  MediaClockAdapter,
   RecordingPackageV1,
   RecordingRepository,
   ReplaySchedulerState,
@@ -313,6 +314,7 @@ describe("ReplayPage", () => {
     });
 
     expect(screen.getByLabelText("回放鼠标位置")).toBeInTheDocument();
+    expect(screen.getByLabelText("回放快捷键")).toHaveTextContent("Comment");
     expect(screen.getByText("Comment")).toBeInTheDocument();
   });
 
@@ -463,6 +465,43 @@ describe("ReplayPage", () => {
 
     expect(adapterAttachOrder).toBeLessThan(loadOrder);
     pause.mockRestore();
+  });
+
+  it("maps recording media offset as a media-time offset on the shared timeline", async () => {
+    const originalMedia = replayPageMock.packageData.media;
+    replayPageMock.packageData.media = {
+      ...originalMedia!,
+      durationMs: 120_000,
+      timelineOffsetMs: 5_000,
+    };
+    const pause = vi.spyOn(HTMLMediaElement.prototype, "pause").mockImplementation(() => {});
+    const { ReplayPage } = await import("../ReplayPage");
+
+    try {
+      render(<ReplayPage />);
+
+      await waitFor(() =>
+        expect(replayPageMock.scheduler.setMediaAdapter.mock.calls.some(([adapter]) => adapter)).toBe(
+          true,
+        ),
+      );
+      const adapter = replayPageMock.scheduler.setMediaAdapter.mock.calls.find(
+        ([candidate]) => candidate,
+      )?.[0] as MediaClockAdapter | undefined;
+
+      expect(adapter?.segments[0]).toEqual({
+        blobId: "blob-1",
+        timelineStartMs: 0,
+        timelineEndMs: 115_000,
+        mediaStartMs: 5_000,
+        mediaEndMs: 120_000,
+      });
+      expect(adapter?.timelineToMediaTime(42_000)).toBe(47_000);
+      expect(adapter?.mediaToTimelineTime(47)).toBe(42_000);
+    } finally {
+      replayPageMock.packageData.media = originalMedia;
+      pause.mockRestore();
+    }
   });
 
   it("keeps the scheduler subscription alive when the replay id changes", async () => {

--- a/apps/web/src/features/player/__tests__/replayScheduler.test.ts
+++ b/apps/web/src/features/player/__tests__/replayScheduler.test.ts
@@ -660,8 +660,33 @@ describe("createReplayScheduler", () => {
 
     await scheduler.seek(1_850);
 
-    expect(transientTicks.at(-1)?.map((event) => event.id)).toEqual(["s-2", "click-3"]);
+    expect(transientTicks.at(-1)?.map((event) => event.id)).toEqual(["move-1", "s-2", "click-3"]);
     expect(scheduler.getStableState().editor.code).toBe("after-stable");
+  });
+
+  it("keeps recent click and later pointer move overlays after seek", async () => {
+    const transientTicks: RecordingEvent[][] = [];
+    const scheduler = createReplayScheduler({
+      tickStrategy: { start: vi.fn(), stop: vi.fn() },
+      onTick: (_state, transientEvents) => {
+        transientTicks.push(transientEvents);
+      },
+    });
+    await scheduler.load(
+      makePkg(
+        [
+          pointerClick(1, 1_000),
+          pointerMove(2, 1_250, 70, 40),
+          content(3, 1_600, "after-stable"),
+        ],
+        [],
+        5_000,
+      ),
+    );
+
+    await scheduler.seek(1_450);
+
+    expect(transientTicks.at(-1)?.map((event) => event.id)).toEqual(["click-1", "move-2"]);
   });
 
   it("handles rejected async media operations during ready ticks", async () => {

--- a/apps/web/src/features/player/__tests__/replayScheduler.test.ts
+++ b/apps/web/src/features/player/__tests__/replayScheduler.test.ts
@@ -47,6 +47,30 @@ function shortcut(seq: number, t: number): RecordingEvent {
   };
 }
 
+function pointerMove(seq: number, t: number, x = 40, y = 20): RecordingEvent {
+  return {
+    id: `move-${seq}`,
+    seq,
+    timestampMs: t,
+    source: "pointer",
+    track: "ui",
+    type: "mouse-move",
+    payload: { x, y, containerWidth: 100, containerHeight: 80 },
+  };
+}
+
+function pointerClick(seq: number, t: number, x = 50, y = 25): RecordingEvent {
+  return {
+    id: `click-${seq}`,
+    seq,
+    timestampMs: t,
+    source: "pointer",
+    track: "ui",
+    type: "mouse-click",
+    payload: { x, y, containerWidth: 100, containerHeight: 80, button: 0 },
+  };
+}
+
 function mediaWarning(seq: number, t: number): RecordingEvent {
   return {
     id: `e-${seq}`,
@@ -611,6 +635,33 @@ describe("createReplayScheduler", () => {
 
     expect(latest().status).toBe("paused");
     expect(scheduler.getStableState().editor.code).toBe("paused-seek");
+  });
+
+  it("replays recent transient pointer and shortcut overlays after seek", async () => {
+    const transientTicks: RecordingEvent[][] = [];
+    const scheduler = createReplayScheduler({
+      tickStrategy: { start: vi.fn(), stop: vi.fn() },
+      onTick: (_state, transientEvents) => {
+        transientTicks.push(transientEvents);
+      },
+    });
+    await scheduler.load(
+      makePkg(
+        [
+          pointerMove(1, 900),
+          shortcut(2, 1_000),
+          pointerClick(3, 1_400),
+          content(4, 1_600, "after-stable"),
+        ],
+        [],
+        5_000,
+      ),
+    );
+
+    await scheduler.seek(1_850);
+
+    expect(transientTicks.at(-1)?.map((event) => event.id)).toEqual(["click-3", "s-2"]);
+    expect(scheduler.getStableState().editor.code).toBe("after-stable");
   });
 
   it("handles rejected async media operations during ready ticks", async () => {

--- a/apps/web/src/features/player/__tests__/replayScheduler.test.ts
+++ b/apps/web/src/features/player/__tests__/replayScheduler.test.ts
@@ -660,7 +660,7 @@ describe("createReplayScheduler", () => {
 
     await scheduler.seek(1_850);
 
-    expect(transientTicks.at(-1)?.map((event) => event.id)).toEqual(["click-3", "s-2"]);
+    expect(transientTicks.at(-1)?.map((event) => event.id)).toEqual(["s-2", "click-3"]);
     expect(scheduler.getStableState().editor.code).toBe("after-stable");
   });
 

--- a/apps/web/src/features/player/replayScheduler.ts
+++ b/apps/web/src/features/player/replayScheduler.ts
@@ -307,18 +307,12 @@ export function createReplayScheduler(options: ReplaySchedulerOptions = {}): Rep
       targetMs,
       SEEK_CLICK_WINDOW_MS,
     );
-    const latestPointer =
-      latestMove && latestClick
-        ? latestMove.timestampMs >= latestClick.timestampMs
-          ? latestMove
-          : latestClick
-        : latestMove ?? latestClick;
     const latestShortcut = latestEventInWindow(
       index.eventsByType.get("shortcut") ?? [],
       targetMs,
       SEEK_SHORTCUT_WINDOW_MS,
     );
-    return [latestPointer, latestShortcut]
+    return [latestMove, latestClick, latestShortcut]
       .filter((event): event is RecordingEvent => Boolean(event))
       .sort((left, right) => left.timestampMs - right.timestampMs || left.seq - right.seq);
   };

--- a/apps/web/src/features/player/replayScheduler.ts
+++ b/apps/web/src/features/player/replayScheduler.ts
@@ -318,7 +318,9 @@ export function createReplayScheduler(options: ReplaySchedulerOptions = {}): Rep
       targetMs,
       SEEK_SHORTCUT_WINDOW_MS,
     );
-    return [latestPointer, latestShortcut].filter((event): event is RecordingEvent => Boolean(event));
+    return [latestPointer, latestShortcut]
+      .filter((event): event is RecordingEvent => Boolean(event))
+      .sort((left, right) => left.timestampMs - right.timestampMs || left.seq - right.seq);
   };
 
   const tickOnce = () => {

--- a/apps/web/src/features/player/replayScheduler.ts
+++ b/apps/web/src/features/player/replayScheduler.ts
@@ -45,6 +45,9 @@ const DEFAULT_RAF_INTERVAL_MS = 1000 / 60;
 const MEDIA_DRIFT_THRESHOLD_MS = 250;
 const MEDIA_BUFFERING_THRESHOLD_MS = 500;
 const MEDIA_FALLBACK_THRESHOLD_MS = 2000;
+const SEEK_POINTER_WINDOW_MS = 1200;
+const SEEK_SHORTCUT_WINDOW_MS = 1200;
+const SEEK_CLICK_WINDOW_MS = 500;
 
 export function defaultTickStrategy(): TickStrategy {
   let handle: number | null = null;
@@ -273,6 +276,51 @@ export function createReplayScheduler(options: ReplaySchedulerOptions = {}): Rep
     return { transientEvents, lastSeq };
   };
 
+  const latestEventInWindow = (
+    events: RecordingEvent[],
+    targetMs: number,
+    windowMs: number,
+  ): RecordingEvent | null => {
+    let latest: RecordingEvent | null = null;
+    const minTimeMs = Math.max(0, targetMs - windowMs);
+    for (const event of events) {
+      if (event.timestampMs < minTimeMs || event.timestampMs > targetMs) continue;
+      if (
+        !latest ||
+        event.timestampMs > latest.timestampMs ||
+        (event.timestampMs === latest.timestampMs && event.seq > latest.seq)
+      ) {
+        latest = event;
+      }
+    }
+    return latest;
+  };
+
+  const transientEventsForSeek = (targetMs: number): RecordingEvent[] => {
+    const latestMove = latestEventInWindow(
+      index.eventsByType.get("mouse-move") ?? [],
+      targetMs,
+      SEEK_POINTER_WINDOW_MS,
+    );
+    const latestClick = latestEventInWindow(
+      index.eventsByType.get("mouse-click") ?? [],
+      targetMs,
+      SEEK_CLICK_WINDOW_MS,
+    );
+    const latestPointer =
+      latestMove && latestClick
+        ? latestMove.timestampMs >= latestClick.timestampMs
+          ? latestMove
+          : latestClick
+        : latestMove ?? latestClick;
+    const latestShortcut = latestEventInWindow(
+      index.eventsByType.get("shortcut") ?? [],
+      targetMs,
+      SEEK_SHORTCUT_WINDOW_MS,
+    );
+    return [latestPointer, latestShortcut].filter((event): event is RecordingEvent => Boolean(event));
+  };
+
   const tickOnce = () => {
     if (!pkg) return;
     const frame = resolveFrame();
@@ -383,7 +431,7 @@ export function createReplayScheduler(options: ReplaySchedulerOptions = {}): Rep
         driftMs: 0,
       });
       if (shouldResumePlayback) ensureDriving();
-      options.onTick?.(stableState, [], clamped);
+      options.onTick?.(stableState, transientEventsForSeek(clamped), clamped);
     },
     setRate(rate: ReplayPlaybackRate) {
       clock.setRate(rate);

--- a/apps/web/src/features/recorder/RecorderPage.tsx
+++ b/apps/web/src/features/recorder/RecorderPage.tsx
@@ -636,6 +636,9 @@ export function RecorderPage() {
             fontSize={editorFontSize}
             theme={theme.resolved}
             readOnly={controllerState.status === "paused"}
+            onCommand={(command) => {
+              if (command === "run") void handleRun();
+            }}
           />
           <CameraPreview
             stream={mediaStream}

--- a/apps/web/src/features/recorder/__tests__/RecorderPage.test.tsx
+++ b/apps/web/src/features/recorder/__tests__/RecorderPage.test.tsx
@@ -422,6 +422,26 @@ describe("RecorderPage", () => {
     expect(output).toHaveTextContent("1");
   });
 
+  it("runs code from the editor run command shortcut", async () => {
+    const { RecorderPage } = await import("../RecorderPage");
+    recorderPageMock.editorValue.current = "console.log('shortcut-run');";
+
+    render(<RecorderPage />);
+    await waitFor(() => expect(recorderPageMock.codeEditorProps?.onCommand).toBeTypeOf("function"));
+
+    await act(async () => {
+      recorderPageMock.codeEditorProps?.onCommand?.("run");
+    });
+
+    await waitFor(() =>
+      expect(recorderPageMock.trigger).toHaveBeenCalledWith({
+        language: "javascript",
+        source: "console.log('shortcut-run');",
+      }),
+    );
+    expect(recorderPageMock.flushPending).toHaveBeenCalledTimes(1);
+  });
+
   it("requests browser media permissions from the setup toolbar and refreshes devices", async () => {
     recorderPageMock.devices.requestPermission.mockResolvedValue("granted");
     const { RecorderPage } = await import("../RecorderPage");


### PR DESCRIPTION
## Issue 参考

Refs #2（总控 issue，不在本 PR 中关闭）。

## 变更说明

- 补齐 P0 常见编辑器快捷键：Go to Line 录制识别，Monaco 内注册运行、格式化、注释、跳转命令，并让 `Ctrl/Cmd+Enter` 真实触发运行。
- 修复回放 seek 后瞬态层恢复：跳转到快捷键/鼠标事件附近时重新展示快捷键 Badge 和鼠标激光笔/点击态；根据 repo-guard 反馈，恢复事件按 `timestampMs/seq` 保持时间线顺序，并在 click 后发生 move 的窗口内同时保留点击态和最新鼠标位置。
- 对齐技术方案中的媒体时间轴语义：`timelineOffsetMs` 作为媒体内部 offset，事件事实时间轴仍从 0 开始。
- 补充回放控件可访问与可测试属性：快捷键 Badge、音量滑杆、静音/音量操作覆盖到 e2e。
- 扩展测试覆盖：快捷键、鼠标、选区、回放 seek 浮层、媒体时间轴、静音和音量控件。

## 影响范围

- 录制主流程：编辑器命令接线、运行快捷键、格式化/注释/跳转快捷键识别。
- 回放主流程：seek 后短时恢复鼠标/点击/快捷键浮层；同一 seek 窗口内 click 与后续 move 会合并为“最新位置 + 点击态”。
- 媒体回放：录制媒体 offset 映射语义调整到 `docs/技术方案.md` 的模型。
- 测试与质量门禁：补充单测、组件测试和 e2e 覆盖；未修改 `docs/progress.json` 或 `docs/progress.md`。

## GitNexus 影响分析摘要

- 风险等级: CRITICAL
- 关键骨架变更: `apps/web/src/features/player/replayScheduler.ts` seek 后瞬态事件恢复；同时触达 `CodeEditor` / `ReplayPage` 的快捷键接线与媒体时间轴映射。
- GitNexus 影响面: detect_changes 报告完整 P0 diff 曾为 12 changed files、24 affected processes；repo-guard 后续 click/move 补丁为 medium，集中在 `createReplayScheduler` 与 `overlayStateFromEvents`；impact(createReplayScheduler) 为 LOW，仅直接影响 `ReplayPage` scheduler；impact(overlayStateFromEvents) 为 LOW，仅直接影响 `ReplayPage` onTick。
- 验证结果: `npm run quality:precommit` passed；`npm run e2e:web` passed；`npm run quality:local` passed；repo-guard 后续补丁已追加命中单测 `npm run test -w apps/web -- replayScheduler ReplayPage` passed，并重新运行 `npm run quality:precommit` 与 `npm run e2e:web` passed。

## 自检

- [x] 本 PR 仅 `Refs #2`，不关闭总控 Issue
- [x] 未修改 `docs/progress.json` 或 `docs/progress.md`
- [x] 已运行 `npm run quality:local`，并在 repo-guard 修复后重新运行 `npm run quality:precommit` / `npm run e2e:web`
- [x] 如果改动关键骨架，已补充契约测试并填写 GitNexus 影响分析摘要
- [ ] 已邀请至少一名非作者同学 CR