### PR TITLE
fix: stabilize replay seek cursor e2e

### DIFF
--- a/apps/web/e2e/record-replay.spec.ts
+++ b/apps/web/e2e/record-replay.spec.ts
@@ -224,19 +224,28 @@ async function readStoredRecording(page: Page, recordingId: string): Promise<Sto
 
 async function seekByProgress(page: Page, targetMs: number, durationMs: number): Promise<void> {
   const percent = durationMs > 0 ? Math.max(0, Math.min(targetMs / durationMs, 1)) : 0;
-  const sliderThumb = page.locator('[aria-label="播放进度"]').first();
+  const targetPercent = Math.round(percent * 1000) / 10;
+  const progressControl = page.locator("[data-replay-progress-control]");
+  const sliderRoot = progressControl.locator('[aria-label="播放进度"]').first();
+  const sliderThumb = progressControl.getByRole("slider", { name: "播放进度" });
+
   await expect(sliderThumb).toBeEnabled();
-  const box = await sliderThumb.evaluate((thumb) => {
-    const root = thumb.parentElement;
-    const rect = root?.getBoundingClientRect();
-    if (!rect) return null;
-    return {
-      x: rect.x,
-      y: rect.y,
-      width: rect.width,
-      height: rect.height,
-    };
+  const rootBox = await sliderRoot.boundingBox();
+  const thumbBox = await sliderThumb.boundingBox();
+  if (!rootBox || !thumbBox) throw new Error("Replay progress slider is not visible");
+
+  await page.mouse.move(thumbBox.x + thumbBox.width / 2, thumbBox.y + thumbBox.height / 2);
+  await page.mouse.down();
+  await page.mouse.move(rootBox.x + rootBox.width * percent, rootBox.y + rootBox.height / 2, {
+    steps: 4,
   });
-  if (!box) throw new Error("Replay progress slider is not visible");
-  await page.mouse.click(box.x + box.width * percent, box.y + box.height / 2);
+  await page.mouse.up();
+
+  await expect
+    .poll(async () => {
+      const value = Number(await sliderThumb.getAttribute("aria-valuenow"));
+      return Math.round(value * 10) / 10;
+    })
+    .toBe(targetPercent);
+  await expect(sliderThumb).toBeEnabled();
 }

--- a/apps/web/src/features/player/ReplayControls.tsx
+++ b/apps/web/src/features/player/ReplayControls.tsx
@@ -124,7 +124,7 @@ export function ReplayControls({
         </span>
       </div>
 
-      <div className="flex-1 min-w-[120px]">
+      <div className="flex-1 min-w-[120px]" data-replay-progress-control>
         <Slider
           value={currentProgressPercent}
           min={0}

--- a/apps/web/src/features/player/ReplayPage.tsx
+++ b/apps/web/src/features/player/ReplayPage.tsx
@@ -413,7 +413,10 @@ function scheduleOverlayCleanup(
   if (hasPointer) {
     if (pointerTimerRef.current) clearTimeout(pointerTimerRef.current);
     pointerTimerRef.current = setTimeout(() => {
-      setOverlayState((current) => ({ ...current, pointer: null }));
+      setOverlayState((current) => ({
+        ...current,
+        pointer: current.pointer ? { ...current.pointer, clicked: false } : null,
+      }));
     }, TRANSIENT_OVERLAY_TTL_MS);
   }
   if (hasShortcut) {

--- a/apps/web/src/features/player/__tests__/ReplayPage.test.tsx
+++ b/apps/web/src/features/player/__tests__/ReplayPage.test.tsx
@@ -370,6 +370,62 @@ describe("ReplayPage", () => {
     expect(pointer.querySelector(".animate-ping")).toBeInTheDocument();
   });
 
+  it("keeps the latest pointer position after the click pulse expires", async () => {
+    const { ReplayPage } = await import("../ReplayPage");
+
+    try {
+      render(<ReplayPage />);
+      await waitFor(() => expect(replayPageMock.scheduler.load).toHaveBeenCalledWith(replayPageMock.packageData));
+
+      vi.useFakeTimers();
+      act(() => {
+        replayPageMock.onTick?.(
+          {
+            editor: {
+              code: "",
+              language: "javascript",
+              cursor: null,
+              selection: null,
+              scrollTop: 0,
+              scrollLeft: 0,
+              fontSize: 14,
+              theme: "dark",
+            },
+            pointer: null,
+            media: { microphoneEnabled: true, cameraEnabled: true, cameraPosition: { x: 0.8, y: 0.75 } },
+            runtime: { status: "idle", stdout: [], stderr: [], previewHtml: null, errorMessage: null },
+          },
+          [
+            {
+              id: "click-ttl",
+              seq: 1,
+              timestampMs: 100,
+              source: "pointer",
+              track: "ui",
+              type: "mouse-click",
+              payload: { x: 30, y: 16, containerWidth: 100, containerHeight: 80, button: 0 },
+            },
+          ],
+          100,
+        );
+      });
+
+      const pointer = screen.getByLabelText("回放鼠标位置");
+      expect(pointer).toHaveStyle({ left: "30%", top: "20%" });
+      expect(pointer.querySelector(".animate-ping")).toBeInTheDocument();
+
+      act(() => {
+        vi.advanceTimersByTime(901);
+      });
+
+      const retainedPointer = screen.getByLabelText("回放鼠标位置");
+      expect(retainedPointer).toHaveStyle({ left: "30%", top: "20%" });
+      expect(retainedPointer.querySelector(".animate-ping")).not.toBeInTheDocument();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("defaults display toggles on and hides replay layers when toggled off", async () => {
     const { ReplayPage } = await import("../ReplayPage");
 

--- a/apps/web/src/shared/ui/Slider.tsx
+++ b/apps/web/src/shared/ui/Slider.tsx
@@ -41,6 +41,7 @@ export const Slider = forwardRef<HTMLSpanElement, SliderProps>(function Slider(
         <RadixSlider.Range className="absolute h-full rounded-full bg-primary" />
       </RadixSlider.Track>
       <RadixSlider.Thumb
+        aria-label={ariaLabel}
         className={cn(
           "block rounded-full bg-foreground shadow-elevation-2 transition-transform duration-150 ease-out-soft",
           variant === "compact" ? "h-3 w-3" : "h-4 w-4",

--- a/apps/web/src/shared/ui/__tests__/Slider.test.tsx
+++ b/apps/web/src/shared/ui/__tests__/Slider.test.tsx
@@ -1,0 +1,19 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { Slider } from "../Slider";
+
+describe("Slider", () => {
+  it("labels the interactive slider thumb", () => {
+    render(
+      <Slider
+        value={25}
+        min={0}
+        max={100}
+        ariaLabel="播放进度"
+        onChange={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByRole("slider", { name: "播放进度" })).toBeEnabled();
+  });
+});


### PR DESCRIPTION
## 关联 Issue

Refs #2（总控 issue，不在本 PR 中关闭）

## 变更说明

- 让 shared Slider 的交互 thumb 继承 `ariaLabel`，E2E 可以稳定定位真正可拖动的 slider。
- 为回放进度控件增加 `data-replay-progress-control` 测试作用域，并把 seek helper 改为拖拽 thumb 后等待 `aria-valuenow` 落地。
- 回放鼠标 overlay 的 TTL 清理只收起 click pulse，不清空最近鼠标位置，保证 seek 后鼠标光标持续展示。
- 增加 Slider 可访问名称单测和 ReplayPage 鼠标位置保持回归测试。

## 影响范围

- 运行时影响集中在 Player 回放页：`ReplayControls` 的进度条标记、`Slider` thumb `aria-label`、`ReplayPage` overlay cleanup。
- 不改录制 schema、存储、调度器 seek 算法或媒体同步逻辑。
- GitNexus：compare 风险 medium（受 `ReplayControls` 流程牵引）；逐点 impact 为 LOW：`Slider -> ReplayControls -> ReplayPage`，`scheduleOverlayCleanup` 仅 `onTick` 直接调用，E2E helper 只影响 `record-replay.spec.ts`。
- 与 PRD/技术方案对齐：P0 要求 seek 后同步展示鼠标位置/激光笔与进度条 seek，本 PR 保持该行为。

## 验证

- `npm run quality:predev`
- `npm run agent:bootstrap`
- `npm run test:web -- Slider.test.tsx --runInBand`（先 RED 后 GREEN）
- `npm run test:web -- ReplayControls.test.tsx --runInBand`
- `npm run test:web -- ReplayPage.test.tsx --runInBand`
- `npm run e2e -w apps/web -- e2e/record-replay.spec.ts --repeat-each=10 --workers=1 --reporter=line`
- `npm run quality:local`
- precommit hook: `quality:precommit`
- prepush hook: `quality:local`

## 自检

- [x] 不关闭 #2；本 PR 不作为独立 issue 交付
- [x] 未修改 `docs/progress.json` 或 `docs/progress.md`
- [x] 已运行 `npm run quality:local`
- [x] 已补充回归测试并填写 GitNexus 影响分析摘要
- [ ] 等待 GitHub Actions、repo-guard、Copilot 和 CR 反馈