### PR TITLE
fix: restore editor shortcuts

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,8 +1,12 @@
-## 关联 Issue
+## 关联
 
-Closes #
+Refs #2（总控 issue，不在本 PR 中关闭）
 
-## 变更说明
+## 改动点
+
+-
+
+## 影响范围
 
 -
 
@@ -15,8 +19,8 @@ Closes #
 
 ## 自检
 
-- [ ] PR author 是该 Issue 的认领者
 - [ ] 未修改 `docs/progress.json` 或 `docs/progress.md`
 - [ ] 已运行 `npm run quality:local`，或说明无法运行的原因
+- [ ] 已说明改动点和影响范围
 - [ ] 如果改动关键骨架，已补充契约测试并填写 GitNexus 影响分析摘要
 - [ ] 已邀请至少一名非作者同学 CR

--- a/apps/web/e2e/editor-shortcuts.spec.ts
+++ b/apps/web/e2e/editor-shortcuts.spec.ts
@@ -1,0 +1,41 @@
+import { expect, test, type Page } from "@playwright/test";
+
+const PRIMARY_MODIFIER = process.platform === "darwin" ? "Meta" : "Control";
+
+test("primary slash comments the current editor line", async ({ page }) => {
+  await openRecorder(page);
+
+  await page.keyboard.type("const commented = true;");
+  await page.keyboard.press(`${PRIMARY_MODIFIER}+/`);
+
+  await expect(editorLines(page)).toContainText(/\/\/[\s\u00a0]*const[\s\u00a0]+commented[\s\u00a0]*=[\s\u00a0]*true;/);
+});
+
+test("shift alt f formats the current editor document", async ({ page }) => {
+  await openRecorder(page);
+
+  await page.keyboard.type("function demo(){return 1;}");
+  await page.keyboard.press("Shift+Alt+F");
+
+  await expect(editorLines(page)).toContainText("function demo() {");
+  await expect(editorLines(page)).toContainText("return 1;");
+});
+
+test("primary g opens Monaco go to line", async ({ page }) => {
+  await openRecorder(page);
+
+  await page.keyboard.type("const first = 1;\nconst second = 2;");
+  await page.keyboard.press(`${PRIMARY_MODIFIER}+G`);
+
+  await expect(page.locator(".quick-input-widget")).toBeVisible();
+});
+
+async function openRecorder(page: Page): Promise<void> {
+  await page.goto("/record", { waitUntil: "domcontentloaded" });
+  await expect(page.locator("[data-code-editor] .monaco-editor")).toBeVisible();
+  await page.locator("[data-code-editor] .monaco-editor").click();
+}
+
+function editorLines(page: Page) {
+  return page.locator("[data-code-editor] .view-lines");
+}

--- a/apps/web/src/features/editor/CodeEditor.tsx
+++ b/apps/web/src/features/editor/CodeEditor.tsx
@@ -121,6 +121,9 @@ async function loadMonaco() {
     await Promise.all([
       import("monaco-editor/esm/vs/basic-languages/javascript/javascript.contribution"),
       import("monaco-editor/esm/vs/basic-languages/typescript/typescript.contribution"),
+      import("monaco-editor/esm/vs/editor/contrib/comment/browser/comment"),
+      import("monaco-editor/esm/vs/editor/contrib/format/browser/formatActions"),
+      import("monaco-editor/esm/vs/editor/standalone/browser/quickAccess/standaloneGotoLineQuickAccess"),
       import("monaco-editor/esm/vs/language/typescript/monaco.contribution"),
     ]);
     defineThemes(monaco);
@@ -308,25 +311,64 @@ export const CodeEditor = forwardRef<CodeEditorHandle, CodeEditorProps>(function
 });
 
 function registerEditorCommands(
-  monaco: MonacoModule,
+  _monaco: MonacoModule,
   editor: Monaco.editor.IStandaloneCodeEditor,
   onCommand: (command: CodeEditorCommand) => void,
 ) {
-  editor.addCommand(monaco.KeyMod.CtrlCmd | monaco.KeyCode.Enter, () => {
-    onCommand("run");
+  editor.onKeyDown((event) => {
+    const browserEvent = event.browserEvent;
+    if (browserEvent.isComposing || browserEvent.repeat) return;
+
+    if (isPrimaryShortcut(event, "Enter")) {
+      consumeShortcut(event);
+      onCommand("run");
+      return;
+    }
+
+    if (isFormatShortcut(event)) {
+      consumeShortcut(event);
+      editor.trigger("keyboard", "editor.action.formatDocument", null);
+      onCommand("format");
+      return;
+    }
+
+    if (isPrimaryShortcut(event, "/")) {
+      consumeShortcut(event);
+      editor.trigger("keyboard", "editor.action.commentLine", null);
+      onCommand("comment");
+      return;
+    }
+
+    if (isPrimaryShortcut(event, "g")) {
+      consumeShortcut(event);
+      editor.trigger("keyboard", "editor.action.gotoLine", null);
+      onCommand("go-to-line");
+    }
   });
-  editor.addCommand(monaco.KeyMod.Shift | monaco.KeyMod.Alt | monaco.KeyCode.KeyF, () => {
-    editor.trigger("keyboard", "editor.action.formatDocument", null);
-    onCommand("format");
-  });
-  editor.addCommand(monaco.KeyMod.CtrlCmd | monaco.KeyCode.Slash, () => {
-    editor.trigger("keyboard", "editor.action.commentLine", null);
-    onCommand("comment");
-  });
-  editor.addCommand(monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyG, () => {
-    editor.trigger("keyboard", "editor.action.gotoLine", null);
-    onCommand("go-to-line");
-  });
+}
+
+function isPrimaryShortcut(event: Monaco.IKeyboardEvent, key: string): boolean {
+  return (event.metaKey || event.ctrlKey) && !event.shiftKey && !event.altKey && matchesKey(event, key);
+}
+
+function isFormatShortcut(event: Monaco.IKeyboardEvent): boolean {
+  return !event.metaKey && !event.ctrlKey && event.shiftKey && event.altKey && matchesKey(event, "f");
+}
+
+function matchesKey(event: Monaco.IKeyboardEvent, key: string): boolean {
+  const expected = key.toLowerCase();
+  const actualKey = event.browserEvent.key.toLowerCase();
+  const expectedCode = `key${expected}`;
+  return (
+    actualKey === expected
+    || event.code.toLowerCase() === expectedCode
+    || event.browserEvent.code.toLowerCase() === expectedCode
+  );
+}
+
+function consumeShortcut(event: Monaco.IKeyboardEvent) {
+  event.preventDefault();
+  event.stopPropagation();
 }
 
 function applyControlledEditorState(

--- a/apps/web/src/features/editor/__tests__/CodeEditor.test.tsx
+++ b/apps/web/src/features/editor/__tests__/CodeEditor.test.tsx
@@ -3,6 +3,17 @@ import { createRef } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { CodeEditorHandle } from "../CodeEditor";
 
+type MockKeyboardEvent = {
+  browserEvent: { key: string; code: string; isComposing: boolean; repeat: boolean };
+  code: string;
+  ctrlKey: boolean;
+  metaKey: boolean;
+  shiftKey: boolean;
+  altKey: boolean;
+  preventDefault: ReturnType<typeof vi.fn>;
+  stopPropagation: ReturnType<typeof vi.fn>;
+};
+
 const monacoMock = vi.hoisted(() => {
   class MockEditorWorker {}
   class MockTsWorker {}
@@ -31,6 +42,7 @@ const monacoMock = vi.hoisted(() => {
   class MockEditor {
     disposed = false;
     commands: Array<{ keybinding: number; handler: () => void }> = [];
+    keyboardListeners: Array<(event: MockKeyboardEvent) => void> = [];
     updateOptions = vi.fn((nextOptions: Record<string, unknown>) => {
       Object.assign(this.options, nextOptions);
     });
@@ -45,6 +57,14 @@ const monacoMock = vi.hoisted(() => {
     addCommand = vi.fn((keybinding: number, handler: () => void) => {
       this.commands.push({ keybinding, handler });
       return `command-${this.commands.length}`;
+    });
+    onKeyDown = vi.fn((listener: (event: MockKeyboardEvent) => void) => {
+      this.keyboardListeners.push(listener);
+      return {
+        dispose: () => {
+          this.keyboardListeners = this.keyboardListeners.filter((candidate) => candidate !== listener);
+        },
+      };
     });
 
     constructor(
@@ -119,6 +139,9 @@ vi.mock("monaco-editor/esm/vs/editor/editor.api", () => ({
 }));
 vi.mock("monaco-editor/esm/vs/basic-languages/javascript/javascript.contribution", () => ({}));
 vi.mock("monaco-editor/esm/vs/basic-languages/typescript/typescript.contribution", () => ({}));
+vi.mock("monaco-editor/esm/vs/editor/contrib/comment/browser/comment", () => ({}));
+vi.mock("monaco-editor/esm/vs/editor/contrib/format/browser/formatActions", () => ({}));
+vi.mock("monaco-editor/esm/vs/editor/standalone/browser/quickAccess/standaloneGotoLineQuickAccess", () => ({}));
 vi.mock("monaco-editor/esm/vs/language/typescript/monaco.contribution", () => ({}));
 vi.mock("monaco-editor/esm/vs/editor/editor.worker?worker", () => ({
   get default() {
@@ -152,10 +175,27 @@ describe("CodeEditor", () => {
     vi.clearAllMocks();
   });
 
-  function runCommand(editor: { commands: Array<{ keybinding: number; handler: () => void }> }, keybinding: number) {
-    const command = editor.commands.find((candidate) => candidate.keybinding === keybinding);
-    if (!command) throw new Error(`Missing command for keybinding ${keybinding}`);
-    command.handler();
+  function pressEditorShortcut(
+    editor: { keyboardListeners: Array<(event: MockKeyboardEvent) => void> },
+    event: Partial<MockKeyboardEvent> & { key: string },
+  ) {
+    const keyboardEvent: MockKeyboardEvent = {
+      browserEvent: {
+        key: event.key,
+        code: event.browserEvent?.code ?? event.code ?? (event.key.length === 1 ? `Key${event.key.toUpperCase()}` : event.key),
+        isComposing: false,
+        repeat: false,
+      },
+      code: event.code ?? (event.key.length === 1 ? `Key${event.key.toUpperCase()}` : event.key),
+      ctrlKey: event.ctrlKey ?? false,
+      metaKey: event.metaKey ?? false,
+      shiftKey: event.shiftKey ?? false,
+      altKey: event.altKey ?? false,
+      preventDefault: vi.fn(),
+      stopPropagation: vi.fn(),
+    };
+    editor.keyboardListeners.forEach((listener) => listener(keyboardEvent));
+    return keyboardEvent;
   }
 
   it("lazy-loads Monaco, creates the editor with initial props, and exposes it", async () => {
@@ -292,15 +332,41 @@ describe("CodeEditor", () => {
     await waitFor(() => expect(monacoMock.editor.create).toHaveBeenCalledTimes(1));
     const editor = monacoMock.editors[0];
 
-    runCommand(editor, monacoMock.KeyMod.CtrlCmd | monacoMock.KeyCode.Enter);
-    runCommand(editor, monacoMock.KeyMod.Shift | monacoMock.KeyMod.Alt | monacoMock.KeyCode.KeyF);
-    runCommand(editor, monacoMock.KeyMod.CtrlCmd | monacoMock.KeyCode.Slash);
-    runCommand(editor, monacoMock.KeyMod.CtrlCmd | monacoMock.KeyCode.KeyG);
+    const runEvent = pressEditorShortcut(editor, { key: "Enter", ctrlKey: true });
+    pressEditorShortcut(editor, { key: "f", shiftKey: true, altKey: true });
+    pressEditorShortcut(editor, { key: "/", code: "Slash", metaKey: true });
+    pressEditorShortcut(editor, { key: "g", metaKey: true });
 
     expect(onCommand).toHaveBeenCalledWith("run");
     expect(editor.trigger).toHaveBeenCalledWith("keyboard", "editor.action.formatDocument", null);
     expect(editor.trigger).toHaveBeenCalledWith("keyboard", "editor.action.commentLine", null);
     expect(editor.trigger).toHaveBeenCalledWith("keyboard", "editor.action.gotoLine", null);
+    expect(runEvent.preventDefault).toHaveBeenCalled();
+    expect(runEvent.stopPropagation).toHaveBeenCalled();
+  });
+
+  it("formats from an Option-modified physical F key", async () => {
+    const { CodeEditor } = await import("../CodeEditor");
+    render(
+      <CodeEditor
+        language="javascript"
+        initialValue="function demo(){return 1;}"
+        fontSize={14}
+        theme="dark"
+      />,
+    );
+    await waitFor(() => expect(monacoMock.editor.create).toHaveBeenCalledTimes(1));
+    const editor = monacoMock.editors[0];
+
+    pressEditorShortcut(editor, {
+      key: "ƒ",
+      code: "",
+      browserEvent: { code: "KeyF", key: "ƒ", isComposing: false, repeat: false },
+      shiftKey: true,
+      altKey: true,
+    });
+
+    expect(editor.trigger).toHaveBeenCalledWith("keyboard", "editor.action.formatDocument", null);
   });
 
   it("configures JS/TS workers and disposes editor resources on unmount", async () => {

--- a/scripts/tests/workflow-rules.test.mjs
+++ b/scripts/tests/workflow-rules.test.mjs
@@ -539,6 +539,17 @@ test('extractImpactSummary stops at the next PR template section', () => {
   assert.match(result.reasons.join('\n'), /structured GitNexus impact summary/);
 });
 
+test('pull request template references the control issue without closing it', () => {
+  const template = readFileSync('.github/PULL_REQUEST_TEMPLATE.md', 'utf8');
+
+  assert.match(template, /Refs #2（总控 issue，不在本 PR 中关闭）/u);
+  assert.doesNotMatch(template, /Closes #/u);
+  assert.match(template, /## 改动点/u);
+  assert.match(template, /## 影响范围/u);
+  assert.match(template, /## GitNexus 影响分析摘要/u);
+  assert.match(template, /已说明改动点和影响范围/u);
+});
+
 test('evaluateGitNexusContract accepts critical changes with matching tests and impact summary', () => {
   const result = evaluateGitNexusContract({
     changedFiles: [


### PR DESCRIPTION
## 关联

Refs #2（总控 issue，不在本 PR 中关闭）

## 改动点

- 加载 Monaco 注释、格式化和跳行贡献模块，使 `editor.action.commentLine`、`editor.action.formatDocument`、`editor.action.gotoLine` 可实际执行。
- 将编辑器快捷键统一接到 `onKeyDown`，覆盖主键+/、主键+G、Shift+Alt/Option+F、主键+Enter，并处理 Mac Option 组合键改变 `key` 的情况。
- 新增真实浏览器 e2e 覆盖注释、格式化、跳行，并补充 CodeEditor 单测和 PR 模板契约测试。

## 影响范围

- 影响内置 Monaco 编辑器的快捷键执行路径与录制页快捷键命令回调。
- 回放页只复用 CodeEditor 展示，不新增回放协议字段。
- PR 模板改为引用总控 issue，不再默认关闭具体 issue；已用 workflow contract 测试锁定。

## GitNexus 影响分析摘要

- 风险等级: HIGH
- 关键骨架变更: `.github/PULL_REQUEST_TEMPLATE.md`；`apps/web/src/features/editor/CodeEditor.tsx`
- GitNexus 影响面: `detect_changes` reported high risk concentrated in CodeEditor shortcut processes; `context` reviewed `loadMonaco`/`registerEditorCommands`/`matchesKey` and workflow template contract.
- 验证结果: `npm run quality:local` passed.

## 自检

- [x] 未修改 `docs/progress.json` 或 `docs/progress.md`
- [x] 已运行 `npm run quality:local`，或说明无法运行的原因
- [x] 已说明改动点和影响范围
- [x] 如果改动关键骨架，已补充契约测试并填写 GitNexus 影响分析摘要
- [ ] 已邀请至少一名非作者同学 CR