### PR TITLE
[codex] Add AI subtitle replay support

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -18,6 +18,7 @@
   },
   "dependencies": {
     "@code-tape/recording-schema": "0.0.0",
+    "@huggingface/transformers": "^4.2.0",
     "@radix-ui/react-popover": "^1.1.2",
     "@radix-ui/react-slider": "^1.2.1",
     "@radix-ui/react-toggle": "^1.1.0",

--- a/apps/web/src/features/player/ReplayPage.tsx
+++ b/apps/web/src/features/player/ReplayPage.tsx
@@ -9,7 +9,7 @@ import {
   type SetStateAction,
 } from "react";
 import { Link, useParams } from "react-router-dom";
-import { Camera, CircleAlert, Keyboard, MousePointer2, TerminalSquare } from "lucide-react";
+import { Camera, Captions, CircleAlert, Keyboard, MousePointer2, TerminalSquare } from "lucide-react";
 import { createReplayScheduler, defaultTickStrategy } from "./replayScheduler";
 import { createTimelineClock } from "./timelineClock";
 import { ReplayControls } from "./ReplayControls";
@@ -18,6 +18,7 @@ import { CodeEditor } from "@/features/editor/CodeEditor";
 import { PreviewPane } from "@/features/runtime-preview/PreviewPane";
 import { createIframeRuntime } from "@/features/runtime-preview/iframeRuntime";
 import { createRecordingStore } from "@/features/library/recordingStore";
+import { SubtitlePanel } from "@/features/subtitles";
 import { Toggle } from "@/shared/ui";
 import type {
   PackageWarning,
@@ -75,12 +76,14 @@ type ReplayDisplayOptions = {
   shortcuts: boolean;
   camera: boolean;
   runtime: boolean;
+  subtitles: boolean;
 };
 const DEFAULT_DISPLAY_OPTIONS: ReplayDisplayOptions = {
   pointer: true,
   shortcuts: true,
   camera: true,
   runtime: true,
+  subtitles: true,
 };
 
 function isEventOnlyMediaDegraded(
@@ -300,6 +303,16 @@ export function ReplayPage() {
           </div>
         ) : null}
       </div>
+      {displayOptions.subtitles ? (
+        <SubtitlePanel
+          recordingId={pkg?.meta.id ?? null}
+          mediaBlob={mediaBlob}
+          hasAudio={Boolean(pkg?.media?.hasAudio)}
+          durationMs={pkg?.meta.durationMs ?? 0}
+          currentTimeMs={schedulerState.timelineTimeMs}
+          onSeek={(target) => scheduler.seek(target)}
+        />
+      ) : null}
       <ReplayControls
         state={schedulerState}
         durationMs={pkg?.meta.durationMs ?? 0}
@@ -459,6 +472,12 @@ function ReplayDisplayToolbar({
         onPressedChange={(pressed) => onChange("runtime", pressed)}
         label="显示运行面板"
         icon={<TerminalSquare size={17} />}
+      />
+      <Toggle
+        pressed={options.subtitles}
+        onPressedChange={(pressed) => onChange("subtitles", pressed)}
+        label="显示字幕"
+        icon={<Captions size={17} />}
       />
     </div>
   );

--- a/apps/web/src/features/player/__tests__/ReplayPage.test.tsx
+++ b/apps/web/src/features/player/__tests__/ReplayPage.test.tsx
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { ReplayControlsProps } from "../ReplayControls";
 import type { CodeEditorProps } from "@/features/editor/CodeEditor";
 import type { PreviewPaneProps } from "@/features/runtime-preview/PreviewPane";
+import type { SubtitlePanelProps } from "@/features/subtitles";
 import type {
   RecordingEvent,
   MediaClockAdapter,
@@ -95,6 +96,7 @@ const replayPageMock = vi.hoisted(() => {
     controlsProps: null as ReplayControlsProps | null,
     codeEditorProps: null as CodeEditorProps | null,
     previewPaneProps: null as PreviewPaneProps | null,
+    subtitlePanelProps: null as SubtitlePanelProps | null,
     onTick: null as ((state: ReplayStableState, events?: RecordingEvent[], timelineTimeMs?: number) => void) | null,
     reset() {
       scheduler.load.mockClear();
@@ -118,6 +120,7 @@ const replayPageMock = vi.hoisted(() => {
       this.controlsProps = null;
       this.codeEditorProps = null;
       this.previewPaneProps = null;
+      this.subtitlePanelProps = null;
       this.onTick = null;
     },
   };
@@ -142,6 +145,13 @@ vi.mock("@/features/runtime-preview/PreviewPane", () => ({
   PreviewPane: (props: PreviewPaneProps) => {
     replayPageMock.previewPaneProps = props;
     return <div aria-label="Mock preview pane" />;
+  },
+}));
+
+vi.mock("@/features/subtitles", () => ({
+  SubtitlePanel: (props: SubtitlePanelProps) => {
+    replayPageMock.subtitlePanelProps = props;
+    return <div aria-label="Mock subtitle panel" />;
   },
 }));
 
@@ -264,6 +274,30 @@ describe("ReplayPage", () => {
     expect(document.body).toHaveTextContent("hello");
     expect(document.body).toHaveTextContent("warn");
     expect(document.body).toHaveTextContent("boom");
+  });
+
+  it("wires replay subtitles to media, current timeline time, and scheduler seek", async () => {
+    const { ReplayPage } = await import("../ReplayPage");
+
+    render(<ReplayPage />);
+    await waitFor(() => expect(replayPageMock.scheduler.load).toHaveBeenCalledWith(replayPageMock.packageData));
+
+    expect(screen.getByLabelText("Mock subtitle panel")).toBeInTheDocument();
+    expect(replayPageMock.subtitlePanelProps).toEqual(
+      expect.objectContaining({
+        recordingId: "recording-1",
+        hasAudio: true,
+        durationMs: 120_000,
+        currentTimeMs: 0,
+      }),
+    );
+    expect(replayPageMock.subtitlePanelProps?.mediaBlob).toBeInstanceOf(Blob);
+
+    await act(async () => {
+      replayPageMock.subtitlePanelProps?.onSeek(2_400);
+    });
+
+    expect(replayPageMock.scheduler.seek).toHaveBeenCalledWith(2_400);
   });
 
   it("renders transient pointer and shortcut overlays from scheduler ticks", async () => {
@@ -436,11 +470,13 @@ describe("ReplayPage", () => {
     const shortcutToggle = screen.getByRole("button", { name: "显示快捷键" });
     const cameraToggle = screen.getByRole("button", { name: "显示摄像头" });
     const runtimeToggle = screen.getByRole("button", { name: "显示运行面板" });
+    const subtitleToggle = screen.getByRole("button", { name: "显示字幕" });
 
     expect(pointerToggle).toHaveAttribute("aria-pressed", "true");
     expect(shortcutToggle).toHaveAttribute("aria-pressed", "true");
     expect(cameraToggle).toHaveAttribute("aria-pressed", "true");
     expect(runtimeToggle).toHaveAttribute("aria-pressed", "true");
+    expect(subtitleToggle).toHaveAttribute("aria-pressed", "true");
 
     act(() => {
       replayPageMock.onTick?.(
@@ -492,17 +528,21 @@ describe("ReplayPage", () => {
     expect(screen.getByLabelText("回放鼠标位置")).toBeInTheDocument();
     expect(screen.getByText("Cmd+S")).toBeInTheDocument();
     expect(screen.getByLabelText("Mock preview pane")).toBeInTheDocument();
+    expect(screen.getByLabelText("Mock subtitle panel")).toBeInTheDocument();
 
     fireEvent.click(pointerToggle);
     fireEvent.click(shortcutToggle);
     fireEvent.click(runtimeToggle);
+    fireEvent.click(subtitleToggle);
 
     expect(screen.queryByLabelText("回放鼠标位置")).not.toBeInTheDocument();
     expect(screen.queryByText("Cmd+S")).not.toBeInTheDocument();
     expect(screen.queryByLabelText("Mock preview pane")).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("Mock subtitle panel")).not.toBeInTheDocument();
     expect(pointerToggle).toHaveAttribute("aria-pressed", "false");
     expect(shortcutToggle).toHaveAttribute("aria-pressed", "false");
     expect(runtimeToggle).toHaveAttribute("aria-pressed", "false");
+    expect(subtitleToggle).toHaveAttribute("aria-pressed", "false");
   });
 
   it("renders recorded camera media when the package has a camera track", async () => {

--- a/apps/web/src/features/subtitles/SubtitlePanel.tsx
+++ b/apps/web/src/features/subtitles/SubtitlePanel.tsx
@@ -1,5 +1,5 @@
 import { Captions, Loader2, WandSparkles } from "lucide-react";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState, type MutableRefObject } from "react";
 import { createSubtitleStore } from "./subtitleStore";
 import { createHuggingFaceSubtitleTranscriber } from "./subtitleTranscriber";
 import type { SubtitleSegment, SubtitleStore, SubtitleTrack, SubtitleTranscriber } from "./types";
@@ -38,11 +38,18 @@ export function SubtitlePanel({
   const [error, setError] = useState<string | null>(null);
   const activeSegment = findActiveSegment(track?.segments ?? [], currentTimeMs);
   const activeSegmentRef = useRef<HTMLButtonElement | null>(null);
+  const requestVersionRef = useRef(0);
+  const generationAbortRef = useRef<AbortController | null>(null);
 
   useEffect(() => {
+    const requestVersion = requestVersionRef.current + 1;
+    requestVersionRef.current = requestVersion;
+    generationAbortRef.current?.abort();
+    generationAbortRef.current = null;
     if (!recordingId) {
       setTrack(null);
       setStatus("idle");
+      setError(null);
       return;
     }
     let cancelled = false;
@@ -52,17 +59,19 @@ export function SubtitlePanel({
     store
       .load(recordingId)
       .then((savedTrack) => {
-        if (cancelled) return;
+        if (cancelled || requestVersionRef.current !== requestVersion) return;
         setTrack(savedTrack);
         setStatus(savedTrack ? "ready" : "idle");
       })
       .catch((err) => {
-        if (cancelled) return;
+        if (cancelled || requestVersionRef.current !== requestVersion) return;
         setError(formatSubtitleError(err));
         setStatus("error");
       });
     return () => {
       cancelled = true;
+      generationAbortRef.current?.abort();
+      generationAbortRef.current = null;
     };
   }, [recordingId, store]);
 
@@ -70,24 +79,42 @@ export function SubtitlePanel({
     activeSegmentRef.current?.scrollIntoView?.({ block: "nearest" });
   }, [activeSegment?.id]);
 
-  const canGenerate = Boolean(recordingId && mediaBlob && hasAudio && status !== "generating");
+  const canGenerate = Boolean(
+    recordingId && mediaBlob && hasAudio && status !== "loading" && status !== "generating",
+  );
   const generateSubtitles = async () => {
     if (!recordingId || !mediaBlob || !hasAudio) return;
+    const requestVersion = requestVersionRef.current + 1;
+    requestVersionRef.current = requestVersion;
+    generationAbortRef.current?.abort();
+    const abortController = new AbortController();
+    generationAbortRef.current = abortController;
     setStatus("generating");
     setError(null);
     try {
-      const draft = await transcriber.transcribe({ mediaBlob, durationMs });
+      const draft = await transcriber.transcribe({
+        mediaBlob,
+        durationMs,
+        signal: abortController.signal,
+      });
+      if (!isCurrentGeneration(requestVersionRef, requestVersion, abortController)) return;
       const nextTrack: SubtitleTrack = {
         recordingId,
         generatedAt: new Date().toISOString(),
         ...draft,
       };
       await store.save(nextTrack);
+      if (!isCurrentGeneration(requestVersionRef, requestVersion, abortController)) return;
       setTrack(nextTrack);
       setStatus("ready");
     } catch (err) {
+      if (abortController.signal.aborted || requestVersionRef.current !== requestVersion) return;
       setError(formatSubtitleError(err));
       setStatus("error");
+    } finally {
+      if (generationAbortRef.current === abortController) {
+        generationAbortRef.current = null;
+      }
     }
   };
 
@@ -163,6 +190,14 @@ export function SubtitlePanel({
       )}
     </section>
   );
+}
+
+function isCurrentGeneration(
+  requestVersionRef: MutableRefObject<number>,
+  requestVersion: number,
+  abortController: AbortController,
+): boolean {
+  return !abortController.signal.aborted && requestVersionRef.current === requestVersion;
 }
 
 function findActiveSegment(

--- a/apps/web/src/features/subtitles/SubtitlePanel.tsx
+++ b/apps/web/src/features/subtitles/SubtitlePanel.tsx
@@ -1,0 +1,187 @@
+import { Captions, Loader2, WandSparkles } from "lucide-react";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { createSubtitleStore } from "./subtitleStore";
+import { createHuggingFaceSubtitleTranscriber } from "./subtitleTranscriber";
+import type { SubtitleSegment, SubtitleStore, SubtitleTrack, SubtitleTranscriber } from "./types";
+import { cn } from "@/shared/ui/utils/cn";
+
+export type SubtitlePanelProps = {
+  recordingId: string | null;
+  mediaBlob: Blob | null;
+  hasAudio: boolean;
+  durationMs: number;
+  currentTimeMs: number;
+  onSeek(timeMs: number): void;
+  store?: SubtitleStore;
+  transcriber?: SubtitleTranscriber;
+};
+
+type GenerationStatus = "idle" | "loading" | "generating" | "ready" | "error";
+
+export function SubtitlePanel({
+  recordingId,
+  mediaBlob,
+  hasAudio,
+  durationMs,
+  currentTimeMs,
+  onSeek,
+  store: injectedStore,
+  transcriber: injectedTranscriber,
+}: SubtitlePanelProps) {
+  const store = useMemo(() => injectedStore ?? createSubtitleStore(), [injectedStore]);
+  const transcriber = useMemo(
+    () => injectedTranscriber ?? createHuggingFaceSubtitleTranscriber(),
+    [injectedTranscriber],
+  );
+  const [track, setTrack] = useState<SubtitleTrack | null>(null);
+  const [status, setStatus] = useState<GenerationStatus>("idle");
+  const [error, setError] = useState<string | null>(null);
+  const activeSegment = findActiveSegment(track?.segments ?? [], currentTimeMs);
+  const activeSegmentRef = useRef<HTMLButtonElement | null>(null);
+
+  useEffect(() => {
+    if (!recordingId) {
+      setTrack(null);
+      setStatus("idle");
+      return;
+    }
+    let cancelled = false;
+    setTrack(null);
+    setStatus("loading");
+    setError(null);
+    store
+      .load(recordingId)
+      .then((savedTrack) => {
+        if (cancelled) return;
+        setTrack(savedTrack);
+        setStatus(savedTrack ? "ready" : "idle");
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        setError(formatSubtitleError(err));
+        setStatus("error");
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [recordingId, store]);
+
+  useEffect(() => {
+    activeSegmentRef.current?.scrollIntoView?.({ block: "nearest" });
+  }, [activeSegment?.id]);
+
+  const canGenerate = Boolean(recordingId && mediaBlob && hasAudio && status !== "generating");
+  const generateSubtitles = async () => {
+    if (!recordingId || !mediaBlob || !hasAudio) return;
+    setStatus("generating");
+    setError(null);
+    try {
+      const draft = await transcriber.transcribe({ mediaBlob, durationMs });
+      const nextTrack: SubtitleTrack = {
+        recordingId,
+        generatedAt: new Date().toISOString(),
+        ...draft,
+      };
+      await store.save(nextTrack);
+      setTrack(nextTrack);
+      setStatus("ready");
+    } catch (err) {
+      setError(formatSubtitleError(err));
+      setStatus("error");
+    }
+  };
+
+  return (
+    <section
+      aria-label="字幕"
+      className="border-t border-border bg-background px-3 py-2"
+    >
+      <div className="mb-2 flex min-h-9 items-center justify-between gap-3">
+        <div className="flex min-w-0 items-center gap-2 text-sm font-medium text-foreground">
+          <Captions aria-hidden size={17} className="shrink-0 text-primary" />
+          <span>字幕</span>
+          {track ? (
+            <span className="truncate text-xs font-normal text-muted">{track.model}</span>
+          ) : null}
+        </div>
+        <button
+          type="button"
+          aria-label="生成字幕"
+          disabled={!canGenerate}
+          onClick={generateSubtitles}
+          className={cn(
+            "inline-flex h-8 items-center gap-1.5 rounded-md border border-border px-2 text-xs font-medium",
+            "text-foreground transition-[background-color,color] duration-150 ease-out-soft",
+            "hover:bg-surface disabled:cursor-not-allowed disabled:opacity-40",
+            "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus focus-visible:ring-offset-2 focus-visible:ring-offset-background",
+          )}
+        >
+          {status === "generating" ? (
+            <Loader2 aria-hidden size={14} className="animate-spin" />
+          ) : (
+            <WandSparkles aria-hidden size={14} />
+          )}
+          <span>生成字幕</span>
+        </button>
+      </div>
+      {status === "error" && error ? (
+        <p role="alert" className="mb-2 text-xs text-danger">
+          {error}
+        </p>
+      ) : null}
+      {!hasAudio ? (
+        <p className="text-xs text-muted">无音频轨道</p>
+      ) : track && track.segments.length > 0 ? (
+        <div className="flex max-h-32 flex-col gap-1 overflow-auto pr-1">
+          {track.segments.map((segment) => {
+            const isActive = activeSegment?.id === segment.id;
+            return (
+              <button
+                key={segment.id}
+                ref={isActive ? activeSegmentRef : undefined}
+                type="button"
+                aria-current={isActive ? "true" : undefined}
+                aria-label={segment.text}
+                onClick={() => onSeek(segment.startMs)}
+                className={cn(
+                  "grid grid-cols-[4.5rem_1fr] gap-2 rounded-md px-2 py-1.5 text-left text-xs leading-5",
+                  "transition-[background-color,color] duration-150 ease-out-soft",
+                  "hover:bg-surface focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus",
+                  isActive ? "bg-surface-raised text-foreground" : "text-muted",
+                )}
+              >
+                <span className="font-mono tabular-nums">{formatSubtitleTime(segment.startMs)}</span>
+                <span className="text-foreground">{segment.text}</span>
+              </button>
+            );
+          })}
+        </div>
+      ) : (
+        <p className="text-xs text-muted">
+          {status === "generating" ? "正在生成字幕..." : "暂无字幕"}
+        </p>
+      )}
+    </section>
+  );
+}
+
+function findActiveSegment(
+  segments: SubtitleSegment[],
+  currentTimeMs: number,
+): SubtitleSegment | null {
+  return (
+    segments.find((segment) => currentTimeMs >= segment.startMs && currentTimeMs < segment.endMs) ??
+    null
+  );
+}
+
+function formatSubtitleTime(ms: number): string {
+  const totalSeconds = Math.max(0, Math.floor(ms / 1000));
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  return `${String(minutes).padStart(2, "0")}:${String(seconds).padStart(2, "0")}`;
+}
+
+function formatSubtitleError(error: unknown): string {
+  return error instanceof Error ? error.message : "字幕生成失败";
+}

--- a/apps/web/src/features/subtitles/__tests__/SubtitlePanel.test.tsx
+++ b/apps/web/src/features/subtitles/__tests__/SubtitlePanel.test.tsx
@@ -1,7 +1,7 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import { SubtitlePanel } from "../SubtitlePanel";
-import type { SubtitleStore, SubtitleTranscriber } from "../types";
+import type { SubtitleStore, SubtitleTrack, SubtitleTrackDraft, SubtitleTranscriber } from "../types";
 
 function createMemorySubtitleStore(): SubtitleStore {
   const tracks = new Map();
@@ -16,6 +16,22 @@ function createMemorySubtitleStore(): SubtitleStore {
       tracks.delete(recordingId);
     },
   };
+}
+
+function createDeferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((promiseResolve, promiseReject) => {
+    resolve = promiseResolve;
+    reject = promiseReject;
+  });
+  return { promise, resolve, reject };
+}
+
+async function flushPromises() {
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
 }
 
 describe("SubtitlePanel", () => {
@@ -46,7 +62,11 @@ describe("SubtitlePanel", () => {
       />,
     );
 
-    fireEvent.click(screen.getByRole("button", { name: "生成字幕" }));
+    const generateButton = screen.getByRole("button", { name: "生成字幕" });
+
+    await waitFor(() => expect(generateButton).not.toBeDisabled());
+
+    fireEvent.click(generateButton);
 
     await waitFor(() => expect(screen.getByText("Render the result.")).toBeInTheDocument());
     expect(screen.getByRole("button", { name: "Render the result." })).toHaveAttribute(
@@ -86,8 +106,107 @@ describe("SubtitlePanel", () => {
       />,
     );
 
-    fireEvent.click(screen.getByRole("button", { name: "生成字幕" }));
+    const generateButton = screen.getByRole("button", { name: "生成字幕" });
+
+    await waitFor(() => expect(generateButton).not.toBeDisabled());
+
+    fireEvent.click(generateButton);
 
     await waitFor(() => expect(screen.getByRole("alert")).toHaveTextContent("model unavailable"));
+  });
+
+  it("keeps generation disabled until saved subtitles finish loading", async () => {
+    const loadedTrack = createDeferred<SubtitleTrack | null>();
+    const store: SubtitleStore = {
+      load: vi.fn(() => loadedTrack.promise),
+      save: vi.fn(),
+      remove: vi.fn(),
+    };
+
+    render(
+      <SubtitlePanel
+        recordingId="recording-1"
+        mediaBlob={new Blob(["webm"], { type: "video/webm" })}
+        hasAudio
+        durationMs={3_000}
+        currentTimeMs={0}
+        onSeek={vi.fn()}
+        store={store}
+        transcriber={{
+          transcribe: vi.fn(async () => ({
+            model: "onnx-community/whisper-tiny",
+            source: "huggingface-local" as const,
+            segments: [],
+          })),
+        }}
+      />,
+    );
+
+    const generateButton = screen.getByRole("button", { name: "生成字幕" });
+
+    await waitFor(() => expect(generateButton).toBeDisabled());
+
+    await act(async () => {
+      loadedTrack.resolve(null);
+      await flushPromises();
+    });
+
+    expect(generateButton).not.toBeDisabled();
+  });
+
+  it("ignores a generated track after switching to another recording", async () => {
+    const generatedTrack = createDeferred<SubtitleTrackDraft>();
+    const store: SubtitleStore = {
+      load: vi.fn(async () => null),
+      save: vi.fn(async () => undefined),
+      remove: vi.fn(),
+    };
+    const transcriber: SubtitleTranscriber = {
+      transcribe: vi.fn(() => generatedTrack.promise),
+    };
+    const firstBlob = new Blob(["first"], { type: "video/webm" });
+    const secondBlob = new Blob(["second"], { type: "video/webm" });
+
+    const { rerender } = render(
+      <SubtitlePanel
+        recordingId="recording-1"
+        mediaBlob={firstBlob}
+        hasAudio
+        durationMs={3_000}
+        currentTimeMs={0}
+        onSeek={vi.fn()}
+        store={store}
+        transcriber={transcriber}
+      />,
+    );
+
+    await waitFor(() => expect(screen.getByRole("button", { name: "生成字幕" })).not.toBeDisabled());
+
+    fireEvent.click(screen.getByRole("button", { name: "生成字幕" }));
+
+    rerender(
+      <SubtitlePanel
+        recordingId="recording-2"
+        mediaBlob={secondBlob}
+        hasAudio
+        durationMs={3_000}
+        currentTimeMs={0}
+        onSeek={vi.fn()}
+        store={store}
+        transcriber={transcriber}
+      />,
+    );
+
+    await act(async () => {
+      generatedTrack.resolve({
+        model: "onnx-community/whisper-tiny",
+        source: "huggingface-local",
+        segments: [{ id: "subtitle-1", startMs: 0, endMs: 1_000, text: "Old recording text." }],
+      });
+      await flushPromises();
+    });
+
+    expect(store.save).not.toHaveBeenCalled();
+    expect(screen.queryByText("Old recording text.")).not.toBeInTheDocument();
   });
 });

--- a/apps/web/src/features/subtitles/__tests__/SubtitlePanel.test.tsx
+++ b/apps/web/src/features/subtitles/__tests__/SubtitlePanel.test.tsx
@@ -1,0 +1,93 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { SubtitlePanel } from "../SubtitlePanel";
+import type { SubtitleStore, SubtitleTranscriber } from "../types";
+
+function createMemorySubtitleStore(): SubtitleStore {
+  const tracks = new Map();
+  return {
+    async load(recordingId) {
+      return tracks.get(recordingId) ?? null;
+    },
+    async save(track) {
+      tracks.set(track.recordingId, track);
+    },
+    async remove(recordingId) {
+      tracks.delete(recordingId);
+    },
+  };
+}
+
+describe("SubtitlePanel", () => {
+  it("generates subtitles from the media blob, highlights the active segment, and seeks on click", async () => {
+    const store = createMemorySubtitleStore();
+    const transcriber: SubtitleTranscriber = {
+      transcribe: vi.fn(async () => ({
+        model: "onnx-community/whisper-tiny",
+        source: "huggingface-local" as const,
+        segments: [
+          { id: "subtitle-1", startMs: 0, endMs: 1_000, text: "Set up state." },
+          { id: "subtitle-2", startMs: 1_000, endMs: 3_000, text: "Render the result." },
+        ],
+      })),
+    };
+    const onSeek = vi.fn();
+
+    render(
+      <SubtitlePanel
+        recordingId="recording-1"
+        mediaBlob={new Blob(["webm"], { type: "video/webm" })}
+        hasAudio
+        durationMs={3_000}
+        currentTimeMs={1_500}
+        onSeek={onSeek}
+        store={store}
+        transcriber={transcriber}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "生成字幕" }));
+
+    await waitFor(() => expect(screen.getByText("Render the result.")).toBeInTheDocument());
+    expect(screen.getByRole("button", { name: "Render the result." })).toHaveAttribute(
+      "aria-current",
+      "true",
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Set up state." }));
+
+    expect(onSeek).toHaveBeenCalledWith(0);
+    await expect(store.load("recording-1")).resolves.toEqual(
+      expect.objectContaining({
+        recordingId: "recording-1",
+        model: "onnx-community/whisper-tiny",
+        source: "huggingface-local",
+      }),
+    );
+  });
+
+  it("surfaces generation failure without blocking replay controls", async () => {
+    const transcriber: SubtitleTranscriber = {
+      transcribe: vi.fn(async () => {
+        throw new Error("model unavailable");
+      }),
+    };
+
+    render(
+      <SubtitlePanel
+        recordingId="recording-1"
+        mediaBlob={new Blob(["webm"], { type: "video/webm" })}
+        hasAudio
+        durationMs={3_000}
+        currentTimeMs={0}
+        onSeek={vi.fn()}
+        store={createMemorySubtitleStore()}
+        transcriber={transcriber}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "生成字幕" }));
+
+    await waitFor(() => expect(screen.getByRole("alert")).toHaveTextContent("model unavailable"));
+  });
+});

--- a/apps/web/src/features/subtitles/__tests__/subtitleCorrection.test.ts
+++ b/apps/web/src/features/subtitles/__tests__/subtitleCorrection.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import { applySubtitleCorrection } from "../subtitleCorrection";
+import type { SubtitleTrack } from "../types";
+
+function makeTrack(): SubtitleTrack {
+  return {
+    recordingId: "recording-1",
+    generatedAt: "2026-05-28T00:00:00.000Z",
+    model: "onnx-community/whisper-tiny",
+    source: "huggingface-local",
+    segments: [
+      { id: "subtitle-1", startMs: 0, endMs: 1_000, text: "use state hook" },
+      { id: "subtitle-2", startMs: 1_000, endMs: 3_000, text: "render result" },
+    ],
+  };
+}
+
+describe("applySubtitleCorrection", () => {
+  it("applies LLM text corrections and validated chapters without changing timestamps", () => {
+    const result = applySubtitleCorrection(makeTrack(), {
+      segments: [
+        { id: "subtitle-1", text: "useState hook" },
+        { id: "subtitle-2", text: "render the result" },
+      ],
+      chapters: [{ title: "State setup", startMs: 0, endMs: 1_000 }],
+    });
+
+    expect(result.warnings).toEqual([]);
+    expect(result.track.segments).toEqual([
+      { id: "subtitle-1", startMs: 0, endMs: 1_000, text: "useState hook" },
+      { id: "subtitle-2", startMs: 1_000, endMs: 3_000, text: "render the result" },
+    ]);
+    expect(result.chapters).toEqual([{ id: "chapter-1", title: "State setup", startMs: 0, endMs: 1_000 }]);
+  });
+
+  it("keeps the original subtitles when the LLM output targets an unknown segment", () => {
+    const track = makeTrack();
+    const result = applySubtitleCorrection(track, {
+      segments: [{ id: "missing", text: "bad correction" }],
+    });
+
+    expect(result.track).toEqual(track);
+    expect(result.chapters).toEqual([]);
+    expect(result.warnings).toEqual([
+      { code: "invalid-correction", message: "correction references unknown segment: missing" },
+    ]);
+  });
+
+  it("keeps the original subtitles when generated chapters overlap", () => {
+    const track = makeTrack();
+    const result = applySubtitleCorrection(track, {
+      segments: [{ id: "subtitle-1", text: "useState hook" }],
+      chapters: [
+        { title: "First", startMs: 0, endMs: 2_000 },
+        { title: "Overlap", startMs: 1_500, endMs: 3_000 },
+      ],
+    });
+
+    expect(result.track).toEqual(track);
+    expect(result.chapters).toEqual([]);
+    expect(result.warnings).toEqual([
+      { code: "invalid-chapter", message: "chapters must be ordered and non-overlapping" },
+    ]);
+  });
+});

--- a/apps/web/src/features/subtitles/__tests__/subtitleStore.test.ts
+++ b/apps/web/src/features/subtitles/__tests__/subtitleStore.test.ts
@@ -1,0 +1,30 @@
+import "fake-indexeddb/auto";
+import { describe, expect, it } from "vitest";
+import { createSubtitleStore } from "../subtitleStore";
+import type { SubtitleTrack } from "../types";
+
+let dbCounter = 0;
+function uniqueDbName() {
+  dbCounter += 1;
+  return `code-tape-subtitles-test-${dbCounter}`;
+}
+
+describe("createSubtitleStore", () => {
+  it("round-trips a generated subtitle track by recording id", async () => {
+    const store = createSubtitleStore({ databaseName: uniqueDbName() });
+    const track: SubtitleTrack = {
+      recordingId: "recording-1",
+      generatedAt: "2026-05-28T00:00:00.000Z",
+      model: "onnx-community/whisper-tiny",
+      source: "huggingface-local",
+      segments: [
+        { id: "subtitle-1", startMs: 0, endMs: 1_200, text: "Hello timeline." },
+      ],
+    };
+
+    await store.save(track);
+
+    await expect(store.load("recording-1")).resolves.toEqual(track);
+    await expect(store.load("missing")).resolves.toBeNull();
+  });
+});

--- a/apps/web/src/features/subtitles/__tests__/subtitleTranscriber.test.ts
+++ b/apps/web/src/features/subtitles/__tests__/subtitleTranscriber.test.ts
@@ -1,5 +1,20 @@
-import { describe, expect, it } from "vitest";
-import { normalizeTranscriptionResult } from "../subtitleTranscriber";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createHuggingFaceSubtitleTranscriber, normalizeTranscriptionResult } from "../subtitleTranscriber";
+
+const originalCreateObjectUrl = URL.createObjectURL;
+const originalRevokeObjectUrl = URL.revokeObjectURL;
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  Object.defineProperty(URL, "createObjectURL", {
+    configurable: true,
+    value: originalCreateObjectUrl,
+  });
+  Object.defineProperty(URL, "revokeObjectURL", {
+    configurable: true,
+    value: originalRevokeObjectUrl,
+  });
+});
 
 describe("normalizeTranscriptionResult", () => {
   it("turns Hugging Face ASR chunks into millisecond subtitle segments", () => {
@@ -55,5 +70,42 @@ describe("normalizeTranscriptionResult", () => {
     expect(segments).toEqual([
       { id: "subtitle-1", startMs: 2_100, endMs: 5_000, text: "final thought" },
     ]);
+  });
+
+  it("retries pipeline initialization after a failed model load", async () => {
+    Object.defineProperty(URL, "createObjectURL", {
+      configurable: true,
+      value: vi.fn(() => "blob:subtitle-source"),
+    });
+    Object.defineProperty(URL, "revokeObjectURL", {
+      configurable: true,
+      value: vi.fn(),
+    });
+    const pipeline = vi.fn(async () => ({ chunks: [] }));
+    const pipelineFactory = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("temporary model load failure"))
+      .mockResolvedValueOnce(pipeline);
+    const transcriber = createHuggingFaceSubtitleTranscriber({ pipelineFactory });
+
+    await expect(
+      transcriber.transcribe({
+        mediaBlob: new Blob(["audio"], { type: "audio/webm" }),
+        durationMs: 1_000,
+      }),
+    ).rejects.toThrow("temporary model load failure");
+
+    await expect(
+      transcriber.transcribe({
+        mediaBlob: new Blob(["audio"], { type: "audio/webm" }),
+        durationMs: 1_000,
+      }),
+    ).resolves.toEqual({
+      model: "onnx-community/whisper-tiny",
+      source: "huggingface-local",
+      language: undefined,
+      segments: [],
+    });
+    expect(pipelineFactory).toHaveBeenCalledTimes(2);
   });
 });

--- a/apps/web/src/features/subtitles/__tests__/subtitleTranscriber.test.ts
+++ b/apps/web/src/features/subtitles/__tests__/subtitleTranscriber.test.ts
@@ -43,4 +43,17 @@ describe("normalizeTranscriptionResult", () => {
       { id: "subtitle-1", startMs: 0, endMs: 3_000, text: "valid" },
     ]);
   });
+
+  it("keeps chunks with an open ended timestamp by ending them at the recording duration", () => {
+    const segments = normalizeTranscriptionResult(
+      {
+        chunks: [{ text: " final thought ", timestamp: [2.1, null] }],
+      },
+      5_000,
+    );
+
+    expect(segments).toEqual([
+      { id: "subtitle-1", startMs: 2_100, endMs: 5_000, text: "final thought" },
+    ]);
+  });
 });

--- a/apps/web/src/features/subtitles/__tests__/subtitleTranscriber.test.ts
+++ b/apps/web/src/features/subtitles/__tests__/subtitleTranscriber.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import { normalizeTranscriptionResult } from "../subtitleTranscriber";
+
+describe("normalizeTranscriptionResult", () => {
+  it("turns Hugging Face ASR chunks into millisecond subtitle segments", () => {
+    const segments = normalizeTranscriptionResult(
+      {
+        text: "We start with state, then render the loop.",
+        chunks: [
+          { text: " We start with state", timestamp: [0.32, 2.1] },
+          { text: " then render the loop.", timestamp: [2.1, 4.75] },
+        ],
+      },
+      5_000,
+    );
+
+    expect(segments).toEqual([
+      { id: "subtitle-1", startMs: 320, endMs: 2_100, text: "We start with state" },
+      { id: "subtitle-2", startMs: 2_100, endMs: 4_750, text: "then render the loop." },
+    ]);
+  });
+
+  it("falls back to one full-duration segment when the model returns plain text", () => {
+    const segments = normalizeTranscriptionResult({ text: "No chunk metadata." }, 7_500);
+
+    expect(segments).toEqual([
+      { id: "subtitle-1", startMs: 0, endMs: 7_500, text: "No chunk metadata." },
+    ]);
+  });
+
+  it("drops empty chunks and clamps out-of-range timestamps", () => {
+    const segments = normalizeTranscriptionResult(
+      {
+        chunks: [
+          { text: "   ", timestamp: [0, 1] },
+          { text: " valid ", timestamp: [-2, 12] },
+        ],
+      },
+      3_000,
+    );
+
+    expect(segments).toEqual([
+      { id: "subtitle-1", startMs: 0, endMs: 3_000, text: "valid" },
+    ]);
+  });
+});

--- a/apps/web/src/features/subtitles/index.ts
+++ b/apps/web/src/features/subtitles/index.ts
@@ -1,0 +1,19 @@
+export { SubtitlePanel, type SubtitlePanelProps } from "./SubtitlePanel";
+export { createSubtitleStore } from "./subtitleStore";
+export {
+  DEFAULT_TRANSCRIPTION_MODEL,
+  createHuggingFaceSubtitleTranscriber,
+  normalizeTranscriptionResult,
+} from "./subtitleTranscriber";
+export { applySubtitleCorrection, type ApplySubtitleCorrectionResult } from "./subtitleCorrection";
+export type {
+  SubtitleChapter,
+  SubtitleCorrectionResult,
+  SubtitleCorrectionWarning,
+  SubtitleSegment,
+  SubtitleStore,
+  SubtitleTrack,
+  SubtitleTrackDraft,
+  SubtitleTranscriber,
+  SubtitleTranscriberInput,
+} from "./types";

--- a/apps/web/src/features/subtitles/subtitleCorrection.ts
+++ b/apps/web/src/features/subtitles/subtitleCorrection.ts
@@ -1,0 +1,87 @@
+import type {
+  SubtitleChapter,
+  SubtitleCorrectionResult,
+  SubtitleCorrectionWarning,
+  SubtitleTrack,
+} from "./types";
+
+export type ApplySubtitleCorrectionResult = {
+  track: SubtitleTrack;
+  chapters: SubtitleChapter[];
+  warnings: SubtitleCorrectionWarning[];
+};
+
+export function applySubtitleCorrection(
+  track: SubtitleTrack,
+  correction: SubtitleCorrectionResult,
+): ApplySubtitleCorrectionResult {
+  const segmentIds = new Set(track.segments.map((segment) => segment.id));
+  const correctedTextById = new Map<string, string>();
+
+  for (const segment of correction.segments) {
+    if (!segmentIds.has(segment.id)) {
+      return invalid(track, "invalid-correction", `correction references unknown segment: ${segment.id}`);
+    }
+    const text = segment.text.trim();
+    if (!text) {
+      return invalid(track, "invalid-correction", `correction text is empty for segment: ${segment.id}`);
+    }
+    correctedTextById.set(segment.id, text);
+  }
+
+  const chapters = normalizeChapters(track, correction.chapters ?? []);
+  if ("warning" in chapters) {
+    return invalid(track, "invalid-chapter", chapters.warning);
+  }
+
+  return {
+    track: {
+      ...track,
+      segments: track.segments.map((segment) => ({
+        ...segment,
+        text: correctedTextById.get(segment.id) ?? segment.text,
+      })),
+    },
+    chapters,
+    warnings: [],
+  };
+}
+
+function normalizeChapters(
+  track: SubtitleTrack,
+  chapters: NonNullable<SubtitleCorrectionResult["chapters"]>,
+): SubtitleChapter[] | { warning: string } {
+  const durationMs = Math.max(0, ...track.segments.map((segment) => segment.endMs));
+  let previousEnd = 0;
+  const normalized: SubtitleChapter[] = [];
+  for (let index = 0; index < chapters.length; index += 1) {
+    const chapter = chapters[index];
+    const title = chapter.title.trim();
+    const startMs = Math.max(0, Math.min(durationMs, Math.round(chapter.startMs)));
+    const endMs =
+      typeof chapter.endMs === "number"
+        ? Math.max(0, Math.min(durationMs, Math.round(chapter.endMs)))
+        : undefined;
+
+    if (!title) return { warning: "chapter title is empty" };
+    if (startMs < previousEnd || (typeof endMs === "number" && endMs <= startMs)) {
+      return { warning: "chapters must be ordered and non-overlapping" };
+    }
+    previousEnd = endMs ?? startMs;
+    normalized.push({
+      id: `chapter-${index + 1}`,
+      title,
+      startMs,
+      ...(typeof endMs === "number" ? { endMs } : {}),
+    });
+  }
+  return normalized;
+}
+
+function invalid(
+  track: SubtitleTrack,
+  code: SubtitleCorrectionWarning["code"],
+  message: string,
+): ApplySubtitleCorrectionResult {
+  return { track, chapters: [], warnings: [{ code, message }] };
+}

--- a/apps/web/src/features/subtitles/subtitleStore.ts
+++ b/apps/web/src/features/subtitles/subtitleStore.ts
@@ -1,0 +1,57 @@
+import { awaitTransaction, openDatabase, promisifyRequest } from "@/features/library/idb";
+import type { SubtitleStore, SubtitleTrack } from "./types";
+
+export type SubtitleStoreOptions = {
+  databaseName?: string;
+};
+
+const DEFAULT_DB_NAME = "code-tape-subtitles";
+const DB_VERSION = 1;
+const STORE_SUBTITLES = "subtitles";
+
+export function createSubtitleStore(options: SubtitleStoreOptions = {}): SubtitleStore {
+  const databaseName = options.databaseName ?? DEFAULT_DB_NAME;
+  const getDb = (() => {
+    let cached: Promise<IDBDatabase> | null = null;
+    return () => {
+      if (!cached) {
+        cached = openDatabase({
+          name: databaseName,
+          version: DB_VERSION,
+          onUpgrade(db) {
+            if (!db.objectStoreNames.contains(STORE_SUBTITLES)) {
+              db.createObjectStore(STORE_SUBTITLES, { keyPath: "recordingId" });
+            }
+          },
+        });
+      }
+      return cached;
+    };
+  })();
+
+  return {
+    async load(recordingId: string): Promise<SubtitleTrack | null> {
+      const db = await getDb();
+      const tx = db.transaction(STORE_SUBTITLES, "readonly");
+      const value = (await promisifyRequest(tx.objectStore(STORE_SUBTITLES).get(recordingId))) as
+        | SubtitleTrack
+        | undefined;
+      await awaitTransaction(tx);
+      return value ?? null;
+    },
+
+    async save(track: SubtitleTrack): Promise<void> {
+      const db = await getDb();
+      const tx = db.transaction(STORE_SUBTITLES, "readwrite");
+      tx.objectStore(STORE_SUBTITLES).put(track);
+      await awaitTransaction(tx);
+    },
+
+    async remove(recordingId: string): Promise<void> {
+      const db = await getDb();
+      const tx = db.transaction(STORE_SUBTITLES, "readwrite");
+      tx.objectStore(STORE_SUBTITLES).delete(recordingId);
+      await awaitTransaction(tx);
+    },
+  };
+}

--- a/apps/web/src/features/subtitles/subtitleTranscriber.ts
+++ b/apps/web/src/features/subtitles/subtitleTranscriber.ts
@@ -38,7 +38,7 @@ export function normalizeTranscriptionResult(
 ): SubtitleSegment[] {
   const chunks = Array.isArray(result.chunks) ? result.chunks : [];
   const segments = chunks
-    .map((chunk, index) => segmentFromChunk(chunk, index, durationMs))
+    .map((chunk, index) => segmentFromChunk(chunk, index, durationMs, chunks[index + 1]))
     .filter((segment): segment is SubtitleSegment => Boolean(segment));
 
   if (segments.length > 0) return reindexSegments(segments);
@@ -100,14 +100,16 @@ function segmentFromChunk(
   value: unknown,
   index: number,
   durationMs: number,
+  nextValue: unknown,
 ): SubtitleSegment | null {
   if (!isPlainObject(value)) return null;
   const chunk = value as RawAsrChunk;
   const text = typeof chunk.text === "string" ? chunk.text.trim() : "";
   if (!text) return null;
   const [startSec, endSec] = readTimestamp(chunk.timestamp);
+  const fallbackEndSec = getOpenEndFallbackSec(nextValue, startSec, durationMs);
   const startMs = clampMs(secondsToMs(startSec), durationMs);
-  const endMs = clampMs(secondsToMs(endSec), durationMs);
+  const endMs = clampMs(secondsToMs(endSec ?? fallbackEndSec), durationMs);
   if (endMs <= startMs) return null;
   return { id: `subtitle-${index + 1}`, startMs, endMs, text };
 }
@@ -116,13 +118,27 @@ function reindexSegments(segments: SubtitleSegment[]): SubtitleSegment[] {
   return segments.map((segment, index) => ({ ...segment, id: `subtitle-${index + 1}` }));
 }
 
-function readTimestamp(value: unknown): [number, number] {
-  if (!Array.isArray(value)) return [0, 0];
+function readTimestamp(value: unknown): [number, number | null] {
+  if (!Array.isArray(value)) return [0, null];
   const [start, end] = value;
   return [
     typeof start === "number" && Number.isFinite(start) ? start : 0,
-    typeof end === "number" && Number.isFinite(end) ? end : 0,
+    typeof end === "number" && Number.isFinite(end) ? end : null,
   ];
+}
+
+function getOpenEndFallbackSec(nextValue: unknown, startSec: number, durationMs: number): number {
+  const nextStartSec = readChunkStartSec(nextValue);
+  if (nextStartSec !== null && nextStartSec > startSec) return nextStartSec;
+  return Math.max(0, durationMs) / 1000;
+}
+
+function readChunkStartSec(value: unknown): number | null {
+  if (!isPlainObject(value)) return null;
+  const timestamp = (value as RawAsrChunk).timestamp;
+  if (!Array.isArray(timestamp)) return null;
+  const [start] = timestamp;
+  return typeof start === "number" && Number.isFinite(start) ? start : null;
 }
 
 function secondsToMs(value: number): number {

--- a/apps/web/src/features/subtitles/subtitleTranscriber.ts
+++ b/apps/web/src/features/subtitles/subtitleTranscriber.ts
@@ -1,0 +1,138 @@
+import type { SubtitleSegment, SubtitleTranscriber } from "./types";
+
+export const DEFAULT_TRANSCRIPTION_MODEL = "onnx-community/whisper-tiny";
+
+type RawAsrChunk = {
+  text?: unknown;
+  timestamp?: unknown;
+};
+
+type RawAsrResult = {
+  text?: unknown;
+  chunks?: unknown;
+  language?: unknown;
+};
+
+type AsrPipeline = (
+  input: string,
+  options: {
+    chunk_length_s: number;
+    stride_length_s: number;
+    return_timestamps: true;
+  },
+) => Promise<RawAsrResult>;
+
+type PipelineFactory = (
+  task: "automatic-speech-recognition",
+  model: string,
+) => Promise<AsrPipeline>;
+
+export type HuggingFaceSubtitleTranscriberOptions = {
+  model?: string;
+  pipelineFactory?: PipelineFactory;
+};
+
+export function normalizeTranscriptionResult(
+  result: RawAsrResult,
+  durationMs: number,
+): SubtitleSegment[] {
+  const chunks = Array.isArray(result.chunks) ? result.chunks : [];
+  const segments = chunks
+    .map((chunk, index) => segmentFromChunk(chunk, index, durationMs))
+    .filter((segment): segment is SubtitleSegment => Boolean(segment));
+
+  if (segments.length > 0) return reindexSegments(segments);
+
+  const text = typeof result.text === "string" ? result.text.trim() : "";
+  if (!text) return [];
+  return [{ id: "subtitle-1", startMs: 0, endMs: Math.max(0, durationMs), text }];
+}
+
+export function createHuggingFaceSubtitleTranscriber(
+  options: HuggingFaceSubtitleTranscriberOptions = {},
+): SubtitleTranscriber {
+  const model = options.model ?? DEFAULT_TRANSCRIPTION_MODEL;
+  let pipelinePromise: Promise<AsrPipeline> | null = null;
+  const getPipeline = () => {
+    if (!pipelinePromise) {
+      pipelinePromise = options.pipelineFactory
+        ? options.pipelineFactory("automatic-speech-recognition", model)
+        : loadDefaultPipeline("automatic-speech-recognition", model);
+    }
+    return pipelinePromise;
+  };
+
+  return {
+    async transcribe({ mediaBlob, durationMs, signal }) {
+      if (signal?.aborted) throw new DOMException("字幕生成已取消", "AbortError");
+      const pipeline = await getPipeline();
+      if (signal?.aborted) throw new DOMException("字幕生成已取消", "AbortError");
+      const url = URL.createObjectURL(mediaBlob);
+      try {
+        const result = await pipeline(url, {
+          chunk_length_s: 30,
+          stride_length_s: 5,
+          return_timestamps: true,
+        });
+        return {
+          model,
+          source: "huggingface-local",
+          language: typeof result.language === "string" ? result.language : undefined,
+          segments: normalizeTranscriptionResult(result, durationMs),
+        };
+      } finally {
+        URL.revokeObjectURL(url);
+      }
+    },
+  };
+}
+
+async function loadDefaultPipeline(
+  task: "automatic-speech-recognition",
+  model: string,
+): Promise<AsrPipeline> {
+  const module = await import("@huggingface/transformers");
+  const pipe = await module.pipeline(task, model);
+  return pipe as unknown as AsrPipeline;
+}
+
+function segmentFromChunk(
+  value: unknown,
+  index: number,
+  durationMs: number,
+): SubtitleSegment | null {
+  if (!isPlainObject(value)) return null;
+  const chunk = value as RawAsrChunk;
+  const text = typeof chunk.text === "string" ? chunk.text.trim() : "";
+  if (!text) return null;
+  const [startSec, endSec] = readTimestamp(chunk.timestamp);
+  const startMs = clampMs(secondsToMs(startSec), durationMs);
+  const endMs = clampMs(secondsToMs(endSec), durationMs);
+  if (endMs <= startMs) return null;
+  return { id: `subtitle-${index + 1}`, startMs, endMs, text };
+}
+
+function reindexSegments(segments: SubtitleSegment[]): SubtitleSegment[] {
+  return segments.map((segment, index) => ({ ...segment, id: `subtitle-${index + 1}` }));
+}
+
+function readTimestamp(value: unknown): [number, number] {
+  if (!Array.isArray(value)) return [0, 0];
+  const [start, end] = value;
+  return [
+    typeof start === "number" && Number.isFinite(start) ? start : 0,
+    typeof end === "number" && Number.isFinite(end) ? end : 0,
+  ];
+}
+
+function secondsToMs(value: number): number {
+  return Math.round(value * 1000);
+}
+
+function clampMs(value: number, durationMs: number): number {
+  return Math.max(0, Math.min(Math.max(0, durationMs), value));
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/apps/web/src/features/subtitles/subtitleTranscriber.ts
+++ b/apps/web/src/features/subtitles/subtitleTranscriber.ts
@@ -55,9 +55,13 @@ export function createHuggingFaceSubtitleTranscriber(
   let pipelinePromise: Promise<AsrPipeline> | null = null;
   const getPipeline = () => {
     if (!pipelinePromise) {
-      pipelinePromise = options.pipelineFactory
+      pipelinePromise = (options.pipelineFactory
         ? options.pipelineFactory("automatic-speech-recognition", model)
-        : loadDefaultPipeline("automatic-speech-recognition", model);
+        : loadDefaultPipeline("automatic-speech-recognition", model)
+      ).catch((error: unknown) => {
+        pipelinePromise = null;
+        throw error;
+      });
     }
     return pipelinePromise;
   };

--- a/apps/web/src/features/subtitles/types.ts
+++ b/apps/web/src/features/subtitles/types.ts
@@ -1,0 +1,57 @@
+export type SubtitleSegment = {
+  id: string;
+  startMs: number;
+  endMs: number;
+  text: string;
+};
+
+export type SubtitleTrack = {
+  recordingId: string;
+  generatedAt: string;
+  model: string;
+  source: "huggingface-local" | "backend-job";
+  language?: string;
+  segments: SubtitleSegment[];
+};
+
+export type SubtitleChapter = {
+  id: string;
+  title: string;
+  startMs: number;
+  endMs?: number;
+};
+
+export type SubtitleCorrectionResult = {
+  segments: Array<{
+    id: string;
+    text: string;
+  }>;
+  chapters?: Array<{
+    title: string;
+    startMs: number;
+    endMs?: number;
+  }>;
+};
+
+export type SubtitleCorrectionWarning = {
+  code: "invalid-correction" | "invalid-chapter";
+  message: string;
+};
+
+export type SubtitleTrackDraft = Omit<SubtitleTrack, "recordingId" | "generatedAt">;
+
+export type SubtitleTranscriberInput = {
+  mediaBlob: Blob;
+  durationMs: number;
+  signal?: AbortSignal;
+};
+
+export type SubtitleTranscriber = {
+  transcribe(input: SubtitleTranscriberInput): Promise<SubtitleTrackDraft>;
+};
+
+export type SubtitleStore = {
+  load(recordingId: string): Promise<SubtitleTrack | null>;
+  save(track: SubtitleTrack): Promise<void>;
+  remove(recordingId: string): Promise<void>;
+};

--- a/docs/技术方案.md
+++ b/docs/技术方案.md
@@ -100,8 +100,8 @@ P1+ 做挑战项：
   - 最小展示版：同步编辑事件和录制状态，让面试官实时看到候选人的编辑器状态。
   - 完整版：增加 WebRTC 双向音视频、网络抖动下的时序同步、面试后保存为回放。
 - AI 字幕分两级：
-  - 最小展示版：录制后生成带时间戳字幕，回放时滚动展示并支持点击 seek。
-  - 完整版：接入术语/变量名纠错、自动分段和章节生成。
+  - 最小展示版：录制后或回放前基于音频生成带时间戳字幕，回放时滚动展示并支持点击 seek。
+  - 完整版：接入面向 code-tape 场景微调或适配的 LLM，对 ASR 结果做术语/变量名纠错，并自动分段生成章节。
 - 课程/题目组织、批注评论、团队复盘列为更远期产品化方向，不作为 PRD P1+ 验收口径。
 
 ## 三、总体架构
@@ -164,6 +164,7 @@ flowchart TD
 | 本地存储    | IndexedDB，封装轻量 repository                                            | 支持 Blob 与结构化数据                                       |
 | iframe 沙箱 | sandboxed iframe + postMessage                                            | P0 前端运行/展示路线                                         |
 | TS 简单运行 | 浏览器侧 transpile，先不做 type checking                                  | 支持简单 TS Demo，不承诺完整工程                             |
+| AI 字幕     | `@huggingface/transformers` + Hugging Face Hub 上的 ASR 模型               | P1+ 默认本地推理，模型点击生成时懒加载，不依赖第三方托管 API |
 | 测试        | Vitest + Testing Library + Playwright                                     | 核心算法单测，关键录制/回放 e2e                              |
 
 ### 4. 状态管理责任边界
@@ -2967,7 +2968,128 @@ P1 云端方案的主线是：**本地录制包先完整生成，云端只负责
 
 在实现顺序上，应先交付上传 session、对象存储、校验 Worker、云端列表和云端播放，再做分享、活动索引、缩略图、WebRTC、AI 字幕和后端沙箱等增强。云端能力要成为 P0 主链路之后的自然扩展，而不是新的复杂度中心。
 
-## 十一、质量、测试与验收
+## 十一、P1+ AI 字幕与 Hugging Face 模型方案
+
+本章收敛 issue #98 的技术路线。AI 字幕是 P1+ 增强能力，不改变 P0/P1 的录制包事实源：`RecordingPackageV1` 仍只保存录制事实、媒体描述和回放索引；字幕、纠错结果和章节属于可重建的派生资产。派生资产可以先保存在本地 IndexedDB，云端阶段再作为 `subtitle`、`chapter` 等 asset 写入对象存储。
+
+### 1. 目标与边界
+
+最小展示版必须满足：
+
+- 有音频的录制可以在录制后或回放前生成带时间戳字幕。
+- 回放页在编辑器下方展示字幕，当前播放时间命中的字幕行高亮并自动滚动到可见区域。
+- 点击字幕行调用播放器 `seek(startMs)`，跳转到对应讲解时间继续回放。
+- 无音频、媒体缺失、模型加载失败、识别失败时，回放主流程不受影响，只展示可恢复的错误或降级状态。
+
+默认不进入最小展示版的能力：
+
+- 不把字幕写入 `RecordingPackageV1` 主 schema，避免核心包校验和迁移复杂度扩大。
+- 不默认上传录音到 Hugging Face Inference API、Spaces 或其他第三方托管服务。
+- 不在前端代码、文档、测试 fixture、PR 描述中保存 Hugging Face token。
+- 不把 LLM 纠错或章节生成作为基础字幕验收前置条件。
+
+### 2. 稳定架构
+
+AI 字幕链路分为四个稳定边界：
+
+| 边界                  | 职责                                                                 | 输入/输出                                               |
+| --------------------- | -------------------------------------------------------------------- | ------------------------------------------------------- |
+| `SubtitleTranscriber` | 负责从媒体 Blob 生成原始字幕段                                       | 输入 `mediaBlob`、`durationMs`；输出 `SubtitleTrack` 草稿 |
+| `SubtitleNormalizer`  | 负责把模型返回的 chunk/timestamp 归一化为毫秒级字幕段                | 输入 ASR 结果；输出 `SubtitleSegment[]`                 |
+| `SubtitleStore`       | 负责按 `recordingId` 存取字幕派生资产                                | 本地 IndexedDB；云端阶段可替换为远端 asset repository   |
+| `SubtitlePanel`       | 负责展示、当前行高亮、自动滚动、点击 seek、生成失败状态              | 输入播放器时间和 `onSeek`；不直接操作 scheduler 内部状态 |
+
+推荐类型：
+
+```ts
+export type SubtitleSegment = {
+  id: string;
+  startMs: number;
+  endMs: number;
+  text: string;
+};
+
+export type SubtitleTrack = {
+  recordingId: string;
+  generatedAt: string;
+  model: string;
+  source: "huggingface-local" | "backend-job";
+  language?: string;
+  segments: SubtitleSegment[];
+};
+```
+
+回放页只依赖 `SubtitlePanel` 和 `onSeek(timeMs)`，不关心模型、token、存储细节。这样字幕能力可以从本地 Hugging Face 模型平滑演进到云端任务或用户自定义模型，而不重写回放调度器。
+
+### 3. Hugging Face ASR 方案
+
+P1+ 最小展示版默认使用 Hugging Face Hub 上兼容 Transformers.js 的 ASR 模型，在浏览器本地推理。推荐首选公开模型：
+
+- 模型：`onnx-community/whisper-tiny`
+- 任务：`automatic-speech-recognition`
+- 运行库：`@huggingface/transformers`
+- 加载策略：用户点击“生成字幕”后再动态 import 和下载模型；普通回放路径不主动加载模型。
+
+公开模型不需要 Hugging Face token。若后续切换到私有模型或团队模型，token 只能通过本机登录态、环境变量或后端密钥管理提供：
+
+- 本地开发：使用 `HF_TOKEN` 环境变量或 `huggingface-cli login`，不写入源码。
+- 前端调用：只允许调用公开模型或浏览器本地可访问的模型资产；不得把 token 打包进浏览器 bundle。
+- 后端调用：若必须调用私有模型或托管推理 API，token 只放在服务端环境变量或密钥管理系统中，前端通过后端任务 API 间接触发。
+
+### 4. LLM 微调与发布路线
+
+LLM 微调用于“ASR 后处理”，不替代 ASR。它的输入是字幕文本、当前代码片段、语言、运行输出和可选术语表；输出必须是可验证 JSON，用于更新字幕文本和生成章节：
+
+```ts
+export type SubtitleCorrectionResult = {
+  segments: Array<{
+    id: string;
+    text: string;
+  }>;
+  chapters?: Array<{
+    title: string;
+    startMs: number;
+    endMs?: number;
+  }>;
+};
+```
+
+微调建议走小模型 + LoRA/PEFT 或指令微调，训练数据来自用户明确授权的讲解样本、人工修订字幕、代码术语表和章节标注。训练、评估、发布不在浏览器中完成，建议独立脚本或 CI 外部任务执行：
+
+1. 采集样本：原始 ASR 字幕、人工修订字幕、对应代码上下文、章节标注。
+2. 生成训练集：把“纠正专业术语、变量名、函数名、英文缩写、章节边界”整理成指令样本。
+3. 微调模型：使用 Hugging Face 生态训练并评估术语准确率、JSON 合法率、章节边界误差。
+4. 发布模型：通过用户本机 `HF_TOKEN` 或 `huggingface-cli login` 推送到 Hugging Face Hub。
+5. 接入调用：本地可运行的模型走 `@huggingface/transformers`；不能在浏览器本地运行的模型走后端 job，token 不下发前端。
+
+微调模型输出必须经过 schema 校验和安全兜底：JSON 解析失败、段落数量不匹配、时间戳越界、章节重叠时，保留原始 ASR 字幕并记录 warning，不阻断播放。
+
+### 5. 云端派生资产
+
+云端阶段字幕不重新定义录制包格式，而是作为派生资产关联到 recording：
+
+| asset kind | 内容                         | 是否必需 | 说明                                     |
+| ---------- | ---------------------------- | -------- | ---------------------------------------- |
+| `subtitle` | `SubtitleTrack` JSON 或 WebVTT | 否       | 可由本地生成后上传，也可由云端任务生成   |
+| `chapter`  | 章节 JSON                    | 否       | 来自 LLM 后处理或人工标注                |
+
+云端播放描述可以返回字幕 asset URL；若不存在字幕，前端仍可在本地基于媒体生成。字幕资产 checksum、model、generatedAt、source 应进入派生资产元数据，便于追踪模型版本和回滚。
+
+### 6. 测试与验收
+
+新增测试覆盖：
+
+- `SubtitleNormalizer`：ASR chunks 转毫秒字幕段、空文本过滤、越界时间戳裁剪、纯文本兜底。
+- `SubtitleStore`：按 `recordingId` 保存、读取、覆盖、删除字幕轨。
+- `SubtitlePanel`：生成成功、生成失败、无音频降级、当前字幕高亮、点击字幕 seek。
+- `ReplayPage` 集成：字幕开关默认开启，字幕面板接收当前 timeline time、媒体 Blob、`hasAudio` 和 scheduler seek。
+
+手工验收至少覆盖两条录制：
+
+- 有音频录制：生成字幕、当前行跟随播放高亮、点击字幕跳转。
+- 无音频录制：生成按钮不可用，回放控制仍可用，页面展示无音频降级状态。
+
+## 十二、质量、测试与验收
 
 ### 1. P0 演示环境与量化预算
 
@@ -3072,7 +3194,7 @@ Demo 前准备一条稳定录制：
 - 媒体：开启麦克风和摄像头。
 - 回放：演示 1x、2x、seek、静音、关闭快捷键展示。
 
-## 十二、风险与降级策略
+## 十三、风险与降级策略
 
 | 风险                                 | 影响                                   | 降级策略                                                                                         |
 | ------------------------------------ | -------------------------------------- | ------------------------------------------------------------------------------------------------ |
@@ -3092,7 +3214,7 @@ Demo 前准备一条稳定录制：
 | 非主演示浏览器差异                   | 权限、WebM 或 autoplay 行为不一致      | P0 主演示锁定 Chrome/Edge latest + HTTPS/localhost，Safari/Firefox 只记录兼容差异                |
 | 最后一周加分项拖累主链路             | Demo 不稳定                            | Python、AI 字幕、WebRTC 都不阻塞 P0；只在主链路冻结后评估                                        |
 
-## 十三、Issue 拆分建议
+## 十四、Issue 拆分建议
 
 ### 1. 方案与 PoC
 
@@ -3147,7 +3269,7 @@ Demo 前准备一条稳定录制：
 | `[P1+ PoC] WebRTC 实时事件同步`                | P1+  |
 | `[P1+ 完整] WebRTC 双向音视频和面试后保存回放` | P1+  |
 
-## 十四、推荐实施顺序
+## 十五、推荐实施顺序
 
 ```mermaid
 flowchart TD
@@ -3173,7 +3295,7 @@ flowchart TD
 | 回放阶段结束    | seek、倍速、媒体同步可演示             |
 | DDL 前一天      | 冻结功能，只修阻塞问题                 |
 
-## 十五、最终结论
+## 十六、最终结论
 
 code-tape 的最优 P0 路线不是做一个缩小版在线 IDE，也不是做普通录屏工具，而是做一个稳定的 **结构化代码讲解播放器**：
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@code-tape/recording-schema": "0.0.0",
+        "@huggingface/transformers": "^4.2.0",
         "@radix-ui/react-popover": "^1.1.2",
         "@radix-ui/react-slider": "^1.2.1",
         "@radix-ui/react-toggle": "^1.1.0",
@@ -545,6 +546,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -1192,6 +1203,34 @@
       "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
       "license": "MIT"
     },
+    "node_modules/@huggingface/jinja": {
+      "version": "0.5.9",
+      "resolved": "https://registry.npmjs.org/@huggingface/jinja/-/jinja-0.5.9.tgz",
+      "integrity": "sha512-uWTG+l3VJRsl7EXxYizuL3P+cCPoc3cRqbWWRcQN0FhejRfbdq0RNhCmbY/YDtnTcz9icdLYuLDjsnz4d8JMuw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@huggingface/tokenizers": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@huggingface/tokenizers/-/tokenizers-0.1.3.tgz",
+      "integrity": "sha512-8rF/RRT10u+kn7YuUbUg0OF30K8rjTc78aHpxT+qJ1uWSqxT1MHi8+9ltwYfkFYJzT/oS+qw3JVfHtNMGAdqyA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@huggingface/transformers": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@huggingface/transformers/-/transformers-4.2.0.tgz",
+      "integrity": "sha512-8BRCoBMH0XsWaEIamuR0LrJGAfftgHAfb2Vrffy0VKlSAE/MnUJ5/h/zTfEP3fDIft+nk7TqB8xXEyABGitBjQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@huggingface/jinja": "^0.5.6",
+        "@huggingface/tokenizers": "^0.1.3",
+        "onnxruntime-node": "1.24.3",
+        "onnxruntime-web": "1.26.0-dev.20260416-b7804b056c",
+        "sharp": "^0.34.5"
+      }
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.2",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
@@ -1256,6 +1295,471 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@img/colour": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
+      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
+      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
+      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
+      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
+      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
+      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-ppc64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
+      "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-riscv64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
+      "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
+      "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
+      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
+      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
+      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
+      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
+      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-ppc64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
+      "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-ppc64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-riscv64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
+      "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-riscv64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
+      "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
+      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
+      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
+      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
+      "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.7.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
+      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
+      "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
+      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
@@ -1361,6 +1865,69 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+      "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+      "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/inquire": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.2.tgz",
+      "integrity": "sha512-pa0vFRuws4wkvaXKK1uXZMAwAX4/t8ANaJo45iw/oQHNQ9q5xUzwgFmVJGXiga2BeN+zpX7Vf9vmsiIa2J+MUw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
+      "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/@radix-ui/number": {
       "version": "1.1.1",
@@ -2481,7 +3048,6 @@
       "version": "22.19.19",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.19.tgz",
       "integrity": "sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -2905,6 +3471,15 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/adm-zip": {
+      "version": "0.5.17",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.17.tgz",
+      "integrity": "sha512-+Ut8d9LLqwEvHHJl1+PIHqoyDxFgVN847JTVM3Izi3xHDWPE4UtzzXysMZQs64DMcrJfBeS/uoEP4AD3HQHnQQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0"
+      }
+    },
     "node_modules/agent-base": {
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
@@ -3105,6 +3680,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/boolean": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/boolean/-/boolean-3.2.0.tgz",
+      "integrity": "sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+      "license": "MIT"
     },
     "node_modules/brace-expansion": {
       "version": "5.0.6",
@@ -3495,6 +4077,40 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/define-data-property": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/define-properties": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
+      "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.0.1",
+        "has-property-descriptors": "^1.0.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -3514,6 +4130,21 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/detect-node": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
+      "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
+      "license": "MIT"
     },
     "node_modules/detect-node-es": {
       "version": "1.1.0",
@@ -3582,7 +4213,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -3592,7 +4222,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -3633,6 +4262,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/es6-error": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
+      "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
+      "license": "MIT"
     },
     "node_modules/esbuild": {
       "version": "0.21.5",
@@ -3687,7 +4322,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
       "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -4088,6 +4722,12 @@
         "node": ">=16"
       }
     },
+    "node_modules/flatbuffers": {
+      "version": "25.9.23",
+      "resolved": "https://registry.npmjs.org/flatbuffers/-/flatbuffers-25.9.23.tgz",
+      "integrity": "sha512-MI1qs7Lo4Syw0EOzUl0xjs2lsoeqFku44KpngfIduHBYvzm8h2+7K8YMQh1JtVVVrUvhLpNwqVi4DERegUJhPQ==",
+      "license": "Apache-2.0"
+    },
     "node_modules/flatted": {
       "version": "3.4.2",
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
@@ -4222,6 +4862,23 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/global-agent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/global-agent/-/global-agent-3.0.0.tgz",
+      "integrity": "sha512-PT6XReJ+D07JvGoxQMkT6qji/jVNfX/h364XHZOWeRzy64sSFr+xJ5OX7LI3b4MPQzdL4H8Y8M0xzPpsVMwA8Q==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "boolean": "^3.0.1",
+        "es6-error": "^4.1.1",
+        "matcher": "^3.0.0",
+        "roarr": "^2.15.3",
+        "semver": "^7.3.2",
+        "serialize-error": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=10.0"
+      }
+    },
     "node_modules/globals": {
       "version": "15.15.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-15.15.0.tgz",
@@ -4235,11 +4892,26 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/globalthis": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
+      "integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "define-properties": "^1.2.1",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -4247,6 +4919,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/guid-typescript": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/guid-typescript/-/guid-typescript-1.0.9.tgz",
+      "integrity": "sha512-Y8T4vYhEfwJOTbouREvG+3XDsjr8E3kIr7uf+JZ0BYloFsttiHU0WfvANVsR7TxNUJa/WpCnw/Ino/p+DeBhBQ==",
+      "license": "ISC"
     },
     "node_modules/has-flag": {
       "version": "4.0.0",
@@ -4256,6 +4934,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/has-symbols": {
@@ -4599,6 +5289,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
+      "license": "ISC"
+    },
     "node_modules/json5": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
@@ -4700,6 +5396,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0"
+    },
     "node_modules/loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -4757,6 +5459,18 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/matcher": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/matcher/-/matcher-3.0.0.tgz",
+      "integrity": "sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng==",
+      "license": "MIT",
+      "dependencies": {
+        "escape-string-regexp": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/math-intrinsics": {
@@ -4940,6 +5654,58 @@
         "node": ">= 6"
       }
     },
+    "node_modules/object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/onnxruntime-common": {
+      "version": "1.24.3",
+      "resolved": "https://registry.npmjs.org/onnxruntime-common/-/onnxruntime-common-1.24.3.tgz",
+      "integrity": "sha512-GeuPZO6U/LBJXvwdaqHbuUmoXiEdeCjWi/EG7Y1HNnDwJYuk6WUbNXpF6luSUY8yASul3cmUlLGrCCL1ZgVXqA==",
+      "license": "MIT"
+    },
+    "node_modules/onnxruntime-node": {
+      "version": "1.24.3",
+      "resolved": "https://registry.npmjs.org/onnxruntime-node/-/onnxruntime-node-1.24.3.tgz",
+      "integrity": "sha512-JH7+czbc8ALA819vlTgcV+Q214/+VjGeBHDjX81+ZCD0PCVCIFGFNtT0V4sXG/1JXypKPgScQcB3ij/hk3YnTg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "os": [
+        "win32",
+        "darwin",
+        "linux"
+      ],
+      "dependencies": {
+        "adm-zip": "^0.5.16",
+        "global-agent": "^3.0.0",
+        "onnxruntime-common": "1.24.3"
+      }
+    },
+    "node_modules/onnxruntime-web": {
+      "version": "1.26.0-dev.20260416-b7804b056c",
+      "resolved": "https://registry.npmjs.org/onnxruntime-web/-/onnxruntime-web-1.26.0-dev.20260416-b7804b056c.tgz",
+      "integrity": "sha512-MD6Ss4GSpQBo6zqoJzyT9LRbKYs7x/JVN23FT24EcEvlqF4VuzPOeH6X38orZPKHQDbprn7K+SBpu0/mj2CQiw==",
+      "license": "MIT",
+      "dependencies": {
+        "flatbuffers": "^25.1.24",
+        "guid-typescript": "^1.0.9",
+        "long": "^5.2.3",
+        "onnxruntime-common": "1.24.0-dev.20251116-b39e144322",
+        "platform": "^1.3.6",
+        "protobufjs": "^7.2.4"
+      }
+    },
+    "node_modules/onnxruntime-web/node_modules/onnxruntime-common": {
+      "version": "1.24.0-dev.20251116-b39e144322",
+      "resolved": "https://registry.npmjs.org/onnxruntime-common/-/onnxruntime-common-1.24.0-dev.20251116-b39e144322.tgz",
+      "integrity": "sha512-BOoomdHYmNRL5r4iQ4bMvsl2t0/hzVQ3OM3PHD0gxeXu1PmggqBv3puZicEUVOA3AtHHYmqZtjMj9FOfGrATTw==",
+      "license": "MIT"
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -5105,6 +5871,12 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/platform": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.6.tgz",
+      "integrity": "sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==",
+      "license": "MIT"
     },
     "node_modules/playwright": {
       "version": "1.60.0",
@@ -5362,6 +6134,30 @@
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
       "license": "MIT"
+    },
+    "node_modules/protobufjs": {
+      "version": "7.6.1",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.1.tgz",
+      "integrity": "sha512-4K0myLaWL5EteuSAro91EGFgcfVgxb64Jx+7oDAY6GOkXD4M69yuSEljNcInGVCA5sOPxmZ/EqDLj2x0Q0+Ygg==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.5",
+        "@protobufjs/eventemitter": "^1.1.1",
+        "@protobufjs/fetch": "^1.1.1",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.2",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.1",
+        "@types/node": ">=13.7.0",
+        "long": "^5.3.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
     },
     "node_modules/punycode": {
       "version": "2.3.1",
@@ -5633,6 +6429,23 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/roarr": {
+      "version": "2.15.4",
+      "resolved": "https://registry.npmjs.org/roarr/-/roarr-2.15.4.tgz",
+      "integrity": "sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "boolean": "^3.0.1",
+        "detect-node": "^2.0.4",
+        "globalthis": "^1.0.1",
+        "json-stringify-safe": "^5.0.1",
+        "semver-compare": "^1.0.0",
+        "sprintf-js": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
     "node_modules/rollup": {
       "version": "4.60.4",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.4.tgz",
@@ -5755,7 +6568,6 @@
       "version": "7.8.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
       "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -5764,11 +6576,76 @@
         "node": ">=10"
       }
     },
+    "node_modules/semver-compare": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
+      "integrity": "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==",
+      "license": "MIT"
+    },
+    "node_modules/serialize-error": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-7.0.1.tgz",
+      "integrity": "sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==",
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^0.13.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/setimmediate": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
       "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
       "license": "MIT"
+    },
+    "node_modules/sharp": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
+      "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@img/colour": "^1.0.0",
+        "detect-libc": "^2.1.2",
+        "semver": "^7.7.3"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.34.5",
+        "@img/sharp-darwin-x64": "0.34.5",
+        "@img/sharp-libvips-darwin-arm64": "1.2.4",
+        "@img/sharp-libvips-darwin-x64": "1.2.4",
+        "@img/sharp-libvips-linux-arm": "1.2.4",
+        "@img/sharp-libvips-linux-arm64": "1.2.4",
+        "@img/sharp-libvips-linux-ppc64": "1.2.4",
+        "@img/sharp-libvips-linux-riscv64": "1.2.4",
+        "@img/sharp-libvips-linux-s390x": "1.2.4",
+        "@img/sharp-libvips-linux-x64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
+        "@img/sharp-linux-arm": "0.34.5",
+        "@img/sharp-linux-arm64": "0.34.5",
+        "@img/sharp-linux-ppc64": "0.34.5",
+        "@img/sharp-linux-riscv64": "0.34.5",
+        "@img/sharp-linux-s390x": "0.34.5",
+        "@img/sharp-linux-x64": "0.34.5",
+        "@img/sharp-linuxmusl-arm64": "0.34.5",
+        "@img/sharp-linuxmusl-x64": "0.34.5",
+        "@img/sharp-wasm32": "0.34.5",
+        "@img/sharp-win32-arm64": "0.34.5",
+        "@img/sharp-win32-ia32": "0.34.5",
+        "@img/sharp-win32-x64": "0.34.5"
+      }
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -5809,6 +6686,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/sprintf-js": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
+      "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/stackback": {
       "version": "0.0.2",
@@ -6166,6 +7049,18 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/type-fest": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
+      "integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
@@ -6208,7 +7103,6 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/update-browserslist-db": {

--- a/scripts/tests/workflow-rules.test.mjs
+++ b/scripts/tests/workflow-rules.test.mjs
@@ -499,6 +499,19 @@ test('technical plan owns P1 cloud contract without standalone cloud plan', () =
   }
 });
 
+test('technical plan owns P1 plus AI subtitle architecture and HF token boundary', () => {
+  const technicalPlan = readFileSync('docs/技术方案.md', 'utf8');
+
+  assert.match(technicalPlan, /## 十一、P1\+ AI 字幕与 Hugging Face 模型方案/u);
+  assert.match(technicalPlan, /字幕、纠错结果和章节属于可重建的派生资产/u);
+  assert.match(technicalPlan, /不把字幕写入 `RecordingPackageV1` 主 schema/u);
+  assert.match(technicalPlan, /`@huggingface\/transformers`/u);
+  assert.match(technicalPlan, /`onnx-community\/whisper-tiny`/u);
+  assert.match(technicalPlan, /不得把 token 打包进浏览器 bundle/u);
+  assert.match(technicalPlan, /通过用户本机 `HF_TOKEN` 或 `huggingface-cli login` 推送到 Hugging Face Hub/u);
+  assert.match(technicalPlan, /JSON 解析失败[\s\S]*保留原始 ASR 字幕/u);
+});
+
 test('repository text does not reference the standalone cloud plan path', () => {
   const trackedFiles = execFileSync('git', ['ls-files'], {
     encoding: 'utf8',


### PR DESCRIPTION
## 关联

Refs #2（总控 issue，不在本 PR 中关闭）
Closes #98

## 改动点

- 将 P1+ AI 字幕与 Hugging Face 模型方案合入 `docs/技术方案.md`，明确字幕作为派生资产、浏览器本地 ASR、LLM 后处理边界和 HF token 安全边界。
- 新增 replay 字幕模块：本地 `@huggingface/transformers` ASR 转写、IndexedDB 字幕缓存、字幕面板、当前字幕高亮、点击字幕 seek、无音频降级态。
- 在回放页集成字幕开关与字幕生成面板，并补充 subtitle/replay/authority-docs 契约测试。
- 根据 repo-guard 反馈补强异步稳定性：生成请求版本仲裁、卸载/切换录制取消、加载中禁用生成、开放 ASR timestamp 兜底、HF pipeline 初始化失败后可重试。

## 影响范围

- 回放体验增加可选 AI 字幕能力，不改变 `RecordingPackageV1` schema，不改变 replay scheduler 内核。
- 浏览器端会懒加载 Transformers.js 相关 wasm/runtime 资源；仅在用户点击生成字幕时进行本地推理。
- Hugging Face token 不进入前端 bundle、源码或 PR；私有模型/发布/托管调用需走本地登录、`HF_TOKEN` 或后续服务端密钥边界。

## GitNexus 影响分析摘要

- 风险等级: HIGH
- 风险说明: 新增字幕链路跨 replay UI、字幕生成、IndexedDB 缓存和浏览器本地 ASR；未修改录制包 schema 或 scheduler 内核。
- 关键骨架变更: `docs/技术方案.md`; `apps/web/src/features/player/ReplayPage.tsx`; `apps/web/src/features/subtitles/SubtitlePanel.tsx`; `apps/web/src/features/subtitles/subtitleTranscriber.ts`。
- GitNexus 影响面: `detect_changes` 显示 15 个文件、94 个 changed symbols、10 条 affected processes；影响集中在 `ReplayPage` 展示链路、`SubtitlePanel` 异步生成仲裁、`createHuggingFaceSubtitleTranscriber/getPipeline` 模型加载重试，以及 `normalizeTranscriptionResult` 时间戳归一化。`context(SubtitlePanel)` 确认上游只由 `ReplayPage` 接入；`context(createHuggingFaceSubtitleTranscriber)` 确认上游只来自字幕面板初始化。
- 验证结果: `npm run quality:predev` passed; `npm run agent:bootstrap` passed; targeted subtitle/replay tests passed; `npm run quality:precommit` passed; `npm run quality:local` passed locally and again through pre-push; GitHub `Workflow Tests / quality` passed. 失败的 `guard` 日志均为 `PR needs CR通过 from the first eligible non-author PR reviewer`。

## 自检

- [x] 未修改 `docs/progress.json` 或 `docs/progress.md`
- [x] 已运行 `npm run quality:local`，或说明无法运行的原因
- [x] 已说明改动点和影响范围
- [x] 如果改动关键骨架，已补充契约测试并填写 GitNexus 影响分析摘要
- [ ] 已邀请至少一名非作者同学 CR
