### PR TITLE
[codex] Document local LLM subtitle plan

### DIFF
--- a/docs/技术方案.md
+++ b/docs/技术方案.md
@@ -2970,7 +2970,7 @@ P1 云端方案的主线是：**本地录制包先完整生成，云端只负责
 
 ## 十一、P1+ AI 字幕与 Hugging Face 模型方案
 
-本章收敛 issue #98 的技术路线。AI 字幕是 P1+ 增强能力，不改变 P0/P1 的录制包事实源：`RecordingPackageV1` 仍只保存录制事实、媒体描述和回放索引；字幕、纠错结果和章节属于可重建的派生资产。派生资产可以先保存在本地 IndexedDB，云端阶段再作为 `subtitle`、`chapter` 等 asset 写入对象存储。
+本章收敛 PRD 中 P1+ AI 字幕生成的技术路线。AI 字幕是 P1+ 增强能力，不改变 P0/P1 的录制包事实源：`RecordingPackageV1` 仍只保存录制事实、媒体描述和回放索引；字幕、纠错结果和章节属于可重建的派生资产。派生资产可以先保存在本地 IndexedDB，云端阶段再作为 `subtitle`、`chapter` 等 asset 写入对象存储。
 
 ### 1. 目标与边界
 
@@ -2987,18 +2987,20 @@ P1 云端方案的主线是：**本地录制包先完整生成，云端只负责
 - 不把字幕写入 `RecordingPackageV1` 主 schema，避免核心包校验和迁移复杂度扩大。
 - 不默认上传录音到 Hugging Face Inference API、Spaces 或其他第三方托管服务。
 - 不在前端代码、文档、测试 fixture、PR 描述中保存 Hugging Face token。
-- 不把 LLM 纠错或章节生成作为基础字幕验收前置条件。
+- 不把 LLM 纠错或章节生成作为基础字幕验收前置条件；二者是 ASR 字幕生成之后的增强链路，失败时必须回退到原始 ASR 字幕。
 
 ### 2. 稳定架构
 
-AI 字幕链路分为四个稳定边界：
+AI 字幕链路分为六个稳定边界：
 
 | 边界                  | 职责                                                                 | 输入/输出                                               |
 | --------------------- | -------------------------------------------------------------------- | ------------------------------------------------------- |
 | `SubtitleTranscriber` | 负责 warm-up 本地模型，并从媒体 Blob 生成原始字幕段                  | 可选 `warmUp()`；输入 `mediaBlob`、`durationMs`；输出 `SubtitleTrack` 草稿 |
 | `SubtitleNormalizer`  | 负责把模型返回的 chunk/timestamp 归一化为毫秒级字幕段                | 输入 ASR 结果；输出 `SubtitleSegment[]`                 |
+| `SubtitlePostProcessor` | 负责调用本地 LLM，对 ASR 字幕做术语、变量名、函数名和中英混合文本纠错，并生成章节跳转点 | 输入 `SubtitleTrack`、代码上下文、运行输出、术语表；输出 `SubtitleCorrectionResult` |
 | `SubtitleStore`       | 负责按 `recordingId` 存取字幕派生资产                                | 本地 IndexedDB；云端阶段可替换为远端 asset repository   |
 | `SubtitlePanel`       | 负责展示、当前行高亮、自动滚动、点击 seek、生成失败状态              | 输入播放器时间和 `onSeek`；不直接操作 scheduler 内部状态 |
+| `SubtitleChapterList` | 负责展示 LLM 生成的章节标题和时间范围，点击章节调用播放器 `seek(startMs)` | 输入校验后的章节数组和 `onSeek`；不持有模型状态 |
 
 推荐类型：
 
@@ -3020,7 +3022,7 @@ export type SubtitleTrack = {
 };
 ```
 
-回放页只依赖 `SubtitlePanel` 和 `onSeek(timeMs)`，不关心模型、token、存储细节。这样字幕能力可以从本地 Hugging Face 模型平滑演进到云端任务或用户自定义模型，而不重写回放调度器。
+回放页只依赖 `SubtitlePanel`、`SubtitleChapterList` 和 `onSeek(timeMs)`，不关心模型、token、存储细节。这样字幕能力可以从本地 Hugging Face 模型平滑演进到云端任务或用户自定义模型，而不重写回放调度器。
 
 ### 3. Hugging Face ASR 方案
 
@@ -3039,7 +3041,19 @@ P1+ 最小展示版默认使用 Hugging Face Hub 上兼容 Transformers.js 的 A
 
 ### 4. LLM 微调与发布路线
 
-LLM 微调用于“ASR 后处理”，不替代 ASR。它的输入是字幕文本、当前代码片段、语言、运行输出和可选术语表；输出必须是可验证 JSON，用于更新字幕文本和生成章节：
+LLM 微调用于“ASR 后处理”，不替代 Whisper/ASR。它只消费已经带时间戳的字幕段和代码讲解上下文，输出两个独立派生结果：
+
+- **纠错后的字幕轨**：修正前端领域术语、组件名、变量名、函数名、包名、英文缩写和 code-tape 专有词；中文内容默认输出简体中文，英文内容保留英文，用户一句中文一句英文时允许同一字幕轨自然混合中英文本。
+- **章节跳转点**：基于字幕内容和时间范围自动分段，生成类似“问题分析”“状态设计”“代码实现”“调试验证”的章节标题；点击章节调用现有播放器 `seek(startMs)`，章节列表独立展示在回放 UI 中，不塞进字幕行，也不写入 `RecordingPackageV1`。
+
+LLM 输入必须保持可审计，建议包含：
+
+- 原始 ASR 字幕段：`id`、`startMs`、`endMs`、`text`。
+- 录制代码上下文：项目语言、当前文件名、可见代码片段、近期编辑过的 symbol。
+- 运行上下文：终端输出、测试失败信息、浏览器报错或用户显式选择的错误文本。
+- 领域术语表：React/Vue/TypeScript、CSS、构建工具、code-tape 功能名、仓库内变量/函数/组件名。
+
+LLM 输出必须是可验证 JSON，用于更新字幕文本和生成章节：
 
 ```ts
 export type SubtitleCorrectionResult = {
@@ -3047,7 +3061,7 @@ export type SubtitleCorrectionResult = {
     id: string;
     text: string;
   }>;
-  chapters?: Array<{
+  chapters: Array<{
     title: string;
     startMs: number;
     endMs?: number;
@@ -3055,15 +3069,31 @@ export type SubtitleCorrectionResult = {
 };
 ```
 
-微调建议走小模型 + LoRA/PEFT 或指令微调，训练数据来自用户明确授权的讲解样本、人工修订字幕、代码术语表和章节标注。训练、评估、发布不在浏览器中完成，建议独立脚本或 CI 外部任务执行：
+代码层为了兼容“只做字幕纠错、不生成章节”的历史调用，`chapters` 可以继续以可选字段接入；但完整 P1+ 模式的模型输出必须总是包含 `chapters` 数组，无法可靠分段时返回空数组，而不是省略字段。
+
+微调建议走小模型 + LoRA/PEFT 或指令微调，训练数据来自用户明确授权的讲解样本、人工修订字幕、代码术语表和章节标注。模型仓库建议公开发布到 Hugging Face Hub，例如 `ceilf6/code-tape-subtitle-postprocessor-onnx`；浏览器本地推理只拉取公开模型资产，不需要也不得携带 Hugging Face token。训练、评估、量化和发布不在浏览器中完成，建议独立脚本或 CI 外部任务执行：
 
 1. 采集样本：原始 ASR 字幕、人工修订字幕、对应代码上下文、章节标注。
-2. 生成训练集：把“纠正专业术语、变量名、函数名、英文缩写、章节边界”整理成指令样本。
-3. 微调模型：使用 Hugging Face 生态训练并评估术语准确率、JSON 合法率、章节边界误差。
+2. 生成训练集：把“纠正专业术语、变量名、函数名、英文缩写、简体中文输出、中英混合保留、章节边界”整理成指令样本。
+3. 微调模型：使用 Hugging Face 生态训练并评估术语准确率、简体中文一致性、中英混合保真率、JSON 合法率、章节边界误差。
 4. 发布模型：通过用户本机 `HF_TOKEN` 或 `huggingface-cli login` 推送到 Hugging Face Hub。
-5. 接入调用：本地可运行的模型走 `@huggingface/transformers`；不能在浏览器本地运行的模型走后端 job，token 不下发前端。
+5. 导出量化：优先导出 Transformers.js 兼容 ONNX，并提供 q4/q8 量化版本；若遇到 ONNX Runtime Web 量化节点缺少 scale 等兼容性问题，必须回退到未融合或重新导出的权重，不在前端吞异常继续展示“已纠错”。
+6. 接入调用：本地可运行的公开模型走 `@huggingface/transformers` 浏览器本地推理；不能在浏览器本地运行的模型才走后端 job，token 不下发前端。
 
-微调模型输出必须经过 schema 校验和安全兜底：JSON 解析失败、段落数量不匹配、时间戳越界、章节重叠时，保留原始 ASR 字幕并记录 warning，不阻断播放。
+浏览器本地 LLM 的运行约束：
+
+- 推理发生在用户浏览器内，优先 WebGPU，缺失时回退 WASM/CPU；参数规模以首次加载、内存占用和移动端可用性为硬约束。
+- 模型加载可以在回放页空闲时提前 warm-up，但只下载/初始化模型，不提前处理字幕内容；ASR 完成后用户触发“纠错并生成章节”才运行后处理。
+- 输出 schema 校验必须在应用层完成，不能相信模型自报格式正确。
+
+微调模型输出必须经过 schema 校验和安全兜底：JSON 解析失败、缺失 `segments` 或 `chapters`、出现未知 segment id、空文本、段落数量不匹配、时间戳越界、章节重叠或章节不按时间排序时，保留原始 ASR 字幕并记录 warning，不阻断播放；如果只有章节非法而字幕纠错合法，可以保留纠错字幕并丢弃章节，或保留上一版合法章节，但不能污染字幕轨。
+
+章节生成的验收标准：
+
+- 章节来源必须是字幕内容和时间戳，不得凭空引用录制包之外的信息。
+- 章节 `startMs` 必须落在录制时长内，`endMs` 缺省时由下一章节或录制结束时间推导。
+- 章节标题保持短文本，面向回放导航，不写成长句总结。
+- 章节列表点击后必须复用现有 `seek(startMs)`，不绕过回放调度器。
 
 ### 5. 云端派生资产
 
@@ -3083,11 +3113,15 @@ export type SubtitleCorrectionResult = {
 - `SubtitleNormalizer`：ASR chunks 转毫秒字幕段、空文本过滤、越界时间戳裁剪、纯文本兜底。
 - `SubtitleStore`：按 `recordingId` 保存、读取、覆盖、删除字幕轨。
 - `SubtitlePanel`：生成成功、生成失败、无音频降级、当前字幕高亮、点击字幕 seek。
+- `SubtitlePostProcessor`：构造本地 LLM prompt、解析严格 JSON、校验 `segments` 和 `chapters`、未知 id/非法章节降级。
+- `SubtitleChapterList`：展示章节标题和时间范围，点击章节调用 `seek(startMs)`。
 - `ReplayPage` 集成：字幕开关默认开启，字幕面板接收当前 timeline time、媒体 Blob、`hasAudio` 和 scheduler seek。
+- 文档契约：PRD 中“本地 LLM 纠错”和“自动分段生成章节跳转点”必须同时出现在技术方案和测试断言中，防止后续只实现其中一半。
 
 手工验收至少覆盖两条录制：
 
 - 有音频录制：生成字幕、当前行跟随播放高亮、点击字幕跳转。
+- 有中英混合讲解的前端代码录制：ASR 结果经本地 LLM 后输出简体中文 + 英文混合字幕，React/TypeScript/code-tape 术语、变量名和函数名不被翻译错，同时生成可点击章节。
 - 无音频录制：生成按钮不可用，回放控制仍可用，页面展示无音频降级状态。
 
 ## 十二、质量、测试与验收

--- a/scripts/tests/workflow-rules.test.mjs
+++ b/scripts/tests/workflow-rules.test.mjs
@@ -538,7 +538,21 @@ test('technical plan owns P1 plus AI subtitle architecture and HF token boundary
   assert.match(technicalPlan, /同一录制媒体只触发一次 warm-up/u);
   assert.match(technicalPlan, /不得把 token 打包进浏览器 bundle/u);
   assert.match(technicalPlan, /通过用户本机 `HF_TOKEN` 或 `huggingface-cli login` 推送到 Hugging Face Hub/u);
+  assert.match(technicalPlan, /公开发布到 Hugging Face Hub/u);
+  assert.match(technicalPlan, /浏览器本地推理只拉取公开模型资产/u);
+  assert.match(technicalPlan, /不得携带 Hugging Face token/u);
+  assert.match(technicalPlan, /不替代 Whisper\/ASR/u);
+  assert.match(technicalPlan, /默认输出简体中文/u);
+  assert.match(technicalPlan, /允许同一字幕轨自然混合中英文本/u);
+  assert.match(technicalPlan, /前端领域术语、组件名、变量名、函数名/u);
+  assert.match(technicalPlan, /章节跳转点/u);
+  assert.match(technicalPlan, /点击章节调用现有播放器 `seek\(startMs\)`/u);
+  assert.match(technicalPlan, /`SubtitleChapterList`/u);
+  assert.match(technicalPlan, /chapters: Array/u);
+  assert.match(technicalPlan, /完整 P1\+ 模式的模型输出必须总是包含 `chapters` 数组/u);
   assert.match(technicalPlan, /JSON 解析失败[\s\S]*保留原始 ASR 字幕/u);
+  assert.match(technicalPlan, /如果只有章节非法而字幕纠错合法[\s\S]*不能污染字幕轨/u);
+  assert.match(technicalPlan, /PRD 中“本地 LLM 纠错”和“自动分段生成章节跳转点”必须同时出现在技术方案/u);
 });
 
 test('repository text does not reference the standalone cloud plan path', () => {


### PR DESCRIPTION
## 概要
- 更新 `docs/技术方案.md` 的 P1+ AI 字幕方案，明确浏览器本地 ASR + LLM 后处理路线。
- 补齐本地 LLM 纠错和自动章节跳转点两个 PRD 挑战项，包含简体中文、中英混合、公开 Hugging Face 模型、token 边界、JSON schema 与降级策略。
- 更新 `scripts/tests/workflow-rules.test.mjs`，将上述约束沉淀为文档契约测试。

## 说明
按用户要求，本 PR 不关联 GitHub issue；目的是触发 repo-guard / Copilot 评论，先检查技术方案质量。

## GitNexus 影响分析摘要
- 风险等级: LOW
- 关键骨架变更: docs/技术方案.md; scripts/tests/workflow-rules.test.mjs
- GitNexus 影响面: detect_changes(scope=all) reported low risk with no affected processes; query("AI subtitle Hugging Face local LLM correction chapters technical plan contract tests") surfaced subtitle transcribe/store/correction definitions; context(applySubtitleCorrection) confirmed existing correction flow only calls normalizeChapters/invalid and no runtime code was changed.
- 验证结果: npm run quality:predev; npm run agent:bootstrap; npm run test -- scripts/tests/workflow-rules.test.mjs; npm run quality:precommit; npm run quality:local

## 自检
- [x] 未在前端、文档或测试中写入 Hugging Face token
- [x] 未修改运行时代码
- [x] PR body 不包含 closing issue 关键词
