### PR TITLE
feat(api): add owner playback descriptor API for cloud recordings

### DIFF
--- a/apps/api/src/cloud/__tests__/objectStorageContract.test.ts
+++ b/apps/api/src/cloud/__tests__/objectStorageContract.test.ts
@@ -1,0 +1,11 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { ObjectStorage } from "../objectStorage.js";
+
+test("ObjectStorage requires playback asset URL generation", () => {
+  type Assert<T extends true> = T;
+  type AssetUrlIsRequired = undefined extends ObjectStorage["getAssetUrl"] ? false : true;
+
+  const contract: Assert<AssetUrlIsRequired> = true;
+  assert.equal(contract, true);
+});

--- a/apps/api/src/cloud/cloudRecordingService.ts
+++ b/apps/api/src/cloud/cloudRecordingService.ts
@@ -9,6 +9,7 @@ import {
 } from "./types.js";
 import type {
   CloudApiError,
+  CloudPlaybackDescriptor,
   CloudRecordingDetail,
   CloudRecordingListItem,
   CloudRecordingAssetRecord,
@@ -24,6 +25,7 @@ import type {
 } from "./types.js";
 
 const REQUIRED_ASSETS: RecordingAssetKind[] = ["manifest", "meta", "events", "snapshots"];
+const PLAYBACK_DESCRIPTOR_TTL_MS = 5 * 60 * 1000;
 const SESSION_TTL_MS = 30 * 60 * 1000;
 const RECORDING_ASSET_KIND_SET = new Set<string>(RECORDING_ASSET_KINDS);
 const RECORDING_LANGUAGES = [
@@ -52,6 +54,10 @@ export type CloudRecordingService = {
     ownerId: string;
     recordingId: string;
   }): Promise<CloudResult<CloudRecordingDetail>>;
+  getPlaybackDescriptor(input: {
+    ownerId: string;
+    recordingId: string;
+  }): Promise<CloudResult<CloudPlaybackDescriptor>>;
 };
 
 export function createCloudRecordingService(deps: {
@@ -206,6 +212,49 @@ export function createCloudRecordingService(deps: {
         return { ok: false, error: { code: "not-found", message: "recording not found" } };
       }
       return { ok: true, value: toDetail(recording) };
+    },
+    async getPlaybackDescriptor({ ownerId, recordingId }) {
+      const recording = await deps.metadata.getRecording(recordingId);
+      if (!recording || recording.ownerId !== ownerId || recording.status !== "ready") {
+        return { ok: false, error: { code: "not-found", message: "recording not found" } };
+      }
+
+      const assets = await deps.metadata.listAssets(recordingId);
+      const assetsByKind = new Map(assets.map((asset) => [asset.kind, asset]));
+      const missingRequired = REQUIRED_ASSETS.filter((kind) => !assetsByKind.has(kind));
+      if (missingRequired.length > 0) {
+        return {
+          ok: false,
+          error: { code: "not-found", message: "playback descriptor not available" },
+        };
+      }
+
+      if (!deps.objectStorage.getAssetUrl) {
+        throw new Error("object storage must support getAssetUrl for playback descriptor generation");
+      }
+
+      const getUrl = (kind: RecordingAssetKind): string | null => {
+        const asset = assetsByKind.get(kind);
+        return asset ? deps.objectStorage.getAssetUrl!(asset.objectKey) : null;
+      };
+
+      return {
+        ok: true,
+        value: {
+          id: recording.id,
+          title: recording.title,
+          durationMs: recording.durationMs,
+          schemaVersion: recording.schemaVersion,
+          manifestUrl: getUrl("manifest")!,
+          metaUrl: getUrl("meta")!,
+          eventsUrl: getUrl("events")!,
+          snapshotsUrl: getUrl("snapshots")!,
+          indexesUrl: getUrl("indexes"),
+          mediaUrl: getUrl("media"),
+          thumbnailUrl: getUrl("thumbnail"),
+          expiresAt: new Date(now().getTime() + PLAYBACK_DESCRIPTOR_TTL_MS).toISOString(),
+        },
+      };
     },
   };
 }

--- a/apps/api/src/cloud/cloudRecordingService.ts
+++ b/apps/api/src/cloud/cloudRecordingService.ts
@@ -229,13 +229,9 @@ export function createCloudRecordingService(deps: {
         };
       }
 
-      if (!deps.objectStorage.getAssetUrl) {
-        throw new Error("object storage must support getAssetUrl for playback descriptor generation");
-      }
-
       const getUrl = (kind: RecordingAssetKind): string | null => {
         const asset = assetsByKind.get(kind);
-        return asset ? deps.objectStorage.getAssetUrl!(asset.objectKey) : null;
+        return asset ? deps.objectStorage.getAssetUrl(asset.objectKey) : null;
       };
 
       return {

--- a/apps/api/src/cloud/localDevObjectStorage.ts
+++ b/apps/api/src/cloud/localDevObjectStorage.ts
@@ -125,6 +125,9 @@ export function createLocalDevObjectStorage(
     async deleteObject(key: string): Promise<void> {
       objects.delete(key);
     },
+    getAssetUrl(key: string): string {
+      return buildLocalDevObjectUrl(publicBaseUrl, key);
+    },
   };
 
   return storage;

--- a/apps/api/src/cloud/memoryObjectStorage.ts
+++ b/apps/api/src/cloud/memoryObjectStorage.ts
@@ -53,6 +53,9 @@ export function createMemoryObjectStorage(): MemoryObjectStorage {
     async deleteObject(key: string): Promise<void> {
       objects.delete(key);
     },
+    getAssetUrl(key: string): string {
+      return `memory:${encodeURIComponent(key)}`;
+    },
   };
 
   return storage;

--- a/apps/api/src/cloud/objectStorage.ts
+++ b/apps/api/src/cloud/objectStorage.ts
@@ -23,4 +23,5 @@ export type ObjectStorage = {
   putObject(input: PutObjectInput): Promise<void>;
   getObject(key: string): Promise<StoredObject | null>;
   deleteObject(key: string): Promise<void>;
+  getAssetUrl?(objectKey: string): string;
 };

--- a/apps/api/src/cloud/objectStorage.ts
+++ b/apps/api/src/cloud/objectStorage.ts
@@ -23,5 +23,5 @@ export type ObjectStorage = {
   putObject(input: PutObjectInput): Promise<void>;
   getObject(key: string): Promise<StoredObject | null>;
   deleteObject(key: string): Promise<void>;
-  getAssetUrl?(objectKey: string): string;
+  getAssetUrl(objectKey: string): string;
 };

--- a/apps/api/src/cloud/types.ts
+++ b/apps/api/src/cloud/types.ts
@@ -121,6 +121,21 @@ export type CloudRecordingDetail = CloudRecordingListItem & {
   failureMessage: string | null;
 };
 
+export type CloudPlaybackDescriptor = {
+  id: string;
+  title: string;
+  durationMs: number;
+  schemaVersion: RecordingSchemaVersion;
+  manifestUrl: string;
+  metaUrl: string;
+  eventsUrl: string;
+  snapshotsUrl: string;
+  indexesUrl: string | null;
+  mediaUrl: string | null;
+  thumbnailUrl: string | null;
+  expiresAt: string;
+};
+
 export type CloudRecordingRecord = {
   id: string;
   ownerId: string;

--- a/apps/api/src/http/__tests__/cloudApiHandler.test.ts
+++ b/apps/api/src/http/__tests__/cloudApiHandler.test.ts
@@ -12,6 +12,15 @@ import { createLocalDevObjectStorageHandler } from "../localDevObjectStorageHand
 import type { MetadataRepository } from "../../cloud/metadataRepository.js";
 import type { CloudRecordingAssetRecord, CloudRecordingRecord, RecordingAssetKind, RecordingStatus } from "../../cloud/types.js";
 
+const NON_PLAYABLE_RECORDING_STATUSES = [
+  "uploading",
+  "processing",
+  "failed",
+  "soft_deleted",
+  "purging",
+  "deleted",
+] as const satisfies readonly Exclude<RecordingStatus, "ready">[];
+
 function createTestApiHandler(
   objectStorage: ReturnType<typeof createMemoryObjectStorage> | ReturnType<typeof createLocalDevObjectStorage>,
   createRequestId: () => string,
@@ -333,22 +342,28 @@ test("GET /api/recordings/:recordingId/playback returns 404 for non-ready or own
     hasAudio: false,
     hasCamera: false,
   }, ["manifest", "meta", "events", "snapshots"]);
-  await seedRecordingWithAssets(metadata, {
-    id: "rec-processing-playback",
-    ownerId: "owner-1",
-    status: "processing",
-    hasAudio: false,
-    hasCamera: false,
-  }, ["manifest", "meta", "events", "snapshots"]);
+  for (const status of NON_PLAYABLE_RECORDING_STATUSES) {
+    await seedRecordingWithAssets(metadata, {
+      id: `rec-${status}-playback`,
+      ownerId: "owner-1",
+      status,
+      hasAudio: false,
+      hasCamera: false,
+    }, ["manifest", "meta", "events", "snapshots"]);
+  }
   const handler = createCloudApiHandler({
     service: createCloudRecordingService({ metadata, objectStorage: createMemoryObjectStorage() }),
     createRequestId: () => "req-playback-not-found",
   });
 
-  for (const path of [
+  const notFoundPlaybackPaths = [
     "http://localhost/api/recordings/rec-owner-2-playback/playback",
-    "http://localhost/api/recordings/rec-processing-playback/playback",
-  ]) {
+    ...NON_PLAYABLE_RECORDING_STATUSES.map(
+      (status) => `http://localhost/api/recordings/rec-${status}-playback/playback`,
+    ),
+  ];
+
+  for (const path of notFoundPlaybackPaths) {
     const response = await handler(
       new Request(path, {
         method: "GET",
@@ -392,6 +407,28 @@ test("GET /api/recordings/:recordingId/playback returns null for optional media/
   assert.equal(body.indexesUrl, null);
   assert.equal(body.mediaUrl, null);
   assert.equal(body.thumbnailUrl, null);
+});
+
+test("GET /api/recordings/:recordingId/playback requires owner token", async () => {
+  const handler = createCloudApiHandler({
+    service: createCloudRecordingService({
+      metadata: createMemoryMetadataRepository(),
+      objectStorage: createMemoryObjectStorage(),
+    }),
+    createRequestId: () => "req-playback-owner-token",
+  });
+
+  const response = await handler(new Request("http://localhost/api/recordings/rec-1/playback", { method: "GET" }));
+  const body = (await response.json()) as { error: { code: string; message: string; requestId: string } };
+
+  assert.equal(response.status, 401);
+  assert.deepEqual(body, {
+    error: {
+      code: "unauthorized",
+      message: "missing owner token",
+      requestId: "req-playback-owner-token",
+    },
+  });
 });
 
 test("GET /api/recordings/:recordingId requires owner token", async () => {

--- a/apps/api/src/http/__tests__/cloudApiHandler.test.ts
+++ b/apps/api/src/http/__tests__/cloudApiHandler.test.ts
@@ -4,13 +4,13 @@ import { canonicalStringify, sha256Hex } from "@code-tape/recording-schema/hash"
 import { RECORDING_SCHEMA_VERSION, type RecordingPackageV1 } from "@code-tape/recording-schema";
 import { createCloudRecordingService } from "../../cloud/cloudRecordingService.js";
 import { createMemoryMetadataRepository } from "../../cloud/memoryMetadataRepository.js";
-import { createLocalDevObjectStorage } from "../../cloud/localDevObjectStorage.js";
+import { buildLocalDevObjectUrl, createLocalDevObjectStorage } from "../../cloud/localDevObjectStorage.js";
 import { createMemoryObjectStorage } from "../../cloud/memoryObjectStorage.js";
 import { createApiHandler } from "../createApiHandler.js";
 import { createCloudApiHandler } from "../cloudApiHandler.js";
 import { createLocalDevObjectStorageHandler } from "../localDevObjectStorageHandler.js";
 import type { MetadataRepository } from "../../cloud/metadataRepository.js";
-import type { CloudRecordingRecord, RecordingStatus } from "../../cloud/types.js";
+import type { CloudRecordingAssetRecord, CloudRecordingRecord, RecordingAssetKind, RecordingStatus } from "../../cloud/types.js";
 
 function createTestApiHandler(
   objectStorage: ReturnType<typeof createMemoryObjectStorage> | ReturnType<typeof createLocalDevObjectStorage>,
@@ -240,6 +240,158 @@ test("GET /api/recordings/:recordingId returns 404 for other owners and hidden s
       requestId: "req-detail-not-found",
     });
   }
+});
+
+test("GET /api/recordings/:recordingId/playback returns playback descriptor for ready recordings", async () => {
+  const metadata = createMemoryMetadataRepository();
+  const objectStorage = createLocalDevObjectStorage({ publicBaseUrl: "http://localhost" });
+  await seedRecordingWithAssets(metadata, {
+    id: "rec-ready-playback",
+    ownerId: "owner-1",
+    status: "ready",
+    hasAudio: true,
+    hasCamera: true,
+  }, ["manifest", "meta", "events", "snapshots", "indexes", "media", "thumbnail"]);
+  const handler = createCloudApiHandler({
+    service: createCloudRecordingService({ metadata, objectStorage }),
+    createRequestId: () => "req-playback-ready",
+  });
+
+  const response = await handler(
+    new Request("http://localhost/api/recordings/rec-ready-playback/playback", {
+      method: "GET",
+      headers: { "x-owner-token": "owner-1" },
+    }),
+  );
+  const body = (await response.json()) as {
+    id: string;
+    title: string;
+    durationMs: number;
+    schemaVersion: string;
+    manifestUrl: string;
+    metaUrl: string;
+    eventsUrl: string;
+    snapshotsUrl: string;
+    indexesUrl: string | null;
+    mediaUrl: string | null;
+    thumbnailUrl: string | null;
+    expiresAt: string;
+  };
+
+  assert.equal(response.status, 200);
+  assert.equal(body.id, "rec-ready-playback");
+  assert.equal(body.title, "Recording rec-ready-playback");
+  assert.equal(body.durationMs, 12345);
+  assert.equal(body.schemaVersion, RECORDING_SCHEMA_VERSION);
+  assert.equal(body.manifestUrl, buildLocalDevObjectUrl("http://localhost", "recordings/rec-ready-playback/package/manifest.json"));
+  assert.equal(body.metaUrl, buildLocalDevObjectUrl("http://localhost", "recordings/rec-ready-playback/package/meta.json"));
+  assert.equal(body.eventsUrl, buildLocalDevObjectUrl("http://localhost", "recordings/rec-ready-playback/package/events.json"));
+  assert.equal(body.snapshotsUrl, buildLocalDevObjectUrl("http://localhost", "recordings/rec-ready-playback/package/snapshots.json"));
+  assert.equal(body.indexesUrl, buildLocalDevObjectUrl("http://localhost", "recordings/rec-ready-playback/package/indexes.json"));
+  assert.equal(body.mediaUrl, buildLocalDevObjectUrl("http://localhost", "recordings/rec-ready-playback/media/media.webm"));
+  assert.equal(body.thumbnailUrl, buildLocalDevObjectUrl("http://localhost", "recordings/rec-ready-playback/thumbnails/poster.webp"));
+  assert.match(body.expiresAt, /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/u);
+});
+
+test("GET /api/recordings/:recordingId/playback returns 404 for ready recordings missing required JSON assets", async () => {
+  const metadata = createMemoryMetadataRepository();
+  const objectStorage = createLocalDevObjectStorage({ publicBaseUrl: "http://localhost" });
+  await seedRecordingWithAssets(metadata, {
+    id: "rec-missing-snapshots",
+    ownerId: "owner-1",
+    status: "ready",
+    hasAudio: false,
+    hasCamera: false,
+  }, ["manifest", "meta", "events"]);
+  const handler = createCloudApiHandler({
+    service: createCloudRecordingService({ metadata, objectStorage }),
+    createRequestId: () => "req-playback-missing-json",
+  });
+
+  const response = await handler(
+    new Request("http://localhost/api/recordings/rec-missing-snapshots/playback", {
+      method: "GET",
+      headers: { "x-owner-token": "owner-1" },
+    }),
+  );
+  const body = (await response.json()) as { error: { code: string; message: string } };
+
+  assert.equal(response.status, 404);
+  assert.deepEqual(body.error, {
+    code: "not-found",
+    message: "playback descriptor not available",
+    requestId: "req-playback-missing-json",
+  });
+});
+
+test("GET /api/recordings/:recordingId/playback returns 404 for non-ready or owner-mismatched recordings", async () => {
+  const metadata = createMemoryMetadataRepository();
+  await seedRecordingWithAssets(metadata, {
+    id: "rec-owner-2-playback",
+    ownerId: "owner-2",
+    status: "ready",
+    hasAudio: false,
+    hasCamera: false,
+  }, ["manifest", "meta", "events", "snapshots"]);
+  await seedRecordingWithAssets(metadata, {
+    id: "rec-processing-playback",
+    ownerId: "owner-1",
+    status: "processing",
+    hasAudio: false,
+    hasCamera: false,
+  }, ["manifest", "meta", "events", "snapshots"]);
+  const handler = createCloudApiHandler({
+    service: createCloudRecordingService({ metadata, objectStorage: createMemoryObjectStorage() }),
+    createRequestId: () => "req-playback-not-found",
+  });
+
+  for (const path of [
+    "http://localhost/api/recordings/rec-owner-2-playback/playback",
+    "http://localhost/api/recordings/rec-processing-playback/playback",
+  ]) {
+    const response = await handler(
+      new Request(path, {
+        method: "GET",
+        headers: { "x-owner-token": "owner-1" },
+      }),
+    );
+    const body = (await response.json()) as { error: { code: string; message: string } };
+    assert.equal(response.status, 404);
+    assert.deepEqual(body.error, {
+      code: "not-found",
+      message: "recording not found",
+      requestId: "req-playback-not-found",
+    });
+  }
+});
+
+test("GET /api/recordings/:recordingId/playback returns null for optional media/indexes when missing", async () => {
+  const metadata = createMemoryMetadataRepository();
+  const objectStorage = createLocalDevObjectStorage({ publicBaseUrl: "http://localhost" });
+  await seedRecordingWithAssets(metadata, {
+    id: "rec-no-media-no-indexes",
+    ownerId: "owner-1",
+    status: "ready",
+    hasAudio: false,
+    hasCamera: false,
+  }, ["manifest", "meta", "events", "snapshots"]);
+  const handler = createCloudApiHandler({
+    service: createCloudRecordingService({ metadata, objectStorage }),
+    createRequestId: () => "req-playback-optional-null",
+  });
+
+  const response = await handler(
+    new Request("http://localhost/api/recordings/rec-no-media-no-indexes/playback", {
+      method: "GET",
+      headers: { "x-owner-token": "owner-1" },
+    }),
+  );
+  const body = (await response.json()) as Record<string, unknown>;
+
+  assert.equal(response.status, 200);
+  assert.equal(body.indexesUrl, null);
+  assert.equal(body.mediaUrl, null);
+  assert.equal(body.thumbnailUrl, null);
 });
 
 test("GET /api/recordings/:recordingId requires owner token", async () => {
@@ -1131,6 +1283,80 @@ async function seedRecording(
       failureMessage: input.failureMessage ?? null,
     },
     assets: [],
+    session: {
+      id: `session-${input.id}`,
+      recordingId: input.id,
+      ownerId: input.ownerId,
+      status: "completed",
+      expiresAt: "2026-05-28T00:00:00.000Z",
+      idempotencyKey: `idem-${input.id}`,
+      createdAt,
+      completedAt: createdAt,
+    },
+  });
+}
+
+async function seedRecordingWithAssets(
+  metadata: MetadataRepository,
+  input: {
+    id: string;
+    ownerId: string;
+    status: RecordingStatus;
+    createdAt?: string;
+    hasAudio?: boolean;
+    hasCamera?: boolean;
+    failureCode?: CloudRecordingRecord["failureCode"];
+    failureMessage?: string | null;
+  },
+  kinds: Array<RecordingAssetKind>,
+): Promise<void> {
+  const createdAt = input.createdAt ?? "2026-05-27T00:00:00.000Z";
+  const assets: CloudRecordingAssetRecord[] = kinds.map((kind) => {
+    const nameByKind: Record<RecordingAssetKind, string> = {
+      manifest: "package/manifest.json",
+      meta: "package/meta.json",
+      events: "package/events.json",
+      snapshots: "package/snapshots.json",
+      indexes: "package/indexes.json",
+      media: "media/media.webm",
+      thumbnail: "thumbnails/poster.webp",
+    };
+    return {
+      id: `asset-${input.id}-${kind}`,
+      recordingId: input.id,
+      kind,
+      objectKey: `recordings/${input.id}/${nameByKind[kind]}`,
+      sha256: "0000000000000000000000000000000000000000000000000000000000000000",
+      sizeBytes: 123,
+      mimeType: kind === "media" ? "video/webm" : kind === "thumbnail" ? "image/webp" : "application/json",
+      uploadedAt: createdAt,
+      validatedAt: createdAt,
+    };
+  });
+
+  await metadata.createUpload({
+    recording: {
+      id: input.id,
+      ownerId: input.ownerId,
+      localPackageId: `local-${input.id}`,
+      title: `Recording ${input.id}`,
+      schemaVersion: RECORDING_SCHEMA_VERSION,
+      status: input.status,
+      visibility: "private",
+      createdAt,
+      updatedAt: createdAt,
+      completedAt: input.status === "ready" ? createdAt : null,
+      durationMs: 12_345,
+      initialLanguage: "javascript",
+      hasAudio: input.hasAudio ?? false,
+      hasCamera: input.hasCamera ?? false,
+      totalSizeBytes: 1024,
+      eventCount: 7,
+      snapshotCount: 2,
+      failureCode: input.failureCode ?? null,
+      failureMessage: input.failureMessage ?? null,
+    },
+    assets,
     session: {
       id: `session-${input.id}`,
       recordingId: input.id,

--- a/apps/api/src/http/cloudApiHandler.ts
+++ b/apps/api/src/http/cloudApiHandler.ts
@@ -54,6 +54,27 @@ export function createCloudApiHandler(deps: {
       return jsonResponse(result.value.recordings, 200, requestId);
     }
 
+    const playbackMatch = url.pathname.match(/^\/api\/recordings\/([^/]+)\/playback$/);
+    if (request.method === "GET" && playbackMatch) {
+      const ownerId = readOwnerToken(request);
+      if (!ownerId) {
+        return jsonError(
+          { code: "unauthorized", message: "missing owner token", requestId },
+          requestId,
+        );
+      }
+      const recordingId = safeDecodePathSegment(playbackMatch[1]!);
+      if (!recordingId.ok) {
+        return jsonError({ ...recordingId.error, requestId }, requestId);
+      }
+      const result = await deps.service.getPlaybackDescriptor({
+        ownerId,
+        recordingId: recordingId.value,
+      });
+      if (!result.ok) return jsonError({ ...result.error, requestId }, requestId);
+      return jsonResponse(result.value, 200, requestId);
+    }
+
     const recordingDetailMatch = url.pathname.match(/^\/api\/recordings\/([^/]+)$/);
     if (request.method === "GET" && recordingDetailMatch) {
       const ownerId = readOwnerToken(request);


### PR DESCRIPTION
## 关联

Refs #2（总控 issue，不在本 PR 中关闭）
Close #118 

## 改动点

- 新增 `GET /api/recordings/:recordingId/playback` 云端播放描述接口
- 仅 owner 可访问，且仅 `ready` 状态录制返回播放描述
- 返回 `CloudPlaybackDescriptor`：
  - `id`
  - `title`
  - `durationMs`
  - `schemaVersion`
  - `manifestUrl`
  - `metaUrl`
  - `eventsUrl`
  - `snapshotsUrl`
  - `indexesUrl | null`
  - `mediaUrl | null`
  - `thumbnailUrl | null`
  - `expiresAt`
- 继续沿用本地开发对象存储 HTTP GET URL，不接 S3/CDN
- 非 `ready`、owner mismatch 或缺少必需 JSON 资产时统一返回 `404`
- 复用统一错误结构和 `x-request-id`

## 影响范围

- cloudApiHandler.ts
- cloudRecordingService.ts
- types.ts
- objectStorage.ts
- localDevObjectStorage.ts
- memoryObjectStorage.ts
- cloudApiHandler.test.ts

## GitNexus 影响分析摘要

- 风险等级: 中
- 关键骨架变更: 新增播放描述接口与云端对象存储 URL 生成逻辑
- GitNexus 影响面: API 路由、服务层、对象存储抽象、测试覆盖
- 验证结果: `npm run build:api` 通过，`npm run test:api` 通过

## 自检

- [x] 未修改 progress.json 或 progress.md
- [x] 已运行 `npm run quality:local`，或说明无法运行的原因  
- [x] 已说明改动点和影响范围
- [ ] 如果改动关键骨架，已补充契约测试并填写 GitNexus 影响分析摘要  
  - 说明：已补充 API 测试覆盖 owner 隔离、非 ready、缺 media、缺 indexes、缺必需资产
- [x] 已邀请至少一名非作者同学 CR

