### PR TITLE
[codex] add WebRTC interview technical plan

### DIFF
--- a/docs/技术方案.md
+++ b/docs/技术方案.md
@@ -161,6 +161,7 @@ flowchart TD
 | 主题系统    | CSS variables + `ThemeProvider` + localStorage 持久化                     | 深浅主题切换进入 P0 必达，默认跟随系统并允许用户显式切换     |
 | 交互组件    | Radix primitives + 自定义样式                                             | Dialog、Popover、Tooltip、Toggle 等保证可访问性和稳定行为    |
 | 媒体采集    | MediaDevices + MediaRecorder                                              | 浏览器原生能力，适合本地录制                                 |
+| 实时面试    | WebRTC RTCPeerConnection + RTCDataChannel + WebSocket 信令                 | P1+ 两人面试场景；媒体走 WebRTC，编辑事件走可靠数据通道       |
 | 本地存储    | IndexedDB，封装轻量 repository                                            | 支持 Blob 与结构化数据                                       |
 | iframe 沙箱 | sandboxed iframe + postMessage                                            | P0 前端运行/展示路线                                         |
 | TS 简单运行 | 浏览器侧 transpile，先不做 type checking                                  | 支持简单 TS Demo，不承诺完整工程                             |
@@ -3130,7 +3131,303 @@ LLM 输出必须经过 schema 校验和安全兜底：JSON 解析失败、缺失
 - 有中英混合讲解的前端代码录制：ASR 结果经本地 LLM 后仍能稳定得到可解析 JSON，React/TypeScript/code-tape 术语、变量名和函数名不被纠错错，同时生成可点击章节。
 - 无音频录制：生成按钮不可用，回放控制仍可用，页面展示无音频降级状态。
 
-## 十二、质量、测试与验收
+## 十二、P1+ WebRTC 实时面试模式方案
+
+本章细化 PRD 中的 WebRTC 实时面试模式。该能力是 P1+ 加分项，不改变 P0/P1 的核心事实源：候选人端仍以 `RecordingClock`、`EventBus`、`PackageBuilder` 生成本地录制包；实时面试只把同一条事件流额外推送给面试官，并用 WebRTC 建立双向音视频。实现时必须先保证候选人本地录制和回放可用，再接入实时层。
+
+### 1. 目标与边界
+
+最小展示版必须满足：
+
+- 候选人创建或加入面试房间后，可以正常开始录制，编辑器内容、语言、光标选区、滚动、鼠标、快捷键、运行结果和录制状态实时同步到面试官端。
+- 面试官端以只读方式实时查看候选人的编辑器稳定状态，不允许直接修改候选人编辑器，避免引入多人协作冲突模型。
+- 候选人与面试官通过 WebRTC 进行双向音视频通话；任一方关闭麦克风或摄像头时，对端 UI 能看到明确状态。
+- 面试结束后，候选人端复用 P0 保存流程，将本次候选人事件流和候选人本地媒体保存为可回放录制。
+- 网络抖动、事件乱序、短暂丢包或 DataChannel 批量到达时，面试官端仍以候选人事件 `seq` 和状态快照恢复一致状态。
+
+默认不进入最小展示版的能力：
+
+- 不做多人同时编辑、面试官接管键盘、题库、判题、白板、聊天、排期和账号体系。
+- 不引入 CRDT/OT。候选人是唯一写入者，实时同步只需要单写者事件序列和快照纠偏。
+- 不默认录制面试官音视频到候选人回放包。最小版只保存候选人的本地录制事实；是否把面试官音频/视频混入回放属于产品待确认问题，完整方案见本章“远端媒体保存扩展”。
+- 不接入 SFU/MCU。两人面试先使用浏览器点对点 WebRTC；超过两人或需要云端录制时再评估 LiveKit、mediasoup、Janus 等服务。
+- 不要求公网部署阶段自建 TURN。局域网/localhost Demo 可使用 host/srflx ICE；正式公网前必须补 STUN/TURN 配置和连通性监控。
+
+### 2. 角色、房间与状态机
+
+实时面试只有两个业务角色：
+
+| 角色 | 权限 | 关键状态 |
+| ---- | ---- | -------- |
+| `candidate` | 创建房间、开始/暂停/继续/结束录制、发送编辑事件和本地媒体、保存回放 | `idle`、`waiting-interviewer`、`connecting`、`live-recording`、`live-paused`、`ending`、`completed`、`failed` |
+| `interviewer` | 加入房间、接收只读编辑器状态、发送本地音视频、查看同步健康状态 | `joining`、`connecting`、`watching`、`reconnecting`、`ended`、`failed` |
+
+房间状态由信令服务维护，推荐最小模型：
+
+```ts
+export type InterviewRole = "candidate" | "interviewer";
+
+export type InterviewRoomStatus =
+  | "waiting"
+  | "connecting"
+  | "live"
+  | "ended"
+  | "expired";
+
+export type InterviewRoom = {
+  id: string;
+  joinCode: string;
+  status: InterviewRoomStatus;
+  createdAt: string;
+  expiresAt: string;
+  candidateConnectionId: string | null;
+  interviewerConnectionId: string | null;
+};
+```
+
+最小版可以用短期 `joinCode` 加本地 owner token 保护房间，避免把完整账号体系前置到 P1+。房间最多允许一个候选人和一个面试官同时在线；第二个相同角色加入时应拒绝或要求原连接显式断开，不能悄悄替换连接。
+
+### 3. 总体架构
+
+```mermaid
+flowchart TD
+  C["Candidate RecorderPage"] --> CB["Recording EventBus"]
+  C --> CM["Candidate MediaStream"]
+  CB --> CP["InterviewSyncPublisher"]
+  CP --> DC["RTCDataChannel: events"]
+  CM --> PC["RTCPeerConnection media tracks"]
+
+  I["Interviewer Room Page"] --> IR["RemoteInterviewRenderer"]
+  DC --> JB["RemoteTimelineBuffer"]
+  JB --> RR["ReplayReducer / Remote Stable State"]
+  RR --> IR
+  PC --> IV["Remote Video / Audio"]
+
+  C <--> S["WebSocket Signaling Service"]
+  I <--> S
+  S --> R["Interview Room Registry"]
+```
+
+实时层只订阅录制事实，不反向侵入 P0 录制链路：
+
+- `RecordingController` 仍然负责候选人本地录制生命周期。
+- `EventBus` 仍然分配本地录制 `seq`、`timestampMs` 和事件 payload。
+- `InterviewSyncPublisher` 只把已产生的录制事件包装成实时消息并发送；它不能修改事件内容，也不能自己分配录制时间。
+- 面试官端复用 `ReplayReducer` 和 `ReplayStableState` 渲染只读编辑器，避免出现“实时看见的状态”和“回放看到的状态”两套解释逻辑。
+
+### 4. 信令与 WebRTC 建连
+
+信令服务使用 WebSocket，不承载持续编辑事件，只负责房间、身份、SDP、ICE 和连接心跳。推荐端点：
+
+| 端点/消息 | 方向 | 作用 |
+| --------- | ---- | ---- |
+| `POST /api/interviews/rooms` | candidate -> api | 创建房间，返回 `roomId`、`joinCode`、`signalingUrl` |
+| `GET /api/interviews/rooms/:roomId` | both -> api | 查询房间状态和过期时间 |
+| `WS /api/interviews/rooms/:roomId/signaling` | both <-> api | 交换 `join`、`offer`、`answer`、`ice-candidate`、`heartbeat`、`leave` |
+| `POST /api/interviews/rooms/:roomId/end` | candidate -> api | 结束房间，通知面试官进入 ended |
+
+信令消息必须带 `roomId`、`connectionId`、`role`、`messageId` 和 `sentAt`。服务端只做校验、转发和房间状态更新，不保存 SDP 内容到长期存储。
+
+WebRTC 连接策略：
+
+- 使用一个 `RTCPeerConnection` 承载双向音频、双向视频和数据通道。
+- 候选人创建 DataChannel，面试官在 `ondatachannel` 接收。
+- 媒体轨使用 `addTrack`，麦克风/摄像头开关优先切换 `MediaStreamTrack.enabled`，不频繁 remove/add track。
+- ICE 失败时 UI 进入 `reconnecting`，保留最近稳定编辑器状态；信令重连成功后重新交换 offer/answer。
+- 正式公网环境必须配置 STUN/TURN；TURN 凭证只由后端短期签发，不能写入前端源码。
+
+### 5. 实时事件通道协议
+
+实时事件消息不改变 `RecordingEvent` schema，而是在外层增加面试同步 envelope：
+
+```ts
+export type InterviewRealtimeMessage =
+  | InterviewClockSyncMessage
+  | InterviewRecordingEventMessage
+  | InterviewSnapshotMessage
+  | InterviewSnapshotRequestMessage
+  | InterviewControlMessage
+  | InterviewAckMessage;
+
+export type InterviewRecordingEventMessage = {
+  kind: "recording-event";
+  roomId: string;
+  sessionId: string;
+  messageId: string;
+  sentAt: number;
+  event: RecordingEvent;
+  stateVersion: number;
+  contentHash?: string;
+};
+
+export type InterviewSnapshotMessage = {
+  kind: "state-snapshot";
+  roomId: string;
+  sessionId: string;
+  messageId: string;
+  sentAt: number;
+  snapshotSeq: number;
+  snapshotTimeMs: number;
+  stateVersion: number;
+  state: ReplayStableState;
+};
+
+export type InterviewSnapshotRequestMessage = {
+  kind: "snapshot-request";
+  roomId: string;
+  sessionId: string;
+  reason: "gap-timeout" | "hash-mismatch" | "manual-reconnect";
+  expectedSeq: number;
+  lastAppliedSeq: number;
+};
+```
+
+DataChannel 分两类：
+
+| 通道 | 配置 | 内容 | 处理规则 |
+| ---- | ---- | ---- | -------- |
+| `events` | `ordered: true`、可靠传输 | 影响稳定状态的录制事件、快照、ACK、控制消息 | 必须按 `seq` 应用；缺口触发等待或快照请求 |
+| `presence` | `ordered: false`、`maxRetransmits: 0` | 高频鼠标移动、连接质量、临时光标提示 | 可丢弃旧消息；永远不能作为稳定状态唯一事实源 |
+
+如果浏览器实现或测试环境只支持单通道，最小版可以先全部走可靠 `events` 通道，但 `pointer` 高频事件必须在发送端节流，并在事件预算过高时降级。
+
+### 6. 网络抖动与时序同步
+
+面试官侧不得“收到一条就立即渲染一条”。必须引入 `RemoteTimelineBuffer`，以候选人事件序列为事实源：
+
+```ts
+export type RemoteTimelineBufferState = {
+  expectedSeq: number;
+  lastAppliedSeq: number;
+  playoutDelayMs: number;
+  clockOffsetMs: number;
+  bufferedEvents: Map<number, RecordingEvent>;
+  lastSnapshot: InterviewSnapshotMessage | null;
+};
+```
+
+同步规则：
+
+1. 建连后先做 3 次 ping/pong clock sync，估算 RTT 和候选人/面试官时钟偏移；`playoutDelayMs` 初始为 `max(250ms, p95Rtt * 1.5)`，上限 1000ms。
+2. 候选人事件必须带 `seq`、`timestampMs`、`stateVersion` 和关键状态 hash。面试官端按 `seq` 放入 buffer，不以本地到达时间决定事实顺序。
+3. 面试官渲染时间为“候选人当前估算时间 - `playoutDelayMs`”。只有当连续 `seq` 都已到达，且事件 `timestampMs` 小于等于渲染时间时，才批量应用到 `ReplayReducer`。
+4. 稳定状态事件发现缺口时最多等待 `gapTimeoutMs = max(500ms, p95Rtt * 2)`；超时后发送 `snapshot-request`，暂停应用后续稳定状态事件。
+5. 候选人每 5 秒或每 50 个稳定状态事件发送一次 `state-snapshot`，并在收到 `snapshot-request` 后立即发送最新快照。
+6. 面试官收到快照后，如果 `snapshotSeq >= lastAppliedSeq`，先用快照替换本地 `ReplayStableState`，再重放 buffer 中 `seq > snapshotSeq` 的后续事件。
+7. `content-change` 后校验 `contentHash`；如果面试官根据事件得到的 code hash 和消息 hash 不一致，立即请求快照。
+8. `mouse-move`、快捷键浮层这类短生命周期 UI 可以因为抖动被跳过或延后淡出，但不能反向影响编辑器稳定状态。
+
+这套策略的核心是“单写者 seq + 小延迟播放 + 周期快照 + hash 校验”。它不解决多人编辑冲突，因为 P1+ 面试模式不允许面试官写入候选人代码；它解决的是网络抖动下只读观察者状态最终一致。
+
+### 7. 候选人录制与回放保存
+
+候选人端仍按 P0 录制流程保存：
+
+1. 候选人点击“开始面试录制”。
+2. `RecordingController.start()` 初始化时钟、事件生产者、媒体录制和包构建。
+3. `InterviewSyncPublisher` 订阅 `EventBus`，把同一批事件发送给面试官。
+4. 候选人点击“结束面试”时，先发送 `interview-ended` 控制消息，再执行 `RecordingController.stop()`。
+5. `PackageBuilder` 生成本地录制包并写入 IndexedDB；保存失败时沿用 P0 文件导出兜底。
+
+最小版回放内容包含：
+
+- 候选人的编辑器事件、鼠标、选区、快捷键、运行结果。
+- 候选人本地麦克风和摄像头媒体。
+- 面试房间元信息作为派生 metadata，例如 `interviewRoomId`、`startedAt`、`endedAt`、`interviewerDisplayName`，不改变 `RecordingPackageV1` 核心事件事实源。
+
+远端媒体保存扩展属于完整方案，需要产品确认后再实现：
+
+- 方案 A：候选人本地通过 Web Audio 混音录入双方音频，只把混音结果保存到现有 WebM；视频仍只保存候选人摄像头。实现成本低，但不能单独调节面试官音量。
+- 方案 B：扩展录制包到多媒体 segment，保存候选人摄像头、面试官摄像头和混音音频，回放页展示双小窗。体验完整，但会触发 schema 迁移、MediaRecorder 多路轨兼容和包体积增长。
+- 方案 C：云端 SFU/录制服务保存会议媒体，候选人包只保存事件和云端媒体 asset 引用。适合正式产品，不适合 P1+ 本地 Demo。
+
+在产品没有明确要求前，实施计划只能采用最小版，避免为了远端媒体录制破坏 P0 保存/回放稳定性。
+
+### 8. 前端页面与交互
+
+新增页面建议：
+
+| 页面 | 路由 | 职责 |
+| ---- | ---- | ---- |
+| 面试候选人页 | `/interview/candidate/:roomId?` | 创建/等待房间、展示 joinCode、录制控制、编辑器、候选人本地预览、面试官远端视频 |
+| 面试官页 | `/interview/interviewer/:roomId` | 输入/读取 joinCode、连接房间、只读编辑器、远端候选人视频、本地预览、同步状态 |
+
+UI 原则：
+
+- 候选人端应接近现有 `RecorderPage`，主区域仍是编辑器和运行结果；实时面试只是增加房间状态、对端视频和连接质量，不重做录制页。
+- 面试官端是只读工作台，默认把候选人代码放在主区域，音视频小窗在侧栏或角落，避免遮挡代码。
+- 同步健康状态必须可见：`实时`、`缓冲中`、`重同步`、`连接中断`、`已结束`。
+- 面试官端如果超过 2 秒没有收到稳定事件或 heartbeat，应展示“正在等待候选人状态”，但保留最后稳定代码。
+- 所有摄像头/麦克风按钮使用现有 `IconButton`、`Toggle`、`Tooltip` 和 lucide 图标，避免引入新的控件风格。
+
+### 9. 后端最小信令服务
+
+现有 `apps/api` 是基于 Request handler 的云端录制 API。WebRTC 信令需要长连接，建议新增独立边界而不是塞进现有 cloud service：
+
+```text
+apps/api/src/interview/
+  interviewRoomService.ts
+  memoryInterviewRoomRepository.ts
+  types.ts
+apps/api/src/signaling/
+  interviewSignalingServer.ts
+  signalingMessages.ts
+```
+
+职责边界：
+
+- `InterviewRoomService`：创建房间、校验 joinCode、结束房间、过期清理。
+- `InterviewRoomRepository`：保存短期房间和连接状态；最小版可内存实现，正式环境替换 Redis。
+- `InterviewSignalingServer`：维护 WebSocket 连接，把 SDP/ICE/控制消息转发给同房间另一角色。
+- `cloudRecordingService` 不依赖 interview 模块；面试结束后的录制保存仍走本地 IndexedDB 或 P1 云端上传。
+
+安全规则：
+
+- 房间默认 2 小时过期；结束后不能再次加入。
+- `joinCode` 至少 8 位随机字符，服务端只保存 hash 或短期内存值。
+- 信令消息大小限制 64KB，拒绝异常大 SDP 或伪造 payload。
+- 同一房间每个角色最多一个活跃连接。
+- 日志不落 SDP、ICE candidate 中的敏感地址细节、媒体设备 label 或用户代码内容。
+
+### 10. 测试与验收
+
+单元测试：
+
+- `RemoteTimelineBuffer`：乱序到达、重复事件、缺失 seq、gap timeout、快照恢复、hash mismatch。
+- `InterviewSyncPublisher`：只转发 `EventBus` 产出的事件，不改写 `seq` / `timestampMs`；断线时进入背压或丢弃策略。
+- `InterviewRoomService`：创建房间、joinCode 校验、角色唯一、过期、结束后拒绝加入。
+- `signalingMessages`：SDP/ICE/control message schema 校验、异常大小拒绝、未知消息拒绝。
+- `RemoteInterviewRenderer`：只读编辑器应用 `ReplayStableState`，不触发候选人写事件。
+
+集成测试：
+
+- 用 fake `RTCDataChannel` 模拟候选人连续发送 `content-change`、`selection-change`、`shortcut`，面试官端最终代码和候选人一致。
+- 模拟 300ms 抖动和乱序到达，面试官端不会应用 `seq=3` 后再回滚到 `seq=2`。
+- 模拟丢失 `seq=5`，面试官端请求快照并在收到 `snapshotSeq=8` 后恢复到正确状态。
+- 模拟 WebSocket 信令断开重连，UI 进入 `reconnecting`，重连后能重新交换 offer/answer。
+- 面试结束后候选人保存出的录制包通过现有 `PackageLoader` 和 `ReplayPage` 打开。
+
+手工验收：
+
+1. 两个浏览器窗口分别以候选人和面试官身份加入同一房间。
+2. 候选人开启麦克风/摄像头并开始录制，面试官能看到远端视频并听到音频；面试官开启麦克风/摄像头后候选人也能看到/听到。
+3. 候选人输入、粘贴、格式化、选择文本、滚动、运行代码，面试官端在 1 秒内看到一致状态。
+4. 用浏览器 DevTools 模拟网络抖动或临时断网，面试官端展示缓冲/重同步状态；恢复后代码内容、语言、光标选区和运行结果与候选人一致。
+5. 候选人结束面试并保存回放，打开回放后能看到候选人事件流和本地媒体。
+
+### 11. 风险与降级
+
+| 风险 | 影响 | 降级策略 |
+| ---- | ---- | -------- |
+| NAT 穿透失败 | 双方无法建立音视频或 DataChannel | Demo 使用 localhost/同网段；正式环境加 TURN；编辑事件可临时降级走 WebSocket |
+| DataChannel 抖动或短断 | 面试官看到状态延迟或缺口 | `RemoteTimelineBuffer` 小延迟播放，缺口请求快照，保留最后稳定状态 |
+| 高频事件过多 | 通道拥塞，编辑状态延迟 | 鼠标走 presence 通道并节流；稳定事件优先；超过预算丢弃旧 pointer |
+| 候选人刷新页面 | 本地录制中断，房间失效 | 房间进入 ended 或 waiting；已保存草稿按 P0 draft 规则处理 |
+| 面试官刷新页面 | 只读状态丢失 | 重新加入后候选人发送最新 snapshot，面试官从 snapshot 恢复 |
+| 浏览器媒体权限拒绝 | 无法双向通话 | 降级为仅事件实时同步，UI 展示无音视频状态 |
+| 远端媒体保存口径不清 | schema 迁移风险扩大 | 最小版不保存面试官媒体；完整保存方案必须先确认产品口径 |
+
+## 十三、质量、测试与验收
 
 ### 1. P0 演示环境与量化预算
 
@@ -3235,7 +3532,7 @@ Demo 前准备一条稳定录制：
 - 媒体：开启麦克风和摄像头。
 - 回放：演示 1x、2x、seek、静音、关闭快捷键展示。
 
-## 十三、风险与降级策略
+## 十四、风险与降级策略
 
 | 风险                                 | 影响                                   | 降级策略                                                                                         |
 | ------------------------------------ | -------------------------------------- | ------------------------------------------------------------------------------------------------ |
@@ -3255,7 +3552,7 @@ Demo 前准备一条稳定录制：
 | 非主演示浏览器差异                   | 权限、WebM 或 autoplay 行为不一致      | P0 主演示锁定 Chrome/Edge latest + HTTPS/localhost，Safari/Firefox 只记录兼容差异                |
 | 最后一周加分项拖累主链路             | Demo 不稳定                            | Python、AI 字幕、WebRTC 都不阻塞 P0；只在主链路冻结后评估                                        |
 
-## 十四、Issue 拆分建议
+## 十五、Issue 拆分建议
 
 ### 1. 方案与 PoC
 
@@ -3307,10 +3604,14 @@ Demo 前准备一条稳定录制：
 | `[P1] WebContainers PoC`                       | P1   |
 | `[P1+ PoC] AI 字幕生成、滚动展示和点击 seek`   | P1+  |
 | `[P1+ 完整] AI 术语纠错和章节生成`             | P1+  |
-| `[P1+ PoC] WebRTC 实时事件同步`                | P1+  |
-| `[P1+ 完整] WebRTC 双向音视频和面试后保存回放` | P1+  |
+| `[P1+ WebRTC] 面试房间与 WebSocket 信令`       | P1+  |
+| `[P1+ WebRTC] RTCDataChannel 实时事件同步`     | P1+  |
+| `[P1+ WebRTC] 面试官只读工作台`                | P1+  |
+| `[P1+ WebRTC] 双向音视频通话`                  | P1+  |
+| `[P1+ WebRTC] 抖动缓冲、快照重同步与 hash 校验` | P1+  |
+| `[P1+ WebRTC] 候选人结束面试并保存回放`        | P1+  |
 
-## 十五、推荐实施顺序
+## 十六、推荐实施顺序
 
 ```mermaid
 flowchart TD
@@ -3336,7 +3637,7 @@ flowchart TD
 | 回放阶段结束    | seek、倍速、媒体同步可演示             |
 | DDL 前一天      | 冻结功能，只修阻塞问题                 |
 
-## 十六、最终结论
+## 十七、最终结论
 
 code-tape 的最优 P0 路线不是做一个缩小版在线 IDE，也不是做普通录屏工具，而是做一个稳定的 **结构化代码讲解播放器**：
 

--- a/scripts/tests/workflow-rules.test.mjs
+++ b/scripts/tests/workflow-rules.test.mjs
@@ -560,6 +560,31 @@ test('technical plan owns P1 plus AI subtitle architecture and HF token boundary
   assert.match(technicalPlan, /PRD 中“本地 LLM 纠错”和“自动分段生成章节跳转点”必须同时出现在技术方案/u);
 });
 
+test('technical plan owns P1 plus WebRTC interview architecture and jitter recovery', () => {
+  const technicalPlan = readFileSync('docs/技术方案.md', 'utf8');
+
+  assert.match(technicalPlan, /## 十二、P1\+ WebRTC 实时面试模式方案/u);
+  assert.match(technicalPlan, /不改变 P0\/P1 的核心事实源/u);
+  assert.match(technicalPlan, /候选人端仍以 `RecordingClock`、`EventBus`、`PackageBuilder` 生成本地录制包/u);
+  assert.match(technicalPlan, /面试官端以只读方式实时查看候选人的编辑器稳定状态/u);
+  assert.match(technicalPlan, /WebRTC 进行双向音视频通话/u);
+  assert.match(technicalPlan, /不引入 CRDT\/OT/u);
+  assert.match(technicalPlan, /不默认录制面试官音视频到候选人回放包/u);
+  assert.match(technicalPlan, /`RTCPeerConnection` 承载双向音频、双向视频和数据通道/u);
+  assert.match(technicalPlan, /RTCDataChannel: events/u);
+  assert.match(technicalPlan, /`events` \| `ordered: true`、可靠传输/u);
+  assert.match(technicalPlan, /`presence` \| `ordered: false`、`maxRetransmits: 0`/u);
+  assert.match(technicalPlan, /`RemoteTimelineBuffer`/u);
+  assert.match(technicalPlan, /小延迟播放 \+ 周期快照 \+ hash 校验/u);
+  assert.match(technicalPlan, /发现缺口时最多等待/u);
+  assert.match(technicalPlan, /收到 `snapshot-request` 后立即发送最新快照/u);
+  assert.match(technicalPlan, /`content-change` 后校验 `contentHash`/u);
+  assert.match(technicalPlan, /面试结束后候选人保存出的录制包通过现有 `PackageLoader` 和 `ReplayPage` 打开/u);
+  assert.match(technicalPlan, /`InterviewRoomService`/u);
+  assert.match(technicalPlan, /`InterviewSignalingServer`/u);
+  assert.match(technicalPlan, /远端媒体保存扩展属于完整方案，需要产品确认后再实现/u);
+});
+
 test('repository text does not reference the standalone cloud plan path', () => {
   const trackedFiles = execFileSync('git', ['ls-files'], {
     encoding: 'utf8',


### PR DESCRIPTION
## 关联

Refs #2（总控 issue，不在本 PR 中关闭）

## 改动点

- 在 `docs/技术方案.md` 增补 P1+ WebRTC 实时面试模式方案。
- 明确候选人端录制事实源、面试官端只读同步、WebRTC 信令/音视频/DataChannel 边界。
- 补充网络抖动下的 `RemoteTimelineBuffer`、seq 排序、快照重同步和 `contentHash` 校验策略。
- 新增 authority-docs 契约测试，防止 WebRTC 方案关键边界被后续改动冲掉。

## 影响范围

- 文档：`docs/技术方案.md`
- 工作流契约测试：`scripts/tests/workflow-rules.test.mjs`
- 不改运行时代码、不改变 P0/P1 录制/回放行为。

## GitNexus 影响分析摘要

- 风险等级: LOW
- 关键骨架变更: `docs/技术方案.md` 新增 P1+ WebRTC 实时面试模式方案；`scripts/tests/workflow-rules.test.mjs` 新增 authority-docs 契约测试。
- GitNexus 影响面: `detect_changes(all)` 显示 changed_count=0、affected_processes=[]、risk_level=low；`query(authority docs technical plan WebRTC interview contract test workflow rules GitNexus impact summary)` 命中 `RunGitNexusContract` / `evaluateGitNexusContract` / `validateStructuredImpactSummary` 相关流程，未发现应用运行时流程受影响。
- 验证结果: `npm run quality:predev`、`npm run quality:precommit`、`npm run quality:local` 均通过；`quality:local` 覆盖 6 条 Chromium Playwright e2e。

## 自检

- [x] 未修改 `docs/progress.json` 或 `docs/progress.md`
- [x] 已运行 `npm run quality:local`，或说明无法运行的原因
- [x] 已说明改动点和影响范围
- [x] 如果改动关键骨架，已补充契约测试并填写 GitNexus 影响分析摘要
- [ ] 已邀请至少一名非作者同学 CR
