### PR TITLE
feat: add WebRTC realtime event sync core

### DIFF
--- a/apps/web/src/features/interview/__tests__/interviewSync.test.ts
+++ b/apps/web/src/features/interview/__tests__/interviewSync.test.ts
@@ -1,0 +1,195 @@
+import { describe, expect, it } from "vitest";
+import type { EventBus, RecordingEvent } from "@/shared/recording-schema";
+import {
+  createInterviewSyncPublisher,
+  createRemoteTimelineBuffer,
+  type InterviewRealtimeDataChannel,
+} from "../interviewSync";
+
+function contentEvent(seq: number, code = `code-${seq}`): RecordingEvent {
+  return {
+    id: `event-${seq}`,
+    seq,
+    timestampMs: seq * 100,
+    source: "editor",
+    track: "main",
+    type: "content-change",
+    payload: {
+      fileId: "main",
+      version: seq,
+      code,
+      contentHash: `hash-${seq}`,
+      language: "typescript",
+      changeReason: "input",
+      changeCount: 1,
+      flushedBy: "debounce",
+    },
+  };
+}
+
+function createFakeChannel(initialState: InterviewRealtimeDataChannel["readyState"] = "open") {
+  const sent: string[] = [];
+  const channel: InterviewRealtimeDataChannel = {
+    readyState: initialState,
+    send(data) {
+      sent.push(data);
+    },
+  };
+  return { channel, sent };
+}
+
+function createFakeEventBus(): Pick<EventBus, "subscribe"> & { emit(event: RecordingEvent): void } {
+  const listeners = new Set<(event: RecordingEvent) => void>();
+  return {
+    subscribe(listener) {
+      listeners.add(listener);
+      return () => listeners.delete(listener);
+    },
+    emit(event) {
+      listeners.forEach((listener) => listener(event));
+    },
+  };
+}
+
+describe("InterviewSyncPublisher", () => {
+  it("wraps event bus recording events for the reliable DataChannel without mutating them", () => {
+    const { channel, sent } = createFakeChannel();
+    const bus = createFakeEventBus();
+    const publisher = createInterviewSyncPublisher({
+      channel,
+      roomId: "room-1",
+      sessionId: "session-1",
+      messageIdProvider: () => "message-1",
+      nowProvider: () => 1234,
+      stateVersionProvider: () => 7,
+    });
+    const event = contentEvent(1, "const answer = 42;");
+    const before = structuredClone(event);
+
+    const unsubscribe = publisher.subscribeTo(bus);
+    bus.emit(event);
+    unsubscribe();
+
+    expect(event).toEqual(before);
+    expect(sent).toHaveLength(1);
+    expect(JSON.parse(sent[0])).toEqual({
+      kind: "recording-event",
+      roomId: "room-1",
+      sessionId: "session-1",
+      messageId: "message-1",
+      sentAt: 1234,
+      stateVersion: 7,
+      contentHash: "hash-1",
+      event,
+    });
+  });
+
+  it("returns an explicit failure when the DataChannel is not open", () => {
+    const { channel, sent } = createFakeChannel("closed");
+    const publisher = createInterviewSyncPublisher({
+      channel,
+      roomId: "room-1",
+      sessionId: "session-1",
+    });
+
+    const result = publisher.publishRecordingEvent(contentEvent(1));
+
+    expect(result).toEqual({ ok: false, reason: "channel-not-open" });
+    expect(sent).toEqual([]);
+  });
+
+  it("returns an explicit failure when DataChannel send throws", () => {
+    const channel: InterviewRealtimeDataChannel = {
+      readyState: "open",
+      send() {
+        throw new Error("send failed");
+      },
+    };
+    const publisher = createInterviewSyncPublisher({
+      channel,
+      roomId: "room-1",
+      sessionId: "session-1",
+    });
+
+    expect(publisher.publishRecordingEvent(contentEvent(1))).toEqual({
+      ok: false,
+      reason: "send-failed",
+    });
+  });
+});
+
+describe("RemoteTimelineBuffer", () => {
+  it("flushes out-of-order events in candidate seq order once the gap is filled", () => {
+    const buffer = createRemoteTimelineBuffer();
+
+    const first = buffer.pushRecordingEvent({
+      kind: "recording-event",
+      roomId: "room-1",
+      sessionId: "session-1",
+      messageId: "message-2",
+      sentAt: 200,
+      stateVersion: 1,
+      event: contentEvent(2),
+    });
+    const second = buffer.pushRecordingEvent({
+      kind: "recording-event",
+      roomId: "room-1",
+      sessionId: "session-1",
+      messageId: "message-1",
+      sentAt: 100,
+      stateVersion: 1,
+      event: contentEvent(1),
+    });
+
+    expect(first.appliedEvents).toEqual([]);
+    expect(first.snapshotRequestNeeded).toEqual({
+      reason: "gap-detected",
+      expectedSeq: 1,
+      lastAppliedSeq: 0,
+    });
+    expect(second.appliedEvents.map((event) => event.seq)).toEqual([1, 2]);
+    expect(second.snapshotRequestNeeded).toBeNull();
+    expect(second.lastAppliedSeq).toBe(2);
+  });
+
+  it("ignores duplicate or old events without rolling back the stable state", () => {
+    const buffer = createRemoteTimelineBuffer();
+
+    expect(buffer.pushRecordingEvent(messageFor(contentEvent(1))).appliedEvents).toHaveLength(1);
+    expect(buffer.pushRecordingEvent(messageFor(contentEvent(2))).appliedEvents).toHaveLength(1);
+
+    const duplicate = buffer.pushRecordingEvent(messageFor(contentEvent(2, "stale duplicate")));
+    const old = buffer.pushRecordingEvent(messageFor(contentEvent(1, "old event")));
+
+    expect(duplicate.appliedEvents).toEqual([]);
+    expect(old.appliedEvents).toEqual([]);
+    expect(duplicate.lastAppliedSeq).toBe(2);
+    expect(old.lastAppliedSeq).toBe(2);
+  });
+
+  it("does not apply a later event across a missing seq and exposes snapshot request state", () => {
+    const buffer = createRemoteTimelineBuffer({ initialExpectedSeq: 2 });
+
+    const result = buffer.pushRecordingEvent(messageFor(contentEvent(3)));
+
+    expect(result.appliedEvents).toEqual([]);
+    expect(result.lastAppliedSeq).toBe(1);
+    expect(result.snapshotRequestNeeded).toEqual({
+      reason: "gap-detected",
+      expectedSeq: 2,
+      lastAppliedSeq: 1,
+    });
+  });
+});
+
+function messageFor(event: RecordingEvent) {
+  return {
+    kind: "recording-event" as const,
+    roomId: "room-1",
+    sessionId: "session-1",
+    messageId: `message-${event.seq}`,
+    sentAt: event.timestampMs,
+    stateVersion: 1,
+    event,
+  };
+}

--- a/apps/web/src/features/interview/index.ts
+++ b/apps/web/src/features/interview/index.ts
@@ -1,0 +1,16 @@
+export {
+  createInterviewSyncPublisher,
+  createRemoteTimelineBuffer,
+  type InterviewAckMessage,
+  type InterviewControlMessage,
+  type InterviewPublishResult,
+  type InterviewRealtimeDataChannel,
+  type InterviewRealtimeMessage,
+  type InterviewRecordingEventMessage,
+  type InterviewSnapshotMessage,
+  type InterviewSnapshotRequestMessage,
+  type InterviewSyncPublisher,
+  type RemoteTimelineBuffer,
+  type RemoteTimelineBufferResult,
+  type SnapshotRequestNeed,
+} from "./interviewSync";

--- a/apps/web/src/features/interview/interviewSync.ts
+++ b/apps/web/src/features/interview/interviewSync.ts
@@ -1,0 +1,195 @@
+import type { EventBus, RecordingEvent, ReplayStableState } from "@/shared/recording-schema";
+
+export type InterviewRealtimeDataChannel = {
+  readyState: "connecting" | "open" | "closing" | "closed";
+  send(data: string): void;
+};
+
+type InterviewRealtimeBaseMessage = {
+  roomId: string;
+  sessionId: string;
+  messageId: string;
+  sentAt: number;
+};
+
+export type InterviewRecordingEventMessage = InterviewRealtimeBaseMessage & {
+  kind: "recording-event";
+  event: RecordingEvent;
+  stateVersion: number;
+  contentHash?: string;
+};
+
+export type InterviewSnapshotMessage = InterviewRealtimeBaseMessage & {
+  kind: "state-snapshot";
+  snapshotSeq: number;
+  snapshotTimeMs: number;
+  stateVersion: number;
+  state: ReplayStableState;
+};
+
+export type InterviewSnapshotRequestMessage = InterviewRealtimeBaseMessage & {
+  kind: "snapshot-request";
+  reason: "gap-timeout" | "hash-mismatch" | "manual-reconnect";
+  expectedSeq: number;
+  lastAppliedSeq: number;
+};
+
+export type InterviewControlMessage = InterviewRealtimeBaseMessage & {
+  kind: "control";
+  action: "recording-started" | "recording-paused" | "recording-resumed" | "interview-ended";
+  reason?: string;
+};
+
+export type InterviewAckMessage = InterviewRealtimeBaseMessage & {
+  kind: "ack";
+  ackedMessageId: string;
+  lastAppliedSeq: number;
+};
+
+export type InterviewRealtimeMessage =
+  | InterviewRecordingEventMessage
+  | InterviewSnapshotMessage
+  | InterviewSnapshotRequestMessage
+  | InterviewControlMessage
+  | InterviewAckMessage;
+
+export type InterviewPublishResult =
+  | { ok: true; message: InterviewRecordingEventMessage }
+  | { ok: false; reason: "channel-not-open" | "send-failed" };
+
+export type InterviewSyncPublisherOptions = {
+  channel: InterviewRealtimeDataChannel;
+  roomId: string;
+  sessionId: string;
+  messageIdProvider?: () => string;
+  nowProvider?: () => number;
+  stateVersionProvider?: () => number;
+};
+
+export type InterviewSyncPublisher = {
+  publishRecordingEvent(event: RecordingEvent): InterviewPublishResult;
+  subscribeTo(bus: Pick<EventBus, "subscribe">): () => void;
+};
+
+export function createInterviewSyncPublisher(
+  options: InterviewSyncPublisherOptions,
+): InterviewSyncPublisher {
+  const messageIdProvider = options.messageIdProvider ?? createMessageId;
+  const nowProvider = options.nowProvider ?? (() => Date.now());
+  const stateVersionProvider = options.stateVersionProvider ?? (() => 0);
+
+  const publishRecordingEvent = (event: RecordingEvent): InterviewPublishResult => {
+    if (options.channel.readyState !== "open") {
+      return { ok: false, reason: "channel-not-open" };
+    }
+
+    const message: InterviewRecordingEventMessage = {
+      kind: "recording-event",
+      roomId: options.roomId,
+      sessionId: options.sessionId,
+      messageId: messageIdProvider(),
+      sentAt: nowProvider(),
+      event,
+      stateVersion: stateVersionProvider(),
+      ...contentHashFor(event),
+    };
+
+    try {
+      options.channel.send(JSON.stringify(message));
+      return { ok: true, message };
+    } catch {
+      return { ok: false, reason: "send-failed" };
+    }
+  };
+
+  return {
+    publishRecordingEvent,
+    subscribeTo(bus) {
+      return bus.subscribe((event) => {
+        publishRecordingEvent(event);
+      });
+    },
+  };
+}
+
+export type SnapshotRequestNeed = {
+  reason: "gap-detected";
+  expectedSeq: number;
+  lastAppliedSeq: number;
+};
+
+export type RemoteTimelineBufferResult = {
+  appliedEvents: RecordingEvent[];
+  expectedSeq: number;
+  lastAppliedSeq: number;
+  snapshotRequestNeeded: SnapshotRequestNeed | null;
+};
+
+export type RemoteTimelineBufferOptions = {
+  initialExpectedSeq?: number;
+};
+
+export type RemoteTimelineBuffer = {
+  pushRecordingEvent(message: InterviewRecordingEventMessage): RemoteTimelineBufferResult;
+  state(): Omit<RemoteTimelineBufferResult, "appliedEvents">;
+};
+
+export function createRemoteTimelineBuffer(
+  options: RemoteTimelineBufferOptions = {},
+): RemoteTimelineBuffer {
+  let expectedSeq = options.initialExpectedSeq ?? 1;
+  let lastAppliedSeq = expectedSeq - 1;
+  const bufferedEvents = new Map<number, RecordingEvent>();
+
+  const currentSnapshotNeed = (): SnapshotRequestNeed | null =>
+    bufferedEvents.size > 0
+      ? { reason: "gap-detected", expectedSeq, lastAppliedSeq }
+      : null;
+
+  const currentState = () => ({
+    expectedSeq,
+    lastAppliedSeq,
+    snapshotRequestNeeded: currentSnapshotNeed(),
+  });
+
+  return {
+    pushRecordingEvent(message) {
+      const { event } = message;
+      if (event.seq <= lastAppliedSeq) {
+        return { appliedEvents: [], ...currentState() };
+      }
+      if (event.seq >= expectedSeq && !bufferedEvents.has(event.seq)) {
+        bufferedEvents.set(event.seq, event);
+      }
+
+      const appliedEvents: RecordingEvent[] = [];
+      while (bufferedEvents.has(expectedSeq)) {
+        const next = bufferedEvents.get(expectedSeq);
+        if (!next) {
+          break;
+        }
+        bufferedEvents.delete(expectedSeq);
+        appliedEvents.push(next);
+        lastAppliedSeq = next.seq;
+        expectedSeq = next.seq + 1;
+      }
+
+      return { appliedEvents, ...currentState() };
+    },
+    state: currentState,
+  };
+}
+
+function contentHashFor(event: RecordingEvent): Pick<InterviewRecordingEventMessage, "contentHash"> {
+  if (event.type !== "content-change") {
+    return {};
+  }
+  return { contentHash: event.payload.contentHash };
+}
+
+function createMessageId(): string {
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+    return crypto.randomUUID();
+  }
+  return `msg-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+}


### PR DESCRIPTION
## 关联

Closes #139
Refs #120（WebRTC 总控 issue，不在本 PR 中关闭）

## 改动点

- 新增 `apps/web/src/features/interview/interviewSync.ts`，定义 WebRTC 实时面试事件同步 envelope：`recording-event`、`state-snapshot`、`snapshot-request`、`control`、`ack`。
- 新增 `InterviewSyncPublisher`，可订阅现有 `EventBus` 并通过可靠 DataChannel 发送候选人录制事件，不改写原始 `seq` / `timestampMs` / payload。
- 新增 `RemoteTimelineBuffer` 最小核心，按候选人 `seq` 缓冲与连续 flush，忽略重复/旧事件，并在缺口时暴露 snapshot request 需求。
- 新增 fake DataChannel / fake EventBus 单测，覆盖 open/closed channel、envelope 字段、乱序、重复、旧事件和缺口场景。

## 影响范围

- 仅新增 Web 前端 `features/interview` 纯 TypeScript 边界。
- 不接入真实 `RTCPeerConnection`，不新增 UI，不改变录制包 schema。
- 不修改 recorder / player 现有流程；后续 PR 再把该核心接入候选人页和面试官只读工作台。

## GitNexus 影响分析摘要

- 风险等级: medium（新增 3 个文件、24 个符号、2 条新增执行流）
- 关键骨架变更: 否；`npm run contract:local` 判定 “No critical contract surface changed”，本 diff 为 advisory。
- GitNexus 影响面: `detect_changes --scope compare --base-ref origin/main` 发现新增 `SubscribeTo → ContentHashFor` 与 `PushRecordingEvent → CurrentSnapshotNeed` 两条流程；`context createInterviewSyncPublisher` 无既有 incoming/outgoing 依赖；`impact createRemoteTimelineBuffer --include-tests` 为 LOW，0 个既有流程/模块受影响。
- 验证结果: `npm run quality:precommit` 通过；`npm run quality:local` 通过，含 Playwright e2e 6/6。

## 自检

- [x] 未修改 `docs/progress.json` 或 `docs/progress.md`
- [x] 已运行 `npm run quality:local`，或说明无法运行的原因
- [x] 已说明改动点和影响范围
- [x] 如果改动关键骨架，已补充契约测试并填写 GitNexus 影响分析摘要
- [ ] 已等待 repo-guard、codex 和 Copilot 评论，并完成必要审查
