### PR TITLE
feat: add remote interview workbench state

### DIFF
--- a/apps/web/src/features/interview/__tests__/remoteInterviewWorkbench.test.ts
+++ b/apps/web/src/features/interview/__tests__/remoteInterviewWorkbench.test.ts
@@ -1,0 +1,208 @@
+import { describe, expect, it } from "vitest";
+import type { RecordingEvent, ReplayStableState } from "@/shared/recording-schema";
+import {
+  createRemoteInterviewWorkbench,
+  type RemoteInterviewWorkbench,
+} from "../remoteInterviewWorkbench";
+
+function initialState(): ReplayStableState {
+  return {
+    editor: {
+      code: "",
+      language: "typescript",
+      cursor: null,
+      selection: null,
+      scrollTop: 0,
+      scrollLeft: 0,
+      fontSize: 14,
+      theme: "dark",
+    },
+    pointer: null,
+    media: {
+      microphoneEnabled: false,
+      cameraEnabled: false,
+      cameraPosition: { x: 0, y: 0 },
+    },
+    runtime: {
+      status: "idle",
+      stdout: [],
+      stderr: [],
+      previewHtml: null,
+      errorMessage: null,
+    },
+  };
+}
+
+function contentEvent(seq: number, code: string): RecordingEvent {
+  return {
+    id: `event-${seq}`,
+    seq,
+    timestampMs: seq * 100,
+    source: "editor",
+    track: "main",
+    type: "content-change",
+    payload: {
+      fileId: "main",
+      version: seq,
+      code,
+      contentHash: `hash-${seq}`,
+      language: "typescript",
+      changeReason: "input",
+      changeCount: 1,
+      flushedBy: "debounce",
+    },
+  };
+}
+
+function selectionEvent(seq: number): RecordingEvent {
+  return {
+    id: `event-${seq}`,
+    seq,
+    timestampMs: seq * 100,
+    source: "editor",
+    track: "main",
+    type: "selection-change",
+    payload: {
+      cursor: { lineNumber: 2, column: 5 },
+      selection: {
+        startLineNumber: 2,
+        startColumn: 1,
+        endLineNumber: 2,
+        endColumn: 5,
+      },
+    },
+  };
+}
+
+function runOutputEvent(seq: number): RecordingEvent {
+  return {
+    id: `event-${seq}`,
+    seq,
+    timestampMs: seq * 100,
+    source: "runtime",
+    track: "runtime",
+    type: "run-output",
+    payload: {
+      runId: "run-1",
+      stdout: ["42"],
+      stderr: [],
+      previewHtml: "<strong>42</strong>",
+      status: "success",
+    },
+  };
+}
+
+function messageFor(event: RecordingEvent) {
+  return {
+    kind: "recording-event" as const,
+    roomId: "room-1",
+    sessionId: "session-1",
+    messageId: `message-${event.seq}`,
+    sentAt: event.timestampMs,
+    stateVersion: 1,
+    event,
+  };
+}
+
+describe("RemoteInterviewWorkbench", () => {
+  it("applies out-of-order remote events through the replay reducer in candidate seq order", () => {
+    const workbench = createRemoteInterviewWorkbench({ initialState: initialState() });
+
+    workbench.pushRecordingEvent(messageFor(selectionEvent(2)));
+    workbench.pushRecordingEvent(messageFor(runOutputEvent(3)));
+    const state = workbench.pushRecordingEvent(messageFor(contentEvent(1, "const answer = 42;")));
+
+    expect(state.lastAppliedSeq).toBe(3);
+    expect(state.syncStatus).toBe("live");
+    expect(state.snapshotRequestNeeded).toBeNull();
+    expect(state.stableState.editor.code).toBe("const answer = 42;");
+    expect(state.stableState.editor.cursor).toEqual({ lineNumber: 2, column: 5 });
+    expect(state.stableState.runtime).toMatchObject({
+      status: "success",
+      stdout: ["42"],
+      previewHtml: "<strong>42</strong>",
+    });
+  });
+
+  it("does not apply events across a missing seq and exposes waiting-for-snapshot state", () => {
+    const workbench = createRemoteInterviewWorkbench({
+      initialState: initialState(),
+      initialExpectedSeq: 2,
+    });
+
+    const state = workbench.pushRecordingEvent(messageFor(contentEvent(3, "skipped gap")));
+
+    expect(state.lastAppliedSeq).toBe(1);
+    expect(state.stableState.editor.code).toBe("");
+    expect(state.syncStatus).toBe("waiting-for-snapshot");
+    expect(state.snapshotRequestNeeded).toEqual({
+      reason: "gap-detected",
+      expectedSeq: 2,
+      lastAppliedSeq: 1,
+    });
+  });
+
+  it("ignores duplicate and old events without rolling back stable state", () => {
+    const workbench = createRemoteInterviewWorkbench({ initialState: initialState() });
+
+    workbench.pushRecordingEvent(messageFor(contentEvent(1, "first")));
+    workbench.pushRecordingEvent(messageFor(contentEvent(2, "second")));
+
+    const duplicate = workbench.pushRecordingEvent(messageFor(contentEvent(2, "duplicate")));
+    const old = workbench.pushRecordingEvent(messageFor(contentEvent(1, "old")));
+
+    expect(duplicate.stableState.editor.code).toBe("second");
+    expect(old.stableState.editor.code).toBe("second");
+    expect(old.lastAppliedSeq).toBe(2);
+  });
+
+  it("exposes observer operations only and returns cloned snapshots", () => {
+    const workbench = createRemoteInterviewWorkbench({ initialState: initialState() });
+    const api = workbench as RemoteInterviewWorkbench & Record<string, unknown>;
+
+    expect(api.publishRecordingEvent).toBeUndefined();
+    expect(api.subscribeTo).toBeUndefined();
+
+    const snapshot = workbench.getState();
+    snapshot.stableState.editor.code = "mutated outside";
+
+    expect(workbench.getState().stableState.editor.code).toBe("");
+  });
+
+  it("returns isolated snapshot request objects from gap snapshots", () => {
+    const workbench = createRemoteInterviewWorkbench({
+      initialState: initialState(),
+      initialExpectedSeq: 2,
+    });
+    workbench.pushRecordingEvent(messageFor(contentEvent(3, "buffered")));
+
+    const snapshot = workbench.getState();
+    if (!snapshot.snapshotRequestNeeded) {
+      throw new Error("expected a snapshot request");
+    }
+    snapshot.snapshotRequestNeeded.expectedSeq = 99;
+
+    expect(workbench.getState().snapshotRequestNeeded).toEqual({
+      reason: "gap-detected",
+      expectedSeq: 2,
+      lastAppliedSeq: 1,
+    });
+  });
+
+  it("notifies subscribers with isolated read-only snapshots", () => {
+    const workbench = createRemoteInterviewWorkbench({ initialState: initialState() });
+    let secondSubscriberCode = "";
+
+    workbench.subscribe((state) => {
+      state.stableState.editor.code = "mutated by first subscriber";
+    });
+    const unsubscribe = workbench.subscribe((state) => {
+      secondSubscriberCode = state.stableState.editor.code;
+    });
+
+    workbench.pushRecordingEvent(messageFor(contentEvent(1, "candidate code")));
+    unsubscribe();
+
+    expect(secondSubscriberCode).toBe("candidate code");
+  });
+});

--- a/apps/web/src/features/interview/index.ts
+++ b/apps/web/src/features/interview/index.ts
@@ -14,3 +14,10 @@ export {
   type RemoteTimelineBufferResult,
   type SnapshotRequestNeed,
 } from "./interviewSync";
+export {
+  createRemoteInterviewWorkbench,
+  type RemoteInterviewSyncStatus,
+  type RemoteInterviewWorkbench,
+  type RemoteInterviewWorkbenchOptions,
+  type RemoteInterviewWorkbenchState,
+} from "./remoteInterviewWorkbench";

--- a/apps/web/src/features/interview/remoteInterviewWorkbench.ts
+++ b/apps/web/src/features/interview/remoteInterviewWorkbench.ts
@@ -1,0 +1,91 @@
+import {
+  cloneReplayStableState,
+  replayReducer,
+  type ReplayStableState,
+} from "@/shared/recording-schema";
+import {
+  createRemoteTimelineBuffer,
+  type InterviewRecordingEventMessage,
+  type SnapshotRequestNeed,
+} from "./interviewSync";
+
+export type RemoteInterviewSyncStatus = "idle" | "live" | "waiting-for-snapshot";
+
+export type RemoteInterviewWorkbenchState = {
+  stableState: ReplayStableState;
+  expectedSeq: number;
+  lastAppliedSeq: number;
+  syncStatus: RemoteInterviewSyncStatus;
+  snapshotRequestNeeded: SnapshotRequestNeed | null;
+};
+
+export type RemoteInterviewWorkbenchOptions = {
+  initialState: ReplayStableState;
+  initialExpectedSeq?: number;
+};
+
+export type RemoteInterviewWorkbench = {
+  getState(): RemoteInterviewWorkbenchState;
+  pushRecordingEvent(message: InterviewRecordingEventMessage): RemoteInterviewWorkbenchState;
+  subscribe(listener: (state: RemoteInterviewWorkbenchState) => void): () => void;
+};
+
+export function createRemoteInterviewWorkbench(
+  options: RemoteInterviewWorkbenchOptions,
+): RemoteInterviewWorkbench {
+  let stableState = cloneReplayStableState(options.initialState);
+  const buffer = createRemoteTimelineBuffer({ initialExpectedSeq: options.initialExpectedSeq });
+  const listeners = new Set<(state: RemoteInterviewWorkbenchState) => void>();
+
+  const snapshot = (): RemoteInterviewWorkbenchState => {
+    const bufferState = buffer.state();
+    return {
+      stableState: cloneReplayStableState(stableState),
+      expectedSeq: bufferState.expectedSeq,
+      lastAppliedSeq: bufferState.lastAppliedSeq,
+      syncStatus: syncStatusFor(bufferState.snapshotRequestNeeded, bufferState.lastAppliedSeq),
+      snapshotRequestNeeded: cloneSnapshotRequestNeed(bufferState.snapshotRequestNeeded),
+    };
+  };
+
+  const notify = (): RemoteInterviewWorkbenchState => {
+    const next = snapshot();
+    listeners.forEach((listener) => listener(cloneWorkbenchState(next)));
+    return next;
+  };
+
+  return {
+    getState: snapshot,
+    pushRecordingEvent(message) {
+      const result = buffer.pushRecordingEvent(message);
+      stableState = result.appliedEvents.reduce(replayReducer, stableState);
+      return notify();
+    },
+    subscribe(listener) {
+      listeners.add(listener);
+      return () => listeners.delete(listener);
+    },
+  };
+}
+
+function cloneWorkbenchState(state: RemoteInterviewWorkbenchState): RemoteInterviewWorkbenchState {
+  return {
+    ...state,
+    stableState: cloneReplayStableState(state.stableState),
+    snapshotRequestNeeded: cloneSnapshotRequestNeed(state.snapshotRequestNeeded),
+  };
+}
+
+function cloneSnapshotRequestNeed(need: SnapshotRequestNeed | null): SnapshotRequestNeed | null {
+  return need ? { ...need } : null;
+}
+
+function syncStatusFor(
+  snapshotRequestNeeded: SnapshotRequestNeed | null,
+  lastAppliedSeq: number,
+): RemoteInterviewSyncStatus {
+  if (snapshotRequestNeeded) {
+    return "waiting-for-snapshot";
+  }
+  return lastAppliedSeq > 0 ? "live" : "idle";
+}


### PR DESCRIPTION
## Summary

- Add `RemoteInterviewWorkbench` as the interviewer-side read-only state core for WebRTC realtime interviews.
- Fold remote `InterviewRecordingEventMessage` objects through `RemoteTimelineBuffer` and the shared `replayReducer` so interviewer state uses the same semantics as replay.
- Expose cloned observer snapshots and subscription updates without any candidate write/publish API.

Closes #141
Refs #120

## GitNexus Impact

- `npm run quality:local` GitNexus contract: passed; no critical contract surface changed.
- `gitnexus context createRemoteTimelineBuffer`: found the existing sync buffer; no incoming/outgoing dependencies or processes reported.
- `gitnexus impact createRemoteTimelineBuffer --include-tests`: LOW risk, 0 direct impacts, 0 affected processes, 0 affected modules.
- `gitnexus impact Function:packages/recording-schema/src/replayState.ts:replayReducer --include-tests`: LOW risk, 0 direct impacts, 0 affected processes, 0 affected modules.
- Note: `gitnexus detect_changes --scope compare --base-ref origin/main` reported `No changes detected` for this worktree even though git diff shows the three intended interview files; symbol-level impact checks above were used for the relevant dependencies.

## Test Plan

- `npm run test -w apps/web -- src/features/interview/__tests__/remoteInterviewWorkbench.test.ts`
- `npm run test -w apps/web -- src/features/interview/__tests__`
- `npm run quality:precommit`
- `npm run quality:local`
- pre-push hook reran `npm run quality:local` and passed, including Playwright `6 passed`.
