### PR TITLE
[P1] CloudRecordingRepository 播放与管理方法补齐

### DIFF
--- a/apps/web/src/features/cloud/__tests__/cloudRecordingRepository.test.ts
+++ b/apps/web/src/features/cloud/__tests__/cloudRecordingRepository.test.ts
@@ -22,6 +22,7 @@ import type {
   CloudRecordingDetail,
   CloudRecordingDetailResponse,
   CloudRecordingListItem,
+  CloudPlaybackDescriptor,
   ListRecordingsResponse,
 } from "../types";
 import { createCloudRecordingRepository } from "../cloudRecordingRepository";
@@ -230,6 +231,26 @@ function makeListResponse(
   nextCursor: string | null = null,
 ): ListRecordingsResponse {
   return { items, nextCursor };
+}
+
+function makePlaybackDescriptor(
+  overrides: Partial<CloudPlaybackDescriptor> = {},
+): CloudPlaybackDescriptor {
+  return {
+    id: "rec_1",
+    title: "Test Recording",
+    durationMs: 5000,
+    schemaVersion: "0.1.0",
+    manifestUrl: "https://storage.example.com/rec_1/manifest.json",
+    metaUrl: "https://storage.example.com/rec_1/meta.json",
+    eventsUrl: "https://storage.example.com/rec_1/events.json",
+    snapshotsUrl: "https://storage.example.com/rec_1/snapshots.json",
+    indexesUrl: null,
+    mediaUrl: "https://storage.example.com/rec_1/media.webm",
+    thumbnailUrl: null,
+    expiresAt: "2026-05-29T00:05:00.000Z",
+    ...overrides,
+  };
 }
 
 // ─────────────────────────────────────────────────────────────
@@ -621,6 +642,137 @@ describe("CloudRecordingRepository", () => {
       expect(result2.ok).toBe(true);
       if (!result2.ok) throw new Error("expected ok");
       expect(result2.value.items).toHaveLength(0);
+    });
+  });
+
+  // ───────────────────────────────────────────────────────
+  // getPlaybackDescriptor（云端播放描述）
+  // ───────────────────────────────────────────────────────
+
+  describe("getPlaybackDescriptor", () => {
+    it("返回 ready 录制的 playback descriptor", async () => {
+      const repo = setupRepo();
+      mockFetch(200, makePlaybackDescriptor({ indexesUrl: "https://storage.example.com/rec_1/indexes.json" }));
+
+      const result = await repo.getPlaybackDescriptor("rec_1");
+
+      expect(result.ok).toBe(true);
+      if (!result.ok) throw new Error("expected ok");
+      expect(result.value).toMatchObject({
+        id: "rec_1",
+        manifestUrl: "https://storage.example.com/rec_1/manifest.json",
+        indexesUrl: "https://storage.example.com/rec_1/indexes.json",
+      });
+      expect(fetch).toHaveBeenCalledWith(
+        "/api/recordings/rec_1/playback",
+        expect.objectContaining({
+          method: "GET",
+          headers: { "x-owner-token": repo.getOwnerToken() },
+        }),
+      );
+    });
+
+    it("playback descriptor 错误时保留结构化错误和 requestId", async () => {
+      const repo = setupRepo();
+      mockFetch(404, {
+        error: { code: "not-found", message: "recording not found" },
+      }, { "x-request-id": "req-playback-1" });
+
+      const result = await repo.getPlaybackDescriptor("rec_missing");
+
+      expect(result.ok).toBe(false);
+      if (result.ok) throw new Error("expected failure");
+      expect(result.error.code).toBe("not-found");
+      expect(result.error.message).toBe("recording not found");
+      expect(result.error.requestId).toBe("req-playback-1");
+    });
+  });
+
+  // ───────────────────────────────────────────────────────
+  // rename（云端重命名）
+  // ───────────────────────────────────────────────────────
+
+  describe("rename", () => {
+    it("PATCH 录制标题并复用 owner token", async () => {
+      const repo = setupRepo();
+      mockFetch(200, {
+        id: "rec_1",
+        title: "New Title",
+        updatedAt: "2026-05-29T00:02:00.000Z",
+      });
+
+      const result = await repo.rename("rec_1", "  New Title  ");
+
+      expect(result.ok).toBe(true);
+      if (!result.ok) throw new Error("expected ok");
+      expect(result.value).toBeUndefined();
+      expect(fetch).toHaveBeenCalledWith(
+        "/api/recordings/rec_1",
+        expect.objectContaining({
+          method: "PATCH",
+          headers: {
+            "content-type": "application/json",
+            "x-owner-token": repo.getOwnerToken(),
+          },
+          body: JSON.stringify({ title: "  New Title  " }),
+        }),
+      );
+    });
+
+    it("rename 非法标题时返回后端结构化错误", async () => {
+      const repo = setupRepo();
+      mockFetch(400, {
+        error: { code: "bad-request", message: "title is required" },
+      }, { "x-request-id": "req-rename-1" });
+
+      const result = await repo.rename("rec_1", "");
+
+      expect(result.ok).toBe(false);
+      if (result.ok) throw new Error("expected failure");
+      expect(result.error.code).toBe("bad-request");
+      expect(result.error.message).toBe("title is required");
+      expect(result.error.requestId).toBe("req-rename-1");
+    });
+  });
+
+  // ───────────────────────────────────────────────────────
+  // remove（云端软删除）
+  // ───────────────────────────────────────────────────────
+
+  describe("remove", () => {
+    it("DELETE 录制并忽略 soft delete 响应细节", async () => {
+      const repo = setupRepo();
+      mockFetch(200, {
+        id: "rec_1",
+        status: "soft_deleted",
+        deletedAt: "2026-05-29T00:03:00.000Z",
+      });
+
+      const result = await repo.remove("rec_1");
+
+      expect(result.ok).toBe(true);
+      if (!result.ok) throw new Error("expected ok");
+      expect(result.value).toBeUndefined();
+      expect(fetch).toHaveBeenCalledWith(
+        "/api/recordings/rec_1",
+        expect.objectContaining({
+          method: "DELETE",
+          headers: { "x-owner-token": repo.getOwnerToken() },
+        }),
+      );
+    });
+
+    it("remove 录制不存在时返回 not-found", async () => {
+      const repo = setupRepo();
+      mockFetch(404, {
+        error: { code: "not-found", message: "recording not found" },
+      });
+
+      const result = await repo.remove("rec_missing");
+
+      expect(result.ok).toBe(false);
+      if (result.ok) throw new Error("expected failure");
+      expect(result.error.code).toBe("not-found");
     });
   });
 

--- a/apps/web/src/features/cloud/cloudRecordingRepository.ts
+++ b/apps/web/src/features/cloud/cloudRecordingRepository.ts
@@ -10,12 +10,13 @@
  * - 调用 complete API 通知服务端开始校验
  * - 查询录制详情与状态（GET /api/recordings/:id）
  * - 查询当前 owner 的 ready 录制列表（GET /api/recordings）
+ * - 获取 playback descriptor，重命名，软删除
  * - 管理持久化的 demo owner token
  *
  * 不包含：
  * - 上传按钮或完整 UI
- * - 云端播放页、playback descriptor、CloudPackageLoader
- * - 重命名、删除或分享
+ * - 云端播放页、CloudPackageLoader
+ * - 分享
  * - 对 P0 本地保存/回放主链路的任何修改
  */
 
@@ -29,6 +30,7 @@ import type {
   CompleteUploadSessionResponse,
   CreateUploadSessionRequest,
   CreateUploadSessionResponse,
+  CloudPlaybackDescriptor,
   ListRecordingsInput,
   ListRecordingsResponse,
   UploadProgress,
@@ -180,6 +182,63 @@ export function createCloudRecordingRepository(
         return handleJsonResponse<ListRecordingsResponse>(response);
       } catch (err) {
         return { ok: false, error: networkError("list recordings failed", err) };
+      }
+    },
+
+    // ── 获取云端播放描述 ──────────────────────────────────
+    async getPlaybackDescriptor(
+      recordingId: string,
+    ): Promise<CloudResult<CloudPlaybackDescriptor>> {
+      const token = repo.getOwnerToken();
+      try {
+        const response = await fetch(
+          `${apiBase}/api/recordings/${encodeURIComponent(recordingId)}/playback`,
+          {
+            method: "GET",
+            headers: { "x-owner-token": token },
+          },
+        );
+        return handleJsonResponse<CloudPlaybackDescriptor>(response);
+      } catch (err) {
+        return { ok: false, error: networkError("get playback descriptor failed", err) };
+      }
+    },
+
+    // ── 重命名云端录制 ────────────────────────────────────
+    async rename(recordingId: string, title: string): Promise<CloudResult<void>> {
+      const token = repo.getOwnerToken();
+      try {
+        const response = await fetch(
+          `${apiBase}/api/recordings/${encodeURIComponent(recordingId)}`,
+          {
+            method: "PATCH",
+            headers: {
+              "content-type": "application/json",
+              "x-owner-token": token,
+            },
+            body: JSON.stringify({ title }),
+          },
+        );
+        return handleVoidResponse(response);
+      } catch (err) {
+        return { ok: false, error: networkError("rename recording failed", err) };
+      }
+    },
+
+    // ── 软删除云端录制 ────────────────────────────────────
+    async remove(recordingId: string): Promise<CloudResult<void>> {
+      const token = repo.getOwnerToken();
+      try {
+        const response = await fetch(
+          `${apiBase}/api/recordings/${encodeURIComponent(recordingId)}`,
+          {
+            method: "DELETE",
+            headers: { "x-owner-token": token },
+          },
+        );
+        return handleVoidResponse(response);
+      } catch (err) {
+        return { ok: false, error: networkError("delete recording failed", err) };
       }
     },
 
@@ -387,6 +446,13 @@ async function handleJsonResponse<T>(response: Response): Promise<CloudResult<T>
       },
     };
   }
+}
+
+async function handleVoidResponse(response: Response): Promise<CloudResult<void>> {
+  if (!response.ok) {
+    return parseApiError(response);
+  }
+  return { ok: true, value: undefined };
 }
 
 /** 从非 2xx 响应中解析结构化错误 */

--- a/apps/web/src/features/cloud/types.ts
+++ b/apps/web/src/features/cloud/types.ts
@@ -173,6 +173,21 @@ export type ListRecordingsResponse = {
   nextCursor: string | null;
 };
 
+export type CloudPlaybackDescriptor = {
+  id: string;
+  title: string;
+  durationMs: number;
+  schemaVersion: RecordingSchemaVersion;
+  manifestUrl: string;
+  metaUrl: string;
+  eventsUrl: string;
+  snapshotsUrl: string;
+  indexesUrl: string | null;
+  mediaUrl: string | null;
+  thumbnailUrl: string | null;
+  expiresAt: string;
+};
+
 // ─────────────────────────────────────────────────────────────
 // 上传进度
 // ─────────────────────────────────────────────────────────────
@@ -234,6 +249,15 @@ export type CloudRecordingRepository = {
 
   /** 查询当前 owner 的 ready 录制列表 */
   list(input?: ListRecordingsInput): Promise<CloudResult<ListRecordingsResponse>>;
+
+  /** 获取 ready 录制的云端播放描述 */
+  getPlaybackDescriptor(recordingId: string): Promise<CloudResult<CloudPlaybackDescriptor>>;
+
+  /** 重命名当前 owner 可访问的云端录制 */
+  rename(recordingId: string, title: string): Promise<CloudResult<void>>;
+
+  /** 软删除当前 owner 可访问的云端录制 */
+  remove(recordingId: string): Promise<CloudResult<void>>;
 
   /** 获取当前持久化的 owner token */
   getOwnerToken(): string;


### PR DESCRIPTION
## 关联

Closes #142
Refs #92
Refs #2（总控 issue，不在本 PR 中关闭）

## 改动点

- 为前端 `CloudRecordingRepository` 补齐 `getPlaybackDescriptor()`、`rename()`、`remove()` 类型与实现。
- 接入现有云端 API：`GET /api/recordings/:id/playback`、`PATCH /api/recordings/:id`、`DELETE /api/recordings/:id`。
- 增加 repository 单测覆盖 playback descriptor、rename、remove 的成功与结构化错误路径。

## 影响范围

- 只影响 `apps/web/src/features/cloud` 前端云端仓库门面。
- 不改本地 IndexedDB 保存/回放链路，不改后端 API，不接入 UI 或 CloudPackageLoader。

## GitNexus 影响分析摘要

- 风险等级: HIGH（`detect_changes` 标记 3 个文件、14 个符号、6 条受影响流程，集中在 `CloudRecordingRepository` 文件）
- 关键骨架变更: 否；`contract:local` 提示未触碰 critical contract surface
- GitNexus 影响面: `detect_changes` 命中 `apps/web/src/features/cloud/cloudRecordingRepository.ts` 的上传相关流程；`context createCloudRecordingRepository --file apps/web/src/features/cloud/cloudRecordingRepository.ts` 显示该符号无 incoming/outgoing/processes，新增方法未改变上传语义
- 验证结果: `npm run test:web -- cloudRecordingRepository` 通过；`npm run quality:precommit` 通过；`npm run quality:local` 通过；push hook 再次运行 `quality:local` 通过

## 自检

- [x] 未修改 `docs/progress.json` 或 `docs/progress.md`
- [x] 已运行 `npm run quality:local`，或说明无法运行的原因
- [x] 已说明改动点和影响范围
- [x] 如果改动关键骨架，已补充契约测试并填写 GitNexus 影响分析摘要
- [ ] 已等待 repo-guard、codex 和 Copilot 评论，并完成必要审查
