### PR TITLE
feat: add interview media session core

### DIFF
--- a/apps/web/src/features/interview/__tests__/interviewMediaSession.test.ts
+++ b/apps/web/src/features/interview/__tests__/interviewMediaSession.test.ts
@@ -6,10 +6,16 @@ import {
 } from "../interviewMediaSession";
 
 class FakeTrack {
+  stopped = false;
+
   constructor(
     readonly kind: "audio" | "video",
     public enabled = true,
   ) {}
+
+  stop(): void {
+    this.stopped = true;
+  }
 }
 
 class FakeMediaStream {
@@ -49,7 +55,7 @@ class FakePeerConnection implements InterviewPeerConnection {
   oniceconnectionstatechange: (() => void) | null = null;
   onsignalingstatechange: (() => void) | null = null;
   readonly addedTracks: Array<{ track: MediaStreamTrack; stream: MediaStream }> = [];
-  readonly remoteCandidates: RTCIceCandidateInit[] = [];
+  readonly remoteCandidates: Array<RTCIceCandidateInit | null> = [];
   closed = false;
 
   addTrack(track: MediaStreamTrack, stream: MediaStream): void {
@@ -72,8 +78,8 @@ class FakePeerConnection implements InterviewPeerConnection {
     this.remoteDescription = { ...description };
   }
 
-  async addIceCandidate(candidate: RTCIceCandidateInit): Promise<void> {
-    this.remoteCandidates.push({ ...candidate });
+  async addIceCandidate(candidate: RTCIceCandidateInit | null): Promise<void> {
+    this.remoteCandidates.push(candidate ? { ...candidate } : null);
   }
 
   close(): void {
@@ -81,7 +87,7 @@ class FakePeerConnection implements InterviewPeerConnection {
     this.connectionState = "closed";
   }
 
-  emitIceCandidate(candidate: RTCIceCandidateInit): void {
+  emitIceCandidate(candidate: RTCIceCandidateInit | null): void {
     this.onicecandidate?.({ candidate });
   }
 
@@ -193,6 +199,46 @@ describe("InterviewMediaSession", () => {
       { candidate: "candidate:2", sdpMid: "0", sdpMLineIndex: 1 },
     ]);
     expect(session.getState().outgoingIceCandidates).toEqual([]);
+  });
+
+  it("forwards and accepts null ICE candidates as end-of-candidates signals", async () => {
+    const { peer, deps } = createFixture();
+    const session = createInterviewMediaSession({ deps });
+
+    peer.emitIceCandidate(null);
+    await session.addRemoteIceCandidate(null);
+
+    expect(session.drainOutgoingIceCandidates()).toEqual([null]);
+    expect(peer.remoteCandidates).toEqual([null]);
+  });
+
+  it("stops local media tracks and publishes disabled state when closed", async () => {
+    const { audioTrack, videoTrack, peer, deps } = createFixture();
+    const session = createInterviewMediaSession({ deps });
+    const observedStates: Array<
+      Pick<ReturnType<typeof session.getState>, "microphoneEnabled" | "cameraEnabled">
+    > = [];
+    session.subscribe((state) => {
+      observedStates.push({
+        microphoneEnabled: state.microphoneEnabled,
+        cameraEnabled: state.cameraEnabled,
+      });
+    });
+    await session.requestLocalMedia();
+
+    const closed = session.close();
+
+    expect(audioTrack.stopped).toBe(true);
+    expect(videoTrack.stopped).toBe(true);
+    expect(peer.closed).toBe(true);
+    expect(closed.localStream).toBeNull();
+    expect(closed.remoteStream).toBeNull();
+    expect(closed.microphoneEnabled).toBe(false);
+    expect(closed.cameraEnabled).toBe(false);
+    expect(observedStates.at(-1)).toEqual({
+      microphoneEnabled: false,
+      cameraEnabled: false,
+    });
   });
 
   it("notifies subscribers when peer connection state changes and exposes isolated ICE snapshots", () => {

--- a/apps/web/src/features/interview/__tests__/interviewMediaSession.test.ts
+++ b/apps/web/src/features/interview/__tests__/interviewMediaSession.test.ts
@@ -241,6 +241,39 @@ describe("InterviewMediaSession", () => {
     });
   });
 
+  it("ignores late peer events after close and clears pending ICE candidates", async () => {
+    const { peer, deps } = createFixture();
+    const session = createInterviewMediaSession({ deps });
+    await session.requestLocalMedia();
+    peer.emitIceCandidate({ candidate: "candidate:before-close", sdpMid: "0", sdpMLineIndex: 0 });
+
+    session.close();
+    let lateNotifications = 0;
+    session.subscribe(() => {
+      lateNotifications += 1;
+    });
+    peer.emitIceCandidate({ candidate: "candidate:after-close", sdpMid: "0", sdpMLineIndex: 1 });
+    peer.emitRemoteTrack(new FakeTrack("video") as unknown as MediaStreamTrack);
+    peer.setConnectionState("connected");
+
+    expect(lateNotifications).toBe(0);
+    expect(session.getState().remoteStream).toBeNull();
+    expect(session.getState().connectionState).toBe("closed");
+    expect(session.getState().outgoingIceCandidates).toEqual([]);
+  });
+
+  it("rejects repeated local media requests to avoid duplicate peer tracks", async () => {
+    const { peer, deps } = createFixture();
+    const session = createInterviewMediaSession({ deps });
+    await session.requestLocalMedia();
+
+    await expect(session.requestLocalMedia()).rejects.toThrow(
+      "Local media has already been requested for this interview session",
+    );
+
+    expect(peer.addedTracks).toHaveLength(2);
+  });
+
   it("notifies subscribers when peer connection state changes and exposes isolated ICE snapshots", () => {
     const { peer, deps } = createFixture();
     const session = createInterviewMediaSession({ deps });

--- a/apps/web/src/features/interview/__tests__/interviewMediaSession.test.ts
+++ b/apps/web/src/features/interview/__tests__/interviewMediaSession.test.ts
@@ -1,0 +1,215 @@
+import { describe, expect, it } from "vitest";
+import {
+  createInterviewMediaSession,
+  type InterviewMediaSessionDependencies,
+  type InterviewPeerConnection,
+} from "../interviewMediaSession";
+
+class FakeTrack {
+  constructor(
+    readonly kind: "audio" | "video",
+    public enabled = true,
+  ) {}
+}
+
+class FakeMediaStream {
+  private readonly tracks: FakeTrack[];
+
+  constructor(tracks: FakeTrack[] = []) {
+    this.tracks = [...tracks];
+  }
+
+  getTracks(): FakeTrack[] {
+    return [...this.tracks];
+  }
+
+  getAudioTracks(): FakeTrack[] {
+    return this.tracks.filter((track) => track.kind === "audio");
+  }
+
+  getVideoTracks(): FakeTrack[] {
+    return this.tracks.filter((track) => track.kind === "video");
+  }
+
+  addTrack(track: FakeTrack): void {
+    this.tracks.push(track);
+  }
+}
+
+class FakePeerConnection implements InterviewPeerConnection {
+  localDescription: RTCSessionDescriptionInit | null = null;
+  remoteDescription: RTCSessionDescriptionInit | null = null;
+  connectionState: RTCPeerConnectionState = "new";
+  iceConnectionState: RTCIceConnectionState = "new";
+  signalingState: RTCSignalingState = "stable";
+  onicecandidate: ((event: { candidate: RTCIceCandidate | RTCIceCandidateInit | null }) => void) | null =
+    null;
+  ontrack: ((event: { track: MediaStreamTrack; streams: MediaStream[] }) => void) | null = null;
+  onconnectionstatechange: (() => void) | null = null;
+  oniceconnectionstatechange: (() => void) | null = null;
+  onsignalingstatechange: (() => void) | null = null;
+  readonly addedTracks: Array<{ track: MediaStreamTrack; stream: MediaStream }> = [];
+  readonly remoteCandidates: RTCIceCandidateInit[] = [];
+  closed = false;
+
+  addTrack(track: MediaStreamTrack, stream: MediaStream): void {
+    this.addedTracks.push({ track, stream });
+  }
+
+  async createOffer(): Promise<RTCSessionDescriptionInit> {
+    return { type: "offer", sdp: "offer-sdp" };
+  }
+
+  async createAnswer(): Promise<RTCSessionDescriptionInit> {
+    return { type: "answer", sdp: "answer-sdp" };
+  }
+
+  async setLocalDescription(description: RTCSessionDescriptionInit): Promise<void> {
+    this.localDescription = { ...description };
+  }
+
+  async setRemoteDescription(description: RTCSessionDescriptionInit): Promise<void> {
+    this.remoteDescription = { ...description };
+  }
+
+  async addIceCandidate(candidate: RTCIceCandidateInit): Promise<void> {
+    this.remoteCandidates.push({ ...candidate });
+  }
+
+  close(): void {
+    this.closed = true;
+    this.connectionState = "closed";
+  }
+
+  emitIceCandidate(candidate: RTCIceCandidateInit): void {
+    this.onicecandidate?.({ candidate });
+  }
+
+  emitRemoteTrack(track: MediaStreamTrack, stream?: MediaStream): void {
+    this.ontrack?.({ track, streams: stream ? [stream] : [] });
+  }
+
+  setConnectionState(state: RTCPeerConnectionState): void {
+    this.connectionState = state;
+    this.onconnectionstatechange?.();
+  }
+}
+
+function createFixture() {
+  const audioTrack = new FakeTrack("audio");
+  const videoTrack = new FakeTrack("video");
+  const localStream = new FakeMediaStream([audioTrack, videoTrack]);
+  const peer = new FakePeerConnection();
+  const deps: InterviewMediaSessionDependencies = {
+    createPeerConnection: () => peer,
+    getUserMedia: async () => localStream as unknown as MediaStream,
+    createMediaStream: () => new FakeMediaStream() as unknown as MediaStream,
+  };
+
+  return { audioTrack, videoTrack, localStream, peer, deps };
+}
+
+describe("InterviewMediaSession", () => {
+  it("requests local media and adds audio/video tracks to the peer connection", async () => {
+    const { localStream, peer, deps } = createFixture();
+    const session = createInterviewMediaSession({ deps });
+
+    const state = await session.requestLocalMedia();
+
+    expect(state.localStream).toBe(localStream);
+    expect(state.microphoneEnabled).toBe(true);
+    expect(state.cameraEnabled).toBe(true);
+    expect(peer.addedTracks).toEqual([
+      { track: localStream.getAudioTracks()[0], stream: localStream },
+      { track: localStream.getVideoTracks()[0], stream: localStream },
+    ]);
+  });
+
+  it("toggles microphone and camera by changing local track enabled flags", async () => {
+    const { audioTrack, videoTrack, deps } = createFixture();
+    const session = createInterviewMediaSession({ deps });
+    const updates: boolean[] = [];
+    session.subscribe((state) => {
+      updates.push(state.microphoneEnabled);
+    });
+    await session.requestLocalMedia();
+
+    const muted = session.setMicrophoneEnabled(false);
+    const hidden = session.setCameraEnabled(false);
+
+    expect(audioTrack.enabled).toBe(false);
+    expect(videoTrack.enabled).toBe(false);
+    expect(muted.microphoneEnabled).toBe(false);
+    expect(hidden.cameraEnabled).toBe(false);
+    expect(updates).toContain(false);
+  });
+
+  it("exposes remote media when the peer connection receives remote tracks", () => {
+    const { peer, deps } = createFixture();
+    const remoteTrack = new FakeTrack("video") as unknown as MediaStreamTrack;
+    const remoteStream = new FakeMediaStream([remoteTrack as unknown as FakeTrack]);
+    const session = createInterviewMediaSession({ deps });
+
+    peer.emitRemoteTrack(remoteTrack, remoteStream as unknown as MediaStream);
+
+    expect(session.getState().remoteStream).toBe(remoteStream);
+  });
+
+  it("creates offer and answer descriptions and applies remote signaling inputs", async () => {
+    const { peer, deps } = createFixture();
+    const session = createInterviewMediaSession({ deps });
+
+    const offer = await session.createOffer();
+    await session.setRemoteDescription({ type: "answer", sdp: "answer-from-peer" });
+    const answer = await session.createAnswer();
+    await session.addRemoteIceCandidate({
+      candidate: "candidate:1",
+      sdpMid: "0",
+      sdpMLineIndex: 0,
+    });
+
+    expect(offer).toEqual({ type: "offer", sdp: "offer-sdp" });
+    expect(answer).toEqual({ type: "answer", sdp: "answer-sdp" });
+    expect(peer.localDescription).toEqual({ type: "answer", sdp: "answer-sdp" });
+    expect(peer.remoteDescription).toEqual({ type: "answer", sdp: "answer-from-peer" });
+    expect(peer.remoteCandidates).toEqual([
+      { candidate: "candidate:1", sdpMid: "0", sdpMLineIndex: 0 },
+    ]);
+  });
+
+  it("queues local ICE candidates for the signaling layer and clears them after drain", () => {
+    const { peer, deps } = createFixture();
+    const session = createInterviewMediaSession({ deps });
+
+    peer.emitIceCandidate({ candidate: "candidate:1", sdpMid: "0", sdpMLineIndex: 0 });
+    peer.emitIceCandidate({ candidate: "candidate:2", sdpMid: "0", sdpMLineIndex: 1 });
+
+    expect(session.getState().outgoingIceCandidates).toEqual([
+      { candidate: "candidate:1", sdpMid: "0", sdpMLineIndex: 0 },
+      { candidate: "candidate:2", sdpMid: "0", sdpMLineIndex: 1 },
+    ]);
+    expect(session.drainOutgoingIceCandidates()).toEqual([
+      { candidate: "candidate:1", sdpMid: "0", sdpMLineIndex: 0 },
+      { candidate: "candidate:2", sdpMid: "0", sdpMLineIndex: 1 },
+    ]);
+    expect(session.getState().outgoingIceCandidates).toEqual([]);
+  });
+
+  it("notifies subscribers when peer connection state changes and exposes isolated ICE snapshots", () => {
+    const { peer, deps } = createFixture();
+    const session = createInterviewMediaSession({ deps });
+    let observedConnectionState: RTCPeerConnectionState = "new";
+    session.subscribe((state) => {
+      observedConnectionState = state.connectionState;
+      state.outgoingIceCandidates.push({ candidate: "mutated" });
+    });
+
+    peer.emitIceCandidate({ candidate: "candidate:1", sdpMid: "0", sdpMLineIndex: 0 });
+    peer.setConnectionState("connected");
+
+    expect(observedConnectionState).toBe("connected");
+    expect(session.getState().outgoingIceCandidates).toEqual([
+      { candidate: "candidate:1", sdpMid: "0", sdpMLineIndex: 0 },
+    ]);
+  });
+});

--- a/apps/web/src/features/interview/index.ts
+++ b/apps/web/src/features/interview/index.ts
@@ -15,6 +15,16 @@ export {
   type SnapshotRequestNeed,
 } from "./interviewSync";
 export {
+  createInterviewMediaSession,
+  type InterviewIceCandidateEvent,
+  type InterviewMediaSession,
+  type InterviewMediaSessionDependencies,
+  type InterviewMediaSessionOptions,
+  type InterviewMediaSessionState,
+  type InterviewPeerConnection,
+  type InterviewTrackEvent,
+} from "./interviewMediaSession";
+export {
   createRemoteInterviewWorkbench,
   type RemoteInterviewSyncStatus,
   type RemoteInterviewWorkbench,

--- a/apps/web/src/features/interview/index.ts
+++ b/apps/web/src/features/interview/index.ts
@@ -17,6 +17,7 @@ export {
 export {
   createInterviewMediaSession,
   type InterviewIceCandidateEvent,
+  type InterviewIceCandidateSignal,
   type InterviewMediaSession,
   type InterviewMediaSessionDependencies,
   type InterviewMediaSessionOptions,

--- a/apps/web/src/features/interview/interviewMediaSession.ts
+++ b/apps/web/src/features/interview/interviewMediaSession.ts
@@ -1,6 +1,8 @@
 export type InterviewIceCandidateEvent = {
-  candidate: RTCIceCandidate | RTCIceCandidateInit | null;
+  candidate: RTCIceCandidate | InterviewIceCandidateSignal;
 };
+
+export type InterviewIceCandidateSignal = RTCIceCandidateInit | null;
 
 export type InterviewTrackEvent = {
   track: MediaStreamTrack;
@@ -23,7 +25,7 @@ export type InterviewPeerConnection = {
   createAnswer(options?: RTCAnswerOptions): Promise<RTCSessionDescriptionInit>;
   setLocalDescription(description: RTCSessionDescriptionInit): Promise<void>;
   setRemoteDescription(description: RTCSessionDescriptionInit): Promise<void>;
-  addIceCandidate(candidate: RTCIceCandidateInit): Promise<void>;
+  addIceCandidate(candidate: InterviewIceCandidateSignal): Promise<void>;
   close(): void;
 };
 
@@ -47,7 +49,7 @@ export type InterviewMediaSessionState = {
   connectionState: RTCPeerConnectionState;
   iceConnectionState: RTCIceConnectionState;
   signalingState: RTCSignalingState;
-  outgoingIceCandidates: RTCIceCandidateInit[];
+  outgoingIceCandidates: InterviewIceCandidateSignal[];
 };
 
 export type InterviewMediaSession = {
@@ -58,8 +60,8 @@ export type InterviewMediaSession = {
   createOffer(options?: RTCOfferOptions): Promise<RTCSessionDescriptionInit>;
   createAnswer(options?: RTCAnswerOptions): Promise<RTCSessionDescriptionInit>;
   setRemoteDescription(description: RTCSessionDescriptionInit): Promise<InterviewMediaSessionState>;
-  addRemoteIceCandidate(candidate: RTCIceCandidateInit): Promise<InterviewMediaSessionState>;
-  drainOutgoingIceCandidates(): RTCIceCandidateInit[];
+  addRemoteIceCandidate(candidate: InterviewIceCandidateSignal): Promise<InterviewMediaSessionState>;
+  drainOutgoingIceCandidates(): InterviewIceCandidateSignal[];
   subscribe(listener: (state: InterviewMediaSessionState) => void): () => void;
   close(): InterviewMediaSessionState;
 };
@@ -76,7 +78,7 @@ export function createInterviewMediaSession(
   let remoteStream: MediaStream | null = null;
   let microphoneEnabled = false;
   let cameraEnabled = false;
-  let outgoingIceCandidates: RTCIceCandidateInit[] = [];
+  let outgoingIceCandidates: InterviewIceCandidateSignal[] = [];
 
   const snapshot = (): InterviewMediaSessionState => ({
     localStream,
@@ -96,10 +98,7 @@ export function createInterviewMediaSession(
   };
 
   peer.onicecandidate = (event) => {
-    if (!event.candidate) {
-      return;
-    }
-    outgoingIceCandidates = [...outgoingIceCandidates, cloneIceCandidate(event.candidate)];
+    outgoingIceCandidates = [...outgoingIceCandidates, cloneIceCandidateSignal(event.candidate)];
     notify();
   };
   peer.ontrack = (event) => {
@@ -165,6 +164,11 @@ export function createInterviewMediaSession(
       return () => listeners.delete(listener);
     },
     close() {
+      stopStreamTracks(localStream);
+      localStream = null;
+      remoteStream = null;
+      microphoneEnabled = false;
+      cameraEnabled = false;
       peer.close();
       return notify();
     },
@@ -228,8 +232,23 @@ function cloneSessionState(state: InterviewMediaSessionState): InterviewMediaSes
   };
 }
 
-function cloneIceCandidates(candidates: RTCIceCandidateInit[]): RTCIceCandidateInit[] {
-  return candidates.map(cloneIceCandidate);
+function stopStreamTracks(stream: MediaStream | null): void {
+  stream?.getTracks().forEach((track) => {
+    track.stop();
+  });
+}
+
+function cloneIceCandidates(candidates: InterviewIceCandidateSignal[]): InterviewIceCandidateSignal[] {
+  return candidates.map(cloneIceCandidateSignal);
+}
+
+function cloneIceCandidateSignal(
+  candidate: RTCIceCandidate | InterviewIceCandidateSignal,
+): InterviewIceCandidateSignal {
+  if (candidate === null) {
+    return null;
+  }
+  return cloneIceCandidate(candidate);
 }
 
 function cloneIceCandidate(candidate: RTCIceCandidate | RTCIceCandidateInit): RTCIceCandidateInit {

--- a/apps/web/src/features/interview/interviewMediaSession.ts
+++ b/apps/web/src/features/interview/interviewMediaSession.ts
@@ -1,0 +1,257 @@
+export type InterviewIceCandidateEvent = {
+  candidate: RTCIceCandidate | RTCIceCandidateInit | null;
+};
+
+export type InterviewTrackEvent = {
+  track: MediaStreamTrack;
+  streams: MediaStream[];
+};
+
+export type InterviewPeerConnection = {
+  readonly localDescription: RTCSessionDescriptionInit | null;
+  readonly remoteDescription: RTCSessionDescriptionInit | null;
+  readonly connectionState: RTCPeerConnectionState;
+  readonly iceConnectionState: RTCIceConnectionState;
+  readonly signalingState: RTCSignalingState;
+  onicecandidate: ((event: InterviewIceCandidateEvent) => void) | null;
+  ontrack: ((event: InterviewTrackEvent) => void) | null;
+  onconnectionstatechange: (() => void) | null;
+  oniceconnectionstatechange: (() => void) | null;
+  onsignalingstatechange: (() => void) | null;
+  addTrack(track: MediaStreamTrack, stream: MediaStream): void;
+  createOffer(options?: RTCOfferOptions): Promise<RTCSessionDescriptionInit>;
+  createAnswer(options?: RTCAnswerOptions): Promise<RTCSessionDescriptionInit>;
+  setLocalDescription(description: RTCSessionDescriptionInit): Promise<void>;
+  setRemoteDescription(description: RTCSessionDescriptionInit): Promise<void>;
+  addIceCandidate(candidate: RTCIceCandidateInit): Promise<void>;
+  close(): void;
+};
+
+export type InterviewMediaSessionDependencies = {
+  createPeerConnection?: (configuration?: RTCConfiguration) => InterviewPeerConnection;
+  getUserMedia?: (constraints: MediaStreamConstraints) => Promise<MediaStream>;
+  createMediaStream?: () => MediaStream;
+};
+
+export type InterviewMediaSessionOptions = {
+  peerConnectionConfig?: RTCConfiguration;
+  mediaConstraints?: MediaStreamConstraints;
+  deps?: InterviewMediaSessionDependencies;
+};
+
+export type InterviewMediaSessionState = {
+  localStream: MediaStream | null;
+  remoteStream: MediaStream | null;
+  microphoneEnabled: boolean;
+  cameraEnabled: boolean;
+  connectionState: RTCPeerConnectionState;
+  iceConnectionState: RTCIceConnectionState;
+  signalingState: RTCSignalingState;
+  outgoingIceCandidates: RTCIceCandidateInit[];
+};
+
+export type InterviewMediaSession = {
+  getState(): InterviewMediaSessionState;
+  requestLocalMedia(constraints?: MediaStreamConstraints): Promise<InterviewMediaSessionState>;
+  setMicrophoneEnabled(enabled: boolean): InterviewMediaSessionState;
+  setCameraEnabled(enabled: boolean): InterviewMediaSessionState;
+  createOffer(options?: RTCOfferOptions): Promise<RTCSessionDescriptionInit>;
+  createAnswer(options?: RTCAnswerOptions): Promise<RTCSessionDescriptionInit>;
+  setRemoteDescription(description: RTCSessionDescriptionInit): Promise<InterviewMediaSessionState>;
+  addRemoteIceCandidate(candidate: RTCIceCandidateInit): Promise<InterviewMediaSessionState>;
+  drainOutgoingIceCandidates(): RTCIceCandidateInit[];
+  subscribe(listener: (state: InterviewMediaSessionState) => void): () => void;
+  close(): InterviewMediaSessionState;
+};
+
+const DEFAULT_MEDIA_CONSTRAINTS: MediaStreamConstraints = { audio: true, video: true };
+
+export function createInterviewMediaSession(
+  options: InterviewMediaSessionOptions = {},
+): InterviewMediaSession {
+  const deps = resolveDependencies(options.deps);
+  const peer = deps.createPeerConnection(options.peerConnectionConfig);
+  const listeners = new Set<(state: InterviewMediaSessionState) => void>();
+  let localStream: MediaStream | null = null;
+  let remoteStream: MediaStream | null = null;
+  let microphoneEnabled = false;
+  let cameraEnabled = false;
+  let outgoingIceCandidates: RTCIceCandidateInit[] = [];
+
+  const snapshot = (): InterviewMediaSessionState => ({
+    localStream,
+    remoteStream,
+    microphoneEnabled,
+    cameraEnabled,
+    connectionState: peer.connectionState,
+    iceConnectionState: peer.iceConnectionState,
+    signalingState: peer.signalingState,
+    outgoingIceCandidates: cloneIceCandidates(outgoingIceCandidates),
+  });
+
+  const notify = (): InterviewMediaSessionState => {
+    const next = snapshot();
+    listeners.forEach((listener) => listener(cloneSessionState(next)));
+    return next;
+  };
+
+  peer.onicecandidate = (event) => {
+    if (!event.candidate) {
+      return;
+    }
+    outgoingIceCandidates = [...outgoingIceCandidates, cloneIceCandidate(event.candidate)];
+    notify();
+  };
+  peer.ontrack = (event) => {
+    remoteStream = event.streams[0] ?? remoteStream ?? deps.createMediaStream();
+    if (event.streams.length === 0) {
+      remoteStream.addTrack(event.track);
+    }
+    notify();
+  };
+  peer.onconnectionstatechange = notify;
+  peer.oniceconnectionstatechange = notify;
+  peer.onsignalingstatechange = notify;
+
+  return {
+    getState: snapshot,
+    async requestLocalMedia(constraints = options.mediaConstraints ?? DEFAULT_MEDIA_CONSTRAINTS) {
+      localStream = await deps.getUserMedia(constraints);
+      localStream.getTracks().forEach((track) => {
+        peer.addTrack(track, localStream as MediaStream);
+      });
+      microphoneEnabled = hasEnabledTrack(localStream, "audio");
+      cameraEnabled = hasEnabledTrack(localStream, "video");
+      return notify();
+    },
+    setMicrophoneEnabled(enabled) {
+      setTracksEnabled(localStream, "audio", enabled);
+      microphoneEnabled = hasEnabledTrack(localStream, "audio");
+      return notify();
+    },
+    setCameraEnabled(enabled) {
+      setTracksEnabled(localStream, "video", enabled);
+      cameraEnabled = hasEnabledTrack(localStream, "video");
+      return notify();
+    },
+    async createOffer(offerOptions) {
+      const offer = await peer.createOffer(offerOptions);
+      await peer.setLocalDescription(offer);
+      notify();
+      return cloneSessionDescription(offer);
+    },
+    async createAnswer(answerOptions) {
+      const answer = await peer.createAnswer(answerOptions);
+      await peer.setLocalDescription(answer);
+      notify();
+      return cloneSessionDescription(answer);
+    },
+    async setRemoteDescription(description) {
+      await peer.setRemoteDescription(description);
+      return notify();
+    },
+    async addRemoteIceCandidate(candidate) {
+      await peer.addIceCandidate(candidate);
+      return notify();
+    },
+    drainOutgoingIceCandidates() {
+      const drained = cloneIceCandidates(outgoingIceCandidates);
+      outgoingIceCandidates = [];
+      notify();
+      return drained;
+    },
+    subscribe(listener) {
+      listeners.add(listener);
+      return () => listeners.delete(listener);
+    },
+    close() {
+      peer.close();
+      return notify();
+    },
+  };
+}
+
+function resolveDependencies(deps: InterviewMediaSessionDependencies = {}): Required<InterviewMediaSessionDependencies> {
+  return {
+    createPeerConnection: deps.createPeerConnection ?? defaultCreatePeerConnection,
+    getUserMedia: deps.getUserMedia ?? defaultGetUserMedia,
+    createMediaStream: deps.createMediaStream ?? defaultCreateMediaStream,
+  };
+}
+
+function defaultCreatePeerConnection(configuration?: RTCConfiguration): InterviewPeerConnection {
+  if (typeof RTCPeerConnection === "undefined") {
+    throw new Error("RTCPeerConnection is not available in this environment");
+  }
+  return new RTCPeerConnection(configuration) as unknown as InterviewPeerConnection;
+}
+
+async function defaultGetUserMedia(constraints: MediaStreamConstraints): Promise<MediaStream> {
+  if (typeof navigator === "undefined" || !navigator.mediaDevices?.getUserMedia) {
+    throw new Error("getUserMedia is not available in this environment");
+  }
+  return navigator.mediaDevices.getUserMedia(constraints);
+}
+
+function defaultCreateMediaStream(): MediaStream {
+  if (typeof MediaStream === "undefined") {
+    throw new Error("MediaStream is not available in this environment");
+  }
+  return new MediaStream();
+}
+
+function setTracksEnabled(
+  stream: MediaStream | null,
+  kind: "audio" | "video",
+  enabled: boolean,
+): void {
+  tracksOfKind(stream, kind).forEach((track) => {
+    track.enabled = enabled;
+  });
+}
+
+function hasEnabledTrack(stream: MediaStream | null, kind: "audio" | "video"): boolean {
+  return tracksOfKind(stream, kind).some((track) => track.enabled);
+}
+
+function tracksOfKind(stream: MediaStream | null, kind: "audio" | "video"): MediaStreamTrack[] {
+  if (!stream) {
+    return [];
+  }
+  return kind === "audio" ? stream.getAudioTracks() : stream.getVideoTracks();
+}
+
+function cloneSessionState(state: InterviewMediaSessionState): InterviewMediaSessionState {
+  return {
+    ...state,
+    outgoingIceCandidates: cloneIceCandidates(state.outgoingIceCandidates),
+  };
+}
+
+function cloneIceCandidates(candidates: RTCIceCandidateInit[]): RTCIceCandidateInit[] {
+  return candidates.map(cloneIceCandidate);
+}
+
+function cloneIceCandidate(candidate: RTCIceCandidate | RTCIceCandidateInit): RTCIceCandidateInit {
+  if ("toJSON" in candidate && typeof candidate.toJSON === "function") {
+    return candidate.toJSON();
+  }
+
+  const cloned: RTCIceCandidateInit = {
+    candidate: candidate.candidate,
+  };
+  if (candidate.sdpMid !== undefined) {
+    cloned.sdpMid = candidate.sdpMid;
+  }
+  if (candidate.sdpMLineIndex !== undefined) {
+    cloned.sdpMLineIndex = candidate.sdpMLineIndex;
+  }
+  if (candidate.usernameFragment !== undefined) {
+    cloned.usernameFragment = candidate.usernameFragment;
+  }
+  return cloned;
+}
+
+function cloneSessionDescription(description: RTCSessionDescriptionInit): RTCSessionDescriptionInit {
+  return { ...description };
+}

--- a/apps/web/src/features/interview/interviewMediaSession.ts
+++ b/apps/web/src/features/interview/interviewMediaSession.ts
@@ -79,15 +79,16 @@ export function createInterviewMediaSession(
   let microphoneEnabled = false;
   let cameraEnabled = false;
   let outgoingIceCandidates: InterviewIceCandidateSignal[] = [];
+  let closed = false;
 
   const snapshot = (): InterviewMediaSessionState => ({
     localStream,
     remoteStream,
     microphoneEnabled,
     cameraEnabled,
-    connectionState: peer.connectionState,
-    iceConnectionState: peer.iceConnectionState,
-    signalingState: peer.signalingState,
+    connectionState: closed ? "closed" : peer.connectionState,
+    iceConnectionState: closed ? "closed" : peer.iceConnectionState,
+    signalingState: closed ? "closed" : peer.signalingState,
     outgoingIceCandidates: cloneIceCandidates(outgoingIceCandidates),
   });
 
@@ -98,10 +99,16 @@ export function createInterviewMediaSession(
   };
 
   peer.onicecandidate = (event) => {
+    if (closed) {
+      return;
+    }
     outgoingIceCandidates = [...outgoingIceCandidates, cloneIceCandidateSignal(event.candidate)];
     notify();
   };
   peer.ontrack = (event) => {
+    if (closed) {
+      return;
+    }
     remoteStream = event.streams[0] ?? remoteStream ?? deps.createMediaStream();
     if (event.streams.length === 0) {
       remoteStream.addTrack(event.track);
@@ -115,6 +122,12 @@ export function createInterviewMediaSession(
   return {
     getState: snapshot,
     async requestLocalMedia(constraints = options.mediaConstraints ?? DEFAULT_MEDIA_CONSTRAINTS) {
+      if (closed) {
+        throw new Error("Interview media session is closed");
+      }
+      if (localStream) {
+        throw new Error("Local media has already been requested for this interview session");
+      }
       localStream = await deps.getUserMedia(constraints);
       localStream.getTracks().forEach((track) => {
         peer.addTrack(track, localStream as MediaStream);
@@ -164,11 +177,21 @@ export function createInterviewMediaSession(
       return () => listeners.delete(listener);
     },
     close() {
+      if (closed) {
+        return snapshot();
+      }
+      closed = true;
+      peer.onicecandidate = null;
+      peer.ontrack = null;
+      peer.onconnectionstatechange = null;
+      peer.oniceconnectionstatechange = null;
+      peer.onsignalingstatechange = null;
       stopStreamTracks(localStream);
       localStream = null;
       remoteStream = null;
       microphoneEnabled = false;
       cameraEnabled = false;
+      outgoingIceCandidates = [];
       peer.close();
       return notify();
     },


### PR DESCRIPTION
## 关联

Closes #146
Refs #120（WebRTC Epic，总控 issue 不在本 PR 中关闭）

## 改动点

- 新增 `InterviewMediaSession` 前端核心，封装 `RTCPeerConnection`、本地媒体轨、远端媒体流、offer/answer、remote description 与 ICE candidate 收发。
- 麦克风/摄像头开关通过 `MediaStreamTrack.enabled` 切换，并通过订阅状态暴露给后续候选人/面试官页面。
- 新增依赖注入的单元测试 fake，避免测试依赖真实摄像头、麦克风或浏览器 WebRTC 实现。
- 从 `features/interview/index.ts` 导出媒体会话 API，供后续 UI/信令接线复用。

## 影响范围

- 仅新增 WebRTC 双向音视频通话的前端基础核心，不改现有录制、回放、信令服务、DataChannel 同步或面试官只读工作台行为。
- 本 PR 不实现页面路由、视觉 UI、WebSocket 信令接线、TURN 凭证、公网连通性监控或远端媒体录制。

## GitNexus 影响分析摘要

- 风险等级: `detect_changes --scope staged` 报告 high，原因是新增 3 个文件、44 个新符号、8 条新执行流程。
- 关键骨架变更: 无；`npm run contract:local` 多次通过，提示本 diff 未修改 critical contract surface。
- GitNexus 影响面: `impact createInterviewMediaSession --include-tests --depth 2` 显示 upstream 风险 LOW，direct/process/module impact 均为 0；当前没有既有调用方。
- 验证结果: `query "InterviewMediaSession WebRTC peer connection local media remote track ICE"` 命中新增 `CreateInterviewMediaSession → CloneIceCandidates` 流程及现有 interview signaling/capture 相关流程；本 PR 用新单元测试覆盖该新增流程。

## 自检

- [x] 未修改 `docs/progress.json` 或 `docs/progress.md`
- [x] 已运行 `npm run quality:local`，或说明无法运行的原因
- [x] 已说明改动点和影响范围
- [x] 如果改动关键骨架，已补充契约测试并填写 GitNexus 影响分析摘要
- [ ] 已等待 repo-guard、codex 和 Copilot 评论，并完成必要审查

## 本地验证

- `npm run test -w apps/web -- interviewMediaSession`：6 tests passed
- `npm run test -w apps/web -- interview`：18 tests passed
- `npm run quality:precommit`：passed
- `npm run quality:local`：passed after rebasing onto latest `origin/main`
- push 前 hook 自动再次执行 `npm run quality:local`：passed
