### PR TITLE
Add subtitle LLM postprocess timeout metrics

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -22,7 +22,7 @@ Refs #2（总控 issue，不在本 PR 中关闭）
 - [ ] 未修改 `docs/progress.json` 或 `docs/progress.md`
 - [ ] 已运行 `npm run quality:local`，或说明无法运行的原因
 - [ ] 涉及 AI 字幕时，已记录一次 `npm run subtitle:postprocess:evaluate` 的“纠错并生成章节”效果验证结果，包含 `representativeOutputSource`、`overallEvaluationDurationMs`，并区分输出校验耗时与真实端到端耗时
-- [ ] 涉及 AI 字幕点击链路、LLM worker、模型加载或性能时，已记录一次 `npm run subtitle:postprocess:runtime-benchmark` 结果，包含 `postprocessClickToResultReadyDurationMs` 和 `playbackProbeResponsiveDuringPostprocess`
+- [ ] 涉及 AI 字幕点击链路、LLM worker、模型加载或性能时，已记录一次 `npm run subtitle:postprocess:runtime-benchmark` 结果，包含 `postprocessClickToResultReadyDurationMs`、`postProcessTimeoutBudgetMs` 和 `playbackProbeResponsiveDuringPostprocess`
 - [ ] 已说明改动点和影响范围
 - [ ] 如果改动关键骨架，已补充契约测试并填写 GitNexus 影响分析摘要
 - [ ] 已等待 repo-guard、codex 和 Copilot 评论，并完成必要审查

--- a/apps/web/src/features/subtitles/SubtitlePanel.tsx
+++ b/apps/web/src/features/subtitles/SubtitlePanel.tsx
@@ -245,6 +245,7 @@ export function SubtitlePanel({
       setStatus("ready");
     } catch (err) {
       if (isPostProcessTimeoutError(err)) {
+        if (requestVersionRef.current !== requestVersion || generationAbortRef.current !== abortController) return;
         setError(formatSubtitleError(err));
         setStatus("error");
         return;

--- a/apps/web/src/features/subtitles/SubtitlePanel.tsx
+++ b/apps/web/src/features/subtitles/SubtitlePanel.tsx
@@ -11,12 +11,15 @@ import type {
   SubtitleCorrectionWarning,
   SubtitlePostProcessor,
   SubtitlePostProcessorContext,
+  SubtitlePostProcessorMetric,
   SubtitleSegment,
   SubtitleStore,
   SubtitleTrack,
   SubtitleTranscriber,
 } from "./types";
 import { cn } from "@/shared/ui/utils/cn";
+
+export const DEFAULT_SUBTITLE_POSTPROCESS_TIMEOUT_MS = 60_000;
 
 export type SubtitlePanelProps = {
   recordingId: string | null;
@@ -29,6 +32,7 @@ export type SubtitlePanelProps = {
   transcriber?: SubtitleTranscriber;
   postProcessor?: SubtitlePostProcessor | null;
   postProcessorContext?: SubtitlePostProcessorContext;
+  postProcessTimeoutMs?: number;
 };
 
 type GenerationStatus = "idle" | "loading" | "generating" | "post-processing" | "ready" | "error";
@@ -44,6 +48,7 @@ export function SubtitlePanel({
   transcriber: injectedTranscriber,
   postProcessor: injectedPostProcessor,
   postProcessorContext,
+  postProcessTimeoutMs = DEFAULT_SUBTITLE_POSTPROCESS_TIMEOUT_MS,
 }: SubtitlePanelProps) {
   const store = useMemo(() => injectedStore ?? createSubtitleStore(), [injectedStore]);
   const transcriber = useMemo(
@@ -55,6 +60,7 @@ export function SubtitlePanel({
       injectedPostProcessor === undefined
         ? createWorkerBackedHuggingFaceSubtitlePostProcessor({
             model: resolveSubtitlePostProcessorModel(),
+            onMetric: logSubtitlePostProcessorMetric,
           })
         : injectedPostProcessor,
     [injectedPostProcessor],
@@ -212,11 +218,17 @@ export function SubtitlePanel({
     setError(null);
     setWarnings([]);
     try {
-      const correction = await postProcessor.process({
-        track,
-        context: postProcessorContext,
-        signal: abortController.signal,
-      });
+      const correction = await runWithPostProcessTimeout(
+        postProcessor.process({
+          track,
+          context: postProcessorContext,
+          signal: abortController.signal,
+        }),
+        {
+          abortController,
+          timeoutMs: postProcessTimeoutMs,
+        },
+      );
       if (!isCurrentGeneration(requestVersionRef, requestVersion, abortController)) return;
       const result = applySubtitleCorrection(track, correction, { durationMs });
       const hasInvalidCorrection = result.warnings.some((warning) => warning.code === "invalid-correction");
@@ -232,6 +244,11 @@ export function SubtitlePanel({
       setWarnings(result.warnings);
       setStatus("ready");
     } catch (err) {
+      if (isPostProcessTimeoutError(err)) {
+        setError(formatSubtitleError(err));
+        setStatus("error");
+        return;
+      }
       if (abortController.signal.aborted || requestVersionRef.current !== requestVersion) return;
       setError(formatSubtitleError(err));
       setStatus("error");
@@ -379,4 +396,64 @@ function formatSubtitleTime(ms: number): string {
 
 function formatSubtitleError(error: unknown): string {
   return error instanceof Error ? error.message : "字幕生成失败";
+}
+
+class PostProcessTimeoutError extends Error {
+  constructor(readonly timeoutMs: number) {
+    super(`字幕纠错超时（${formatTimeoutBudget(timeoutMs)}），已保留当前字幕和章节。`);
+    this.name = "PostProcessTimeoutError";
+  }
+}
+
+function runWithPostProcessTimeout<T>(
+  operation: Promise<T>,
+  {
+    abortController,
+    timeoutMs,
+  }: {
+    abortController: AbortController;
+    timeoutMs: number;
+  },
+): Promise<T> {
+  if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) return operation;
+  let timeoutId: ReturnType<typeof setTimeout> | null = null;
+  let didTimeout = false;
+  const guardedOperation = operation.catch((error) => {
+    if (didTimeout) throw new PostProcessTimeoutError(timeoutMs);
+    throw error;
+  });
+  const timeout = new Promise<never>((_, reject) => {
+    timeoutId = setTimeout(() => {
+      didTimeout = true;
+      abortController.abort();
+      reject(new PostProcessTimeoutError(timeoutMs));
+    }, timeoutMs);
+  });
+  return Promise.race([guardedOperation, timeout]).finally(() => {
+    if (timeoutId !== null) clearTimeout(timeoutId);
+  });
+}
+
+function isPostProcessTimeoutError(error: unknown): error is PostProcessTimeoutError {
+  return error instanceof Error && error.name === "PostProcessTimeoutError";
+}
+
+function formatTimeoutBudget(timeoutMs: number): string {
+  if (timeoutMs < 1_000) return `${Math.round(timeoutMs)}ms`;
+  return `${Math.round(timeoutMs / 1_000)} 秒`;
+}
+
+function logSubtitlePostProcessorMetric(metric: SubtitlePostProcessorMetric): void {
+  console.debug("[code-tape] subtitle postprocessor metric", {
+    phase: metric.phase,
+    status: metric.status,
+    model: metric.model,
+    workerLoadDurationMs: roundMetricDuration(metric.workerLoadDurationMs),
+    workerRequestDurationMs: roundMetricDuration(metric.workerRequestDurationMs),
+    totalDurationMs: roundMetricDuration(metric.totalDurationMs),
+  });
+}
+
+function roundMetricDuration(durationMs: number): number {
+  return Math.round(Math.max(0, durationMs) * 1_000) / 1_000;
 }

--- a/apps/web/src/features/subtitles/__tests__/SubtitlePanel.test.tsx
+++ b/apps/web/src/features/subtitles/__tests__/SubtitlePanel.test.tsx
@@ -466,6 +466,84 @@ describe("SubtitlePanel", () => {
     expect(screen.getByRole("button", { name: "纠错并生成章节" })).not.toBeDisabled();
   });
 
+  it("ignores stale local LLM timeout after switching recordings", async () => {
+    const firstTrack: SubtitleTrack = {
+      recordingId: "recording-1",
+      generatedAt: "2026-05-28T00:00:00.000Z",
+      model: "onnx-community/whisper-tiny",
+      source: "huggingface-local",
+      segments: [{ id: "subtitle-1", startMs: 0, endMs: 1_000, text: "old recording subtitle" }],
+    };
+    const secondTrack: SubtitleTrack = {
+      recordingId: "recording-2",
+      generatedAt: "2026-05-28T00:00:01.000Z",
+      model: "onnx-community/whisper-tiny",
+      source: "huggingface-local",
+      segments: [{ id: "subtitle-2", startMs: 0, endMs: 1_000, text: "current recording subtitle" }],
+    };
+    const store = createMemorySubtitleStore();
+    await store.saveWithChapters(firstTrack, [{ id: "chapter-1", title: "旧章节", startMs: 0, endMs: 1_000 }]);
+    await store.saveWithChapters(secondTrack, [
+      { id: "chapter-2", title: "当前章节", startMs: 0, endMs: 1_000 },
+    ]);
+    let processSignal: AbortSignal | undefined;
+    const postProcessor: SubtitlePostProcessor = {
+      process: vi.fn(
+        ({ signal }) =>
+          new Promise<SubtitleCorrectionResult>(() => {
+            processSignal = signal;
+          }),
+      ),
+    };
+    const props = {
+      mediaBlob: new Blob(["webm"], { type: "video/webm" }),
+      hasAudio: true,
+      durationMs: 1_000,
+      currentTimeMs: 0,
+      onSeek: vi.fn(),
+      store,
+      transcriber: {
+        transcribe: vi.fn(async () => ({
+          model: "onnx-community/whisper-tiny",
+          source: "huggingface-local" as const,
+          segments: [],
+        })),
+      },
+      postProcessor,
+      postProcessTimeoutMs: 25,
+    };
+
+    const { rerender } = render(<SubtitlePanel recordingId="recording-1" {...props} />);
+
+    await waitFor(() => expect(screen.getByText("old recording subtitle")).toBeInTheDocument());
+
+    vi.useFakeTimers();
+    try {
+      fireEvent.click(screen.getByRole("button", { name: "纠错并生成章节" }));
+      await act(async () => {
+        await flushPromises();
+      });
+
+      rerender(<SubtitlePanel recordingId="recording-2" {...props} />);
+      await act(async () => {
+        await flushPromises();
+      });
+      expect(screen.getByText("current recording subtitle")).toBeInTheDocument();
+
+      await act(async () => {
+        vi.advanceTimersByTime(25);
+        await flushPromises();
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+
+    expect(processSignal?.aborted).toBe(true);
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+    expect(screen.getByText("current recording subtitle")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /当前章节/ })).toBeInTheDocument();
+  });
+
   it("surfaces generation failure without blocking replay controls", async () => {
     const transcriber: SubtitleTranscriber = {
       transcribe: vi.fn(async () => {

--- a/apps/web/src/features/subtitles/__tests__/SubtitlePanel.test.tsx
+++ b/apps/web/src/features/subtitles/__tests__/SubtitlePanel.test.tsx
@@ -1,8 +1,9 @@
 import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { SubtitlePanel } from "../SubtitlePanel";
 import type {
   SubtitleChapter,
+  SubtitleCorrectionResult,
   SubtitlePostProcessor,
   SubtitleStore,
   SubtitleTrack,
@@ -54,6 +55,10 @@ async function flushPromises() {
 }
 
 describe("SubtitlePanel", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it("generates subtitles from the media blob, highlights the active segment, and seeks on click", async () => {
     const store = createMemorySubtitleStore();
     const transcriber: SubtitleTranscriber = {
@@ -374,6 +379,91 @@ describe("SubtitlePanel", () => {
     expect(screen.getByRole("button", { name: /已有章节/ })).toBeInTheDocument();
     await expect(store.load("recording-1")).resolves.toEqual(originalTrack);
     await expect(store.loadChapters("recording-1")).resolves.toEqual(existingChapters);
+  });
+
+  it("times out stalled local LLM post-processing without clearing subtitles or chapters", async () => {
+    const originalTrack: SubtitleTrack = {
+      recordingId: "recording-1",
+      generatedAt: "2026-05-28T00:00:00.000Z",
+      model: "onnx-community/whisper-tiny",
+      source: "huggingface-local",
+      segments: [
+        { id: "subtitle-1", startMs: 0, endMs: 1_000, text: "use state hook" },
+        { id: "subtitle-2", startMs: 1_000, endMs: 3_000, text: "render result" },
+      ],
+    };
+    const existingChapters: SubtitleChapter[] = [
+      { id: "chapter-1", title: "已有章节", startMs: 0, endMs: 3_000 },
+    ];
+    const store = createMemorySubtitleStore();
+    await store.saveWithChapters(originalTrack, existingChapters);
+    const onSeek = vi.fn();
+    let processSignal: AbortSignal | undefined;
+    const postProcessor: SubtitlePostProcessor = {
+      process: vi.fn(
+        ({ signal }) =>
+          new Promise<SubtitleCorrectionResult>((_, reject) => {
+            processSignal = signal;
+            signal?.addEventListener(
+              "abort",
+              () => reject(new DOMException("字幕纠错已取消", "AbortError")),
+              { once: true },
+            );
+          }),
+      ),
+    };
+
+    render(
+      <SubtitlePanel
+        recordingId="recording-1"
+        mediaBlob={new Blob(["webm"], { type: "video/webm" })}
+        hasAudio
+        durationMs={3_000}
+        currentTimeMs={500}
+        onSeek={onSeek}
+        store={store}
+        transcriber={{
+          transcribe: vi.fn(async () => ({
+            model: "onnx-community/whisper-tiny",
+            source: "huggingface-local" as const,
+            segments: [],
+          })),
+        }}
+        postProcessor={postProcessor}
+        postProcessTimeoutMs={25}
+      />,
+    );
+
+    await waitFor(() => expect(screen.getByRole("button", { name: /已有章节/ })).toBeInTheDocument());
+
+    vi.useFakeTimers();
+    try {
+      fireEvent.click(screen.getByRole("button", { name: "纠错并生成章节" }));
+      await act(async () => {
+        await flushPromises();
+      });
+      expect(postProcessor.process).toHaveBeenCalledTimes(1);
+
+      fireEvent.click(screen.getByRole("button", { name: "render result" }));
+      fireEvent.click(screen.getByRole("button", { name: /已有章节/ }));
+
+      await act(async () => {
+        vi.advanceTimersByTime(25);
+        await flushPromises();
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+
+    await waitFor(() => expect(screen.getByRole("alert")).toHaveTextContent("字幕纠错超时"));
+    expect(processSignal?.aborted).toBe(true);
+    expect(screen.getByText("use state hook")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /已有章节/ })).toBeInTheDocument();
+    expect(onSeek).toHaveBeenCalledWith(1_000);
+    expect(onSeek).toHaveBeenCalledWith(0);
+    await expect(store.load("recording-1")).resolves.toEqual(originalTrack);
+    await expect(store.loadChapters("recording-1")).resolves.toEqual(existingChapters);
+    expect(screen.getByRole("button", { name: "纠错并生成章节" })).not.toBeDisabled();
   });
 
   it("surfaces generation failure without blocking replay controls", async () => {

--- a/apps/web/src/features/subtitles/__tests__/subtitlePostProcessorRuntimeBenchmark.test.tsx
+++ b/apps/web/src/features/subtitles/__tests__/subtitlePostProcessorRuntimeBenchmark.test.tsx
@@ -1,6 +1,9 @@
 import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
-import { SubtitlePanel } from "../SubtitlePanel";
+import {
+  DEFAULT_SUBTITLE_POSTPROCESS_TIMEOUT_MS,
+  SubtitlePanel,
+} from "../SubtitlePanel";
 import type {
   SubtitleChapter,
   SubtitlePostProcessor,
@@ -150,6 +153,7 @@ describe("subtitle postprocessor runtime benchmark", () => {
       mockWorkerInferenceDurationMs: roundDuration(processResolvedAt - processCalledAt),
       resultToUiCommitDurationMs: roundDuration(resultReadyAt - processResolvedAt),
       postprocessClickToResultReadyDurationMs: roundDuration(resultReadyAt - clickStartedAt),
+      postProcessTimeoutBudgetMs: DEFAULT_SUBTITLE_POSTPROCESS_TIMEOUT_MS,
       playbackProbeResponsiveDuringPostprocess,
     };
 
@@ -162,6 +166,7 @@ describe("subtitle postprocessor runtime benchmark", () => {
     expect(metrics.clickToPostProcessorCallDurationMs).toBeGreaterThanOrEqual(0);
     expect(metrics.mockWorkerInferenceDurationMs).toBeGreaterThanOrEqual(0);
     expect(metrics.resultToUiCommitDurationMs).toBeGreaterThanOrEqual(0);
+    expect(metrics.postProcessTimeoutBudgetMs).toBe(60_000);
     expect(metrics.playbackProbeResponsiveDuringPostprocess).toBe(true);
     expect(screen.getByRole("button", { name: /代码实现/ })).toBeInTheDocument();
   });

--- a/apps/web/src/features/subtitles/__tests__/subtitlePostProcessorWorkerClient.test.ts
+++ b/apps/web/src/features/subtitles/__tests__/subtitlePostProcessorWorkerClient.test.ts
@@ -47,10 +47,12 @@ function createMockWorker() {
 describe("createWorkerBackedHuggingFaceSubtitlePostProcessor", () => {
   it("runs subtitle post-processing through a browser worker", async () => {
     const worker = createMockWorker();
+    const onMetric = vi.fn();
     const workerFactory = vi.fn(() => worker as unknown as Worker);
     const postProcessor = createWorkerBackedHuggingFaceSubtitlePostProcessor({
       model: "ceilf6/test-subtitle-model",
       workerFactory,
+      onMetric,
     });
     const context = { fileName: "Counter.tsx", glossary: ["useState"] };
     const result: SubtitleCorrectionResult = {
@@ -72,15 +74,33 @@ describe("createWorkerBackedHuggingFaceSubtitlePostProcessor", () => {
       }),
     );
 
-    worker.dispatch({ id: request.id, type: "success", result });
+    worker.dispatch({
+      id: request.id,
+      type: "success",
+      result,
+      metrics: { workerRequestDurationMs: 12.345 },
+    });
 
     await expect(promise).resolves.toEqual(result);
+    expect(onMetric).toHaveBeenCalledWith(
+      expect.objectContaining({
+        model: "ceilf6/test-subtitle-model",
+        phase: "process",
+        status: "success",
+        workerLoadDurationMs: expect.any(Number),
+        workerRequestDurationMs: 12.345,
+        totalDurationMs: expect.any(Number),
+      }),
+    );
+    expect(JSON.stringify(onMetric.mock.calls[0]?.[0])).not.toContain("use state hook");
   });
 
   it("terminates in-flight worker inference when the request is aborted", async () => {
     const worker = createMockWorker();
+    const onMetric = vi.fn();
     const postProcessor = createWorkerBackedHuggingFaceSubtitlePostProcessor({
       workerFactory: () => worker as unknown as Worker,
+      onMetric,
     });
     const abortController = new AbortController();
 
@@ -94,6 +114,15 @@ describe("createWorkerBackedHuggingFaceSubtitlePostProcessor", () => {
 
     await expect(promise).rejects.toMatchObject({ name: "AbortError" });
     expect(worker.terminate).toHaveBeenCalledTimes(1);
+    expect(onMetric).toHaveBeenCalledWith(
+      expect.objectContaining({
+        phase: "process",
+        status: "aborted",
+        workerLoadDurationMs: expect.any(Number),
+        workerRequestDurationMs: expect.any(Number),
+        totalDurationMs: expect.any(Number),
+      }),
+    );
   });
 
   it("treats abort as an exclusive worker reset and succeeds on the next request", async () => {

--- a/apps/web/src/features/subtitles/__tests__/subtitlePostProcessorWorkerClient.test.ts
+++ b/apps/web/src/features/subtitles/__tests__/subtitlePostProcessorWorkerClient.test.ts
@@ -95,6 +95,33 @@ describe("createWorkerBackedHuggingFaceSubtitlePostProcessor", () => {
     expect(JSON.stringify(onMetric.mock.calls[0]?.[0])).not.toContain("use state hook");
   });
 
+  it("emits an error metric when worker creation fails before posting a request", async () => {
+    const onMetric = vi.fn();
+    const workerFactory = vi.fn(() => {
+      throw new Error("worker bootstrap failed");
+    });
+    const postProcessor = createWorkerBackedHuggingFaceSubtitlePostProcessor({
+      model: "ceilf6/test-subtitle-model",
+      workerFactory,
+      onMetric,
+    });
+
+    await expect(postProcessor.process({ track: makeTrack() })).rejects.toThrow("worker bootstrap failed");
+
+    expect(workerFactory).toHaveBeenCalledTimes(1);
+    expect(onMetric).toHaveBeenCalledWith(
+      expect.objectContaining({
+        model: "ceilf6/test-subtitle-model",
+        phase: "process",
+        status: "error",
+        workerLoadDurationMs: expect.any(Number),
+        workerRequestDurationMs: 0,
+        totalDurationMs: expect.any(Number),
+      }),
+    );
+    expect(JSON.stringify(onMetric.mock.calls[0]?.[0])).not.toContain("use state hook");
+  });
+
   it("terminates in-flight worker inference when the request is aborted", async () => {
     const worker = createMockWorker();
     const onMetric = vi.fn();

--- a/apps/web/src/features/subtitles/subtitlePostProcessorWorker.ts
+++ b/apps/web/src/features/subtitles/subtitlePostProcessorWorker.ts
@@ -33,16 +33,22 @@ type WorkerResponse =
       id: string;
       type: "success";
       result?: SubtitleCorrectionResult;
+      metrics?: WorkerResponseMetrics;
     }
   | {
       id: string;
       type: "error";
       error: SerializedWorkerError;
+      metrics?: WorkerResponseMetrics;
     };
 
 type SerializedWorkerError = {
   name: string;
   message: string;
+};
+
+type WorkerResponseMetrics = {
+  workerRequestDurationMs: number;
 };
 
 const processorsByModel = new Map<string, SubtitlePostProcessor>();
@@ -61,11 +67,16 @@ async function handleRequest(request: WorkerRequest): Promise<void> {
 
   const abortController = new AbortController();
   abortControllersByRequest.set(request.id, abortController);
+  const requestStartedAt = performance.now();
   try {
     const postProcessor = getPostProcessor(request.model);
     if (request.type === "warmUp") {
       await postProcessor.warmUp?.();
-      postWorkerResponse({ id: request.id, type: "success" });
+      postWorkerResponse({
+        id: request.id,
+        type: "success",
+        metrics: buildWorkerMetrics(requestStartedAt),
+      });
       return;
     }
 
@@ -73,12 +84,18 @@ async function handleRequest(request: WorkerRequest): Promise<void> {
       ...request.input,
       signal: abortController.signal,
     });
-    postWorkerResponse({ id: request.id, type: "success", result });
+    postWorkerResponse({
+      id: request.id,
+      type: "success",
+      result,
+      metrics: buildWorkerMetrics(requestStartedAt),
+    });
   } catch (error) {
     postWorkerResponse({
       id: request.id,
       type: "error",
       error: serializeWorkerError(error),
+      metrics: buildWorkerMetrics(requestStartedAt),
     });
   } finally {
     abortControllersByRequest.delete(request.id);
@@ -95,6 +112,12 @@ function getPostProcessor(model: string): SubtitlePostProcessor {
 
 function postWorkerResponse(response: WorkerResponse): void {
   globalThis.postMessage(response);
+}
+
+function buildWorkerMetrics(requestStartedAt: number): WorkerResponseMetrics {
+  return {
+    workerRequestDurationMs: performance.now() - requestStartedAt,
+  };
 }
 
 function serializeWorkerError(error: unknown): SerializedWorkerError {

--- a/apps/web/src/features/subtitles/subtitlePostProcessorWorkerClient.ts
+++ b/apps/web/src/features/subtitles/subtitlePostProcessorWorkerClient.ts
@@ -3,6 +3,7 @@ import type {
   SubtitleCorrectionResult,
   SubtitlePostProcessor,
   SubtitlePostProcessorContext,
+  SubtitlePostProcessorMetric,
   SubtitleTrack,
 } from "./types";
 
@@ -42,11 +43,13 @@ type WorkerResponse =
       id: string;
       type: "success";
       result?: SubtitleCorrectionResult;
+      metrics?: WorkerResponseMetrics;
     }
   | {
       id: string;
       type: "error";
       error: SerializedWorkerError;
+      metrics?: WorkerResponseMetrics;
     };
 
 type SerializedWorkerError = {
@@ -54,14 +57,19 @@ type SerializedWorkerError = {
   message: string;
 };
 
+type WorkerResponseMetrics = {
+  workerRequestDurationMs: number;
+};
+
 type PendingRequest = {
-  resolve(result: SubtitleCorrectionResult | undefined): void;
-  reject(error: unknown): void;
+  resolve(result: SubtitleCorrectionResult | undefined, metrics?: WorkerResponseMetrics): void;
+  reject(error: unknown, metrics?: WorkerResponseMetrics): void;
 };
 
 export type WorkerBackedSubtitlePostProcessorOptions = {
   model?: string;
   workerFactory?: () => Worker;
+  onMetric?: (metric: SubtitlePostProcessorMetric) => void;
 };
 
 export function createWorkerBackedHuggingFaceSubtitlePostProcessor(
@@ -105,30 +113,49 @@ export function createWorkerBackedHuggingFaceSubtitlePostProcessor(
     signal?: AbortSignal,
   ): Promise<SubtitleCorrectionResult | undefined> => {
     if (signal?.aborted) throw createAbortError();
+    const startedAt = performance.now();
     const activeWorker = await ensureWorker();
+    const workerLoadDurationMs = performance.now() - startedAt;
     if (activeWorker !== worker) throw createAbortError();
     if (signal?.aborted) throw createAbortError();
     const id = `subtitle-postprocess-${nextRequestId}`;
     nextRequestId += 1;
     const message = { ...request, id, model } as WorkerRequest;
+    const requestPostedAt = performance.now();
     return new Promise((resolve, reject) => {
       const cleanup = () => {
         pendingRequests.delete(id);
         signal?.removeEventListener("abort", onAbort);
       };
+      const emitRequestMetric = (
+        status: SubtitlePostProcessorMetric["status"],
+        metrics?: WorkerResponseMetrics,
+      ) => {
+        emitMetric({
+          phase: request.type,
+          status,
+          model,
+          workerLoadDurationMs,
+          workerRequestDurationMs:
+            metrics?.workerRequestDurationMs ?? performance.now() - requestPostedAt,
+          totalDurationMs: performance.now() - startedAt,
+        });
+      };
       const onAbort = () => {
         const abortError = createAbortError();
-        cleanup();
-        reject(abortError);
+        const pending = pendingRequests.get(id);
+        pending?.reject(abortError);
         activeWorker.postMessage({ id, type: "abort" } satisfies WorkerRequest);
         terminateWorker(abortError);
       };
       pendingRequests.set(id, {
-        resolve(result) {
+        resolve(result, metrics) {
+          emitRequestMetric("success", metrics);
           cleanup();
           resolve(result);
         },
-        reject(error) {
+        reject(error, metrics) {
+          emitRequestMetric(isAbortError(error) ? "aborted" : "error", metrics);
           cleanup();
           reject(error);
         },
@@ -151,15 +178,23 @@ export function createWorkerBackedHuggingFaceSubtitlePostProcessor(
     workerPromise = null;
   };
 
+  const emitMetric = (metric: SubtitlePostProcessorMetric) => {
+    try {
+      options.onMetric?.(metric);
+    } catch {
+      // Metrics are diagnostic only; they must never break subtitle recovery.
+    }
+  };
+
   function handleWorkerMessage(event: MessageEvent<WorkerResponse>) {
     const response = event.data;
     const pending = pendingRequests.get(response.id);
     if (!pending) return;
     if (response.type === "success") {
-      pending.resolve(response.result);
+      pending.resolve(response.result, response.metrics);
       return;
     }
-    pending.reject(deserializeWorkerError(response.error));
+    pending.reject(deserializeWorkerError(response.error), response.metrics);
   }
 
   function handleWorkerError(event: Event | ErrorEvent) {
@@ -208,4 +243,10 @@ function deserializeWorkerError(error: SerializedWorkerError): Error {
 
 function createAbortError(): DOMException {
   return new DOMException("字幕纠错已取消", "AbortError");
+}
+
+function isAbortError(error: unknown): boolean {
+  return error instanceof DOMException
+    ? error.name === "AbortError"
+    : error instanceof Error && error.name === "AbortError";
 }

--- a/apps/web/src/features/subtitles/subtitlePostProcessorWorkerClient.ts
+++ b/apps/web/src/features/subtitles/subtitlePostProcessorWorkerClient.ts
@@ -114,10 +114,25 @@ export function createWorkerBackedHuggingFaceSubtitlePostProcessor(
   ): Promise<SubtitleCorrectionResult | undefined> => {
     if (signal?.aborted) throw createAbortError();
     const startedAt = performance.now();
-    const activeWorker = await ensureWorker();
-    const workerLoadDurationMs = performance.now() - startedAt;
-    if (activeWorker !== worker) throw createAbortError();
-    if (signal?.aborted) throw createAbortError();
+    let activeWorker: Worker;
+    let workerLoadDurationMs: number;
+    try {
+      activeWorker = await ensureWorker();
+      workerLoadDurationMs = performance.now() - startedAt;
+      if (activeWorker !== worker) throw createAbortError();
+      if (signal?.aborted) throw createAbortError();
+    } catch (error) {
+      const failedLoadDurationMs = performance.now() - startedAt;
+      emitMetric({
+        phase: request.type,
+        status: isAbortError(error) ? "aborted" : "error",
+        model,
+        workerLoadDurationMs: failedLoadDurationMs,
+        workerRequestDurationMs: 0,
+        totalDurationMs: failedLoadDurationMs,
+      });
+      throw error;
+    }
     const id = `subtitle-postprocess-${nextRequestId}`;
     nextRequestId += 1;
     const message = { ...request, id, model } as WorkerRequest;

--- a/apps/web/src/features/subtitles/types.ts
+++ b/apps/web/src/features/subtitles/types.ts
@@ -47,6 +47,15 @@ export type SubtitlePostProcessorInput = {
   signal?: AbortSignal;
 };
 
+export type SubtitlePostProcessorMetric = {
+  phase: "warmUp" | "process";
+  status: "success" | "error" | "aborted";
+  model: string;
+  workerLoadDurationMs: number;
+  workerRequestDurationMs: number;
+  totalDurationMs: number;
+};
+
 export type SubtitlePostProcessor = {
   warmUp?(): Promise<void>;
   process(input: SubtitlePostProcessorInput): Promise<SubtitleCorrectionResult>;

--- a/docs/技术方案.md
+++ b/docs/技术方案.md
@@ -3092,7 +3092,7 @@ export type SubtitleCorrectionResult = {
 - 这些耗时字段可作为后续 prompt、模型或 fallback 变更的可重复本地性能基线，但不能替代浏览器点击“纠错并生成章节”后的真实端到端等待时间。
 - PR 涉及 AI 字幕后处理时，需要在描述或自检中记录一次该命令输出摘要，包括 `representativeOutputSource`、代表性样例通过率、JSON/segment/章节指标、`overallEvaluationDurationMs` 以及输出校验耗时，作为 repo-guard、Codex 和人工审查的共同质量基线；真实模型下载、初始化、推理和 worker 通信耗时需要用单独的 runtime benchmark 记录。
 - `npm run subtitle:postprocess:runtime-benchmark` 覆盖浏览器侧 React/jsdom 点击路径：预置已有字幕轨，注入可控 mock postProcessor，点击“纠错并生成章节”，记录模型/worker 预热、点击到 worker 调用、mock 推理等待、结果提交到 UI 和点击到结果可用的耗时。
-- runtime benchmark 输出 `postprocessClickToResultReadyDurationMs`、`modelWorkerWarmUpDurationMs`、`clickToPostProcessorCallDurationMs`、`mockWorkerInferenceDurationMs`、`resultToUiCommitDurationMs` 和 `playbackProbeResponsiveDuringPostprocess`。其中 `playbackProbeResponsiveDuringPostprocess=true` 表示 LLM 后处理 pending 时字幕行和已有章节仍能触发 seek，不阻塞播放操作。
+- runtime benchmark 输出 `postprocessClickToResultReadyDurationMs`、`postProcessTimeoutBudgetMs`、`modelWorkerWarmUpDurationMs`、`clickToPostProcessorCallDurationMs`、`mockWorkerInferenceDurationMs`、`resultToUiCommitDurationMs` 和 `playbackProbeResponsiveDuringPostprocess`。其中 `postProcessTimeoutBudgetMs` 是点击“纠错并生成章节”后允许本地 LLM worker 返回的默认超时预算；`playbackProbeResponsiveDuringPostprocess=true` 表示 LLM 后处理 pending 时字幕行和已有章节仍能触发 seek，不阻塞播放操作。
 - 该 runtime benchmark 不下载真实 Hugging Face 模型，也不调用外部 API；它用于稳定覆盖 UI 点击链路、worker/推理等待的时间分段和播放不阻塞契约。真实模型冷启动、网络缓存、WASM 初始化和长字幕推理仍需要在后续模型变更 PR 中补充真实浏览器 smoke 或手工记录。
 
 浏览器本地 LLM 的运行约束：
@@ -3100,6 +3100,8 @@ export type SubtitleCorrectionResult = {
 - 推理发生在用户浏览器内，优先 WebGPU，缺失时回退 WASM/CPU；参数规模、量化类型、prompt 长度和输出 token 数以首次加载、内存占用和移动端可用性为硬约束。
 - 模型加载可以在回放页空闲时提前 warm-up，但只下载/初始化模型，不提前处理字幕内容；有音频媒体时可以预热本地 LLM，ASR 完成后用户触发“纠错并生成章节”才运行后处理。
 - LLM 生成阶段必须在浏览器 Web Worker 中运行；`SubtitlePanel` 只能更新后台处理状态和接收最终结果，字幕行、章节跳转和播放器进度条仍留在主线程响应用户操作。录制切换、用户取消或组件卸载时，主线程通过 `AbortController` 终止未完成 worker 请求，避免旧结果污染当前字幕。
+- 点击“纠错并生成章节”的后处理请求默认使用 60s 超时预算；超时后必须取消 worker 请求、保留当前字幕轨和已有合法章节、展示可恢复错误，并允许用户继续 seek 或再次重试。该预算偏保守，用于防止无限卡死，不作为真实模型性能达标阈值。
+- Worker-backed LLM client 应上报不含字幕正文、代码正文和运行输出正文的阶段耗时 metrics，至少包含 `phase`、`status`、`model`、`workerLoadDurationMs`、`workerRequestDurationMs` 和 `totalDurationMs`，用于定位 worker 创建、warm-up 和 process 阶段的性能瓶颈。
 - 本地小模型输出采用稀疏 `segments` 契约，因此动态 `max_new_tokens` 必须以章节和少量变更为预算，而不是按“每个字幕都完整重写”估算；长字幕轨也要把单次输出上限控制在浏览器可接受范围内。
 - 输出 schema 校验必须在应用层完成，不能相信模型自报格式正确。
 

--- a/scripts/tests/subtitle-finetune.test.mjs
+++ b/scripts/tests/subtitle-finetune.test.mjs
@@ -421,6 +421,7 @@ test('PR self-check asks for one correction and chapter generation evaluation re
   assert.match(template, /overallEvaluationDurationMs/u);
   assert.match(template, /输出校验耗时/u);
   assert.match(template, /postprocessClickToResultReadyDurationMs/u);
+  assert.match(template, /postProcessTimeoutBudgetMs/u);
   assert.match(template, /playbackProbeResponsiveDuringPostprocess/u);
   assert.equal(
     packageJson.scripts['subtitle:postprocess:runtime-benchmark'],
@@ -436,6 +437,8 @@ test('PR self-check asks for one correction and chapter generation evaluation re
   assert.match(technicalPlan, /postprocessor-runner/u);
   assert.match(technicalPlan, /representativeOutputSource/u);
   assert.match(technicalPlan, /postprocessClickToResultReadyDurationMs/u);
+  assert.match(technicalPlan, /postProcessTimeoutBudgetMs/u);
+  assert.match(technicalPlan, /workerLoadDurationMs/u);
   assert.match(technicalPlan, /playbackProbeResponsiveDuringPostprocess/u);
 });
 


### PR DESCRIPTION
## 关联

Closes #150
Refs #2（总控 issue，不在本 PR 中关闭）

## 改动点

- 为“纠错并生成章节”增加默认 60s 后处理超时，超时后取消 worker 请求、保留现有字幕和章节、展示可恢复错误并允许重试。
- 为 worker-backed subtitle postProcessor 增加不含字幕/代码正文的阶段耗时 metrics，覆盖 warmUp/process 的 load、request、total duration 与 success/error/aborted 状态。
- 补充真实 abort 竞态回归测试、worker client metrics 测试、runtime benchmark 的 timeout budget 输出，以及 PR 自检/技术方案/契约测试说明。

## 影响范围

- 影响 AI 字幕后处理点击链路、LLM worker client/worker 通信和 SubtitlePanel 的错误恢复状态。
- 不改 ASR 语言设置、不改模型选择、不引入云端 API；用户在 LLM pending 时仍可点击字幕行和章节跳转。

## GitNexus 影响分析摘要

- 风险等级: HIGH
- 关键骨架变更: 修改 SubtitlePanel 的 LLM 后处理超时兜底与指标记录，补充 worker client/worker telemetry，并更新 PR 模板、技术方案和对应契约测试。
- GitNexus 影响面: detect_changes --scope compare --base-ref origin/main 显示 9 files / 35 symbols / 8 affected flows，整体 high 来自 SubtitlePanel 与 contract 文档变更；impact createWorkerBackedHuggingFaceSubtitlePostProcessor 为 LOW，仅直接影响 SubtitlePanel 且无 affected processes；impact SubtitlePanel 为 LOW，上游仅 ReplayPage/Player。
- 验证结果: targeted subtitle tests 22 passed；subtitle:postprocess:evaluate representativeOutputSource=postprocessor-runner、representative rates 均为 1、overallEvaluationDurationMs=1.8541；runtime benchmark postprocessClickToResultReadyDurationMs=33.353, postProcessTimeoutBudgetMs=60000, playbackProbeResponsiveDuringPostprocess=true；quality:local passed after rebase，pre-push quality:local passed。

## 自检

- [x] 未修改 `docs/progress.json` 或 `docs/progress.md`
- [x] 已运行 `npm run quality:local`，或说明无法运行的原因
- [x] 涉及 AI 字幕时，已记录一次 `npm run subtitle:postprocess:evaluate` 的“纠错并生成章节”效果验证结果，包含 `representativeOutputSource`、`overallEvaluationDurationMs`，并区分输出校验耗时与真实端到端耗时
- [x] 涉及 AI 字幕点击链路、LLM worker、模型加载或性能时，已记录一次 `npm run subtitle:postprocess:runtime-benchmark` 结果，包含 `postprocessClickToResultReadyDurationMs`、`postProcessTimeoutBudgetMs` 和 `playbackProbeResponsiveDuringPostprocess`
- [x] 已说明改动点和影响范围
- [x] 如果改动关键骨架，已补充契约测试并填写 GitNexus 影响分析摘要
- [ ] 已等待 repo-guard、codex 和 Copilot 评论，并完成必要审查
