### PR TITLE
[P1] CloudPackageLoader 云端录制包加载

### DIFF
--- a/apps/web/src/features/player/__tests__/cloudPackageLoader.test.ts
+++ b/apps/web/src/features/player/__tests__/cloudPackageLoader.test.ts
@@ -144,6 +144,32 @@ describe("createCloudPackageLoader", () => {
     }
   });
 
+  it("keeps JSON playback available when a declared media asset cannot be downloaded", async () => {
+    const expectedMedia = new Blob(["media"], { type: "video/webm" });
+    const parts = await makePackageParts({ mediaBlob: expectedMedia });
+    const loader = createCloudPackageLoader({
+      repository: makeRepository({ ok: true, value: makeDescriptor({ indexesUrl: null }) }),
+      fetch: makeAssetFetch({
+        "https://assets.example.com/manifest.json": jsonResponse(parts.manifest),
+        "https://assets.example.com/meta.json": jsonResponse(parts.meta),
+        "https://assets.example.com/events.json": jsonResponse(parts.events),
+        "https://assets.example.com/snapshots.json": jsonResponse(parts.snapshots),
+        "https://assets.example.com/media.webm": new Response("missing media", {
+          status: 404,
+          statusText: "Not Found",
+        }),
+      }),
+    });
+
+    const result = await loader.load("rec-1");
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.mediaBlob).toBeNull();
+      expect(result.warnings).toContainEqual({ code: "media-missing", blobId: "cloud-media" });
+    }
+  });
+
   it("preserves checksum mismatch failures from the shared package verifier", async () => {
     const parts = await makePackageParts();
     const changedEvent = { ...parts.events[0], timestampMs: 999 };

--- a/apps/web/src/features/player/__tests__/cloudPackageLoader.test.ts
+++ b/apps/web/src/features/player/__tests__/cloudPackageLoader.test.ts
@@ -1,0 +1,324 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  sha256Blob,
+  type PackageLoadError,
+  type RecordingIndexes,
+  type RecordingPackageV1,
+} from "@/shared/recording-schema";
+import { canonicalStringify, sha256Hex } from "@/shared/util/hash";
+import type { CloudPlaybackDescriptor, CloudRecordingRepository } from "@/features/cloud/types";
+import { createCloudPackageLoader } from "../cloudPackageLoader";
+
+type DescriptorRepository = Pick<CloudRecordingRepository, "getPlaybackDescriptor">;
+
+describe("createCloudPackageLoader", () => {
+  it("loads a ready cloud recording into a PackageLoadResult", async () => {
+    const mediaBlob = new Blob(["media"], { type: "video/webm" });
+    const parts = await makePackageParts({ mediaBlob, includeIndexes: true });
+    const repository = makeRepository({ ok: true, value: makeDescriptor() });
+    const loader = createCloudPackageLoader({
+      repository,
+      fetch: makeAssetFetch({
+        "https://assets.example.com/manifest.json": jsonResponse(parts.manifest),
+        "https://assets.example.com/meta.json": jsonResponse(parts.meta),
+        "https://assets.example.com/events.json": jsonResponse(parts.events),
+        "https://assets.example.com/snapshots.json": jsonResponse(parts.snapshots),
+        "https://assets.example.com/indexes.json": jsonResponse(parts.indexes),
+        "https://assets.example.com/media.webm": await blobResponse(mediaBlob),
+      }),
+    });
+
+    const result = await loader.load("rec-1");
+
+    expect(repository.getPlaybackDescriptor).toHaveBeenCalledWith("rec-1");
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.package.meta.title).toBe("Cloud Demo");
+      expect(result.package.indexes).toEqual(parts.indexes);
+      expect(result.mediaBlob).not.toBeNull();
+      expect(await readBlobText(result.mediaBlob!)).toBe("media");
+      expect(result.warnings).toEqual([]);
+    }
+  });
+
+  it("returns a load error with cloud request context when descriptor lookup fails", async () => {
+    const loader = createCloudPackageLoader({
+      repository: makeRepository({
+        ok: false,
+        error: { code: "not-found", message: "recording not found", requestId: "req-1" },
+      }),
+      fetch: makeAssetFetch({}),
+    });
+
+    const result = await loader.load("missing-rec");
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expectInvalidManifestMessage(result.error, "not-found");
+      expectInvalidManifestMessage(result.error, "req-1");
+    }
+  });
+
+  it("fails when a required JSON asset download returns a non-2xx response", async () => {
+    const parts = await makePackageParts();
+    const loader = createCloudPackageLoader({
+      repository: makeRepository({ ok: true, value: makeDescriptor({ indexesUrl: null }) }),
+      fetch: makeAssetFetch({
+        "https://assets.example.com/manifest.json": new Response("nope", {
+          status: 500,
+          statusText: "Server Error",
+        }),
+        "https://assets.example.com/meta.json": jsonResponse(parts.meta),
+        "https://assets.example.com/events.json": jsonResponse(parts.events),
+        "https://assets.example.com/snapshots.json": jsonResponse(parts.snapshots),
+      }),
+    });
+
+    const result = await loader.load("rec-1");
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expectInvalidManifestMessage(result.error, "manifest");
+      expectInvalidManifestMessage(result.error, "500");
+    }
+  });
+
+  it("fails when a required JSON asset is malformed", async () => {
+    const parts = await makePackageParts();
+    const loader = createCloudPackageLoader({
+      repository: makeRepository({ ok: true, value: makeDescriptor({ indexesUrl: null }) }),
+      fetch: makeAssetFetch({
+        "https://assets.example.com/manifest.json": jsonResponse(parts.manifest),
+        "https://assets.example.com/meta.json": new Response("{", { status: 200 }),
+        "https://assets.example.com/events.json": jsonResponse(parts.events),
+        "https://assets.example.com/snapshots.json": jsonResponse(parts.snapshots),
+      }),
+    });
+
+    const result = await loader.load("rec-1");
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expectInvalidManifestMessage(result.error, "meta");
+      expectInvalidManifestMessage(result.error, "json parse failed");
+    }
+  });
+
+  it("loads successfully when indexesUrl is null", async () => {
+    const parts = await makePackageParts({ includeIndexes: false });
+    const loader = createCloudPackageLoader({
+      repository: makeRepository({ ok: true, value: makeDescriptor({ indexesUrl: null, mediaUrl: null }) }),
+      fetch: makeAssetFetch({
+        "https://assets.example.com/manifest.json": jsonResponse(parts.manifest),
+        "https://assets.example.com/meta.json": jsonResponse(parts.meta),
+        "https://assets.example.com/events.json": jsonResponse(parts.events),
+        "https://assets.example.com/snapshots.json": jsonResponse(parts.snapshots),
+      }),
+    });
+
+    const result = await loader.load("rec-1");
+
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.package.indexes).toBeUndefined();
+  });
+
+  it("keeps JSON playback available with a media-missing warning when mediaUrl is null", async () => {
+    const expectedMedia = new Blob(["media"], { type: "video/webm" });
+    const parts = await makePackageParts({ mediaBlob: expectedMedia });
+    const loader = createCloudPackageLoader({
+      repository: makeRepository({ ok: true, value: makeDescriptor({ indexesUrl: null, mediaUrl: null }) }),
+      fetch: makeAssetFetch({
+        "https://assets.example.com/manifest.json": jsonResponse(parts.manifest),
+        "https://assets.example.com/meta.json": jsonResponse(parts.meta),
+        "https://assets.example.com/events.json": jsonResponse(parts.events),
+        "https://assets.example.com/snapshots.json": jsonResponse(parts.snapshots),
+      }),
+    });
+
+    const result = await loader.load("rec-1");
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.mediaBlob).toBeNull();
+      expect(result.warnings).toContainEqual({ code: "media-missing", blobId: "cloud-media" });
+    }
+  });
+
+  it("preserves checksum mismatch failures from the shared package verifier", async () => {
+    const parts = await makePackageParts();
+    const changedEvent = { ...parts.events[0], timestampMs: 999 };
+    const loader = createCloudPackageLoader({
+      repository: makeRepository({ ok: true, value: makeDescriptor({ indexesUrl: null, mediaUrl: null }) }),
+      fetch: makeAssetFetch({
+        "https://assets.example.com/manifest.json": jsonResponse(parts.manifest),
+        "https://assets.example.com/meta.json": jsonResponse(parts.meta),
+        "https://assets.example.com/events.json": jsonResponse([changedEvent]),
+        "https://assets.example.com/snapshots.json": jsonResponse(parts.snapshots),
+      }),
+    });
+
+    const result = await loader.load("rec-1");
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toEqual({ code: "checksum-mismatch", target: "events" });
+  });
+});
+
+async function makePackageParts(input: { mediaBlob?: Blob; includeIndexes?: boolean } = {}) {
+  const events: RecordingPackageV1["events"] = [
+    {
+      id: "e-1",
+      seq: 1,
+      timestampMs: 100,
+      source: "editor",
+      track: "main",
+      type: "content-change",
+      payload: {
+        fileId: "main",
+        version: 1,
+        code: "console.log('cloud')",
+        contentHash: "hash-1",
+        language: "javascript",
+        changeReason: "input",
+        changeCount: 1,
+        flushedBy: "debounce",
+      },
+    },
+  ];
+  const snapshots: RecordingPackageV1["snapshots"] = [
+    {
+      id: "snap-1",
+      timestampMs: 0,
+      eventSeq: 1,
+      state: {
+        editor: {
+          code: "console.log('cloud')",
+          language: "javascript",
+          cursor: null,
+          selection: null,
+          scrollTop: 0,
+          scrollLeft: 0,
+          fontSize: 14,
+          theme: "dark",
+        },
+        pointer: null,
+        media: {
+          microphoneEnabled: Boolean(input.mediaBlob),
+          cameraEnabled: false,
+          cameraPosition: { x: 0, y: 0 },
+        },
+        runtime: {
+          status: "idle",
+          stdout: [],
+          stderr: [],
+          previewHtml: null,
+          errorMessage: null,
+        },
+      },
+    },
+  ];
+  const mediaSha256 = input.mediaBlob ? await sha256Blob(input.mediaBlob) : undefined;
+  const manifest: RecordingPackageV1["manifest"] = {
+    packageId: "pkg-cloud-1",
+    schemaVersion: "0.1.0",
+    status: "complete",
+    createdAt: "2026-05-29T00:00:00.000Z",
+    completedAt: "2026-05-29T00:01:00.000Z",
+    checksums: {
+      eventsSha256: await sha256Hex(canonicalStringify(events)),
+      snapshotsSha256: await sha256Hex(canonicalStringify(snapshots)),
+      ...(mediaSha256 ? { mediaSha256 } : {}),
+    },
+  };
+  const meta: RecordingPackageV1["meta"] = {
+    id: "rec-1",
+    title: "Cloud Demo",
+    createdAt: "2026-05-29T00:00:00.000Z",
+    durationMs: 1000,
+    appVersion: "0.0.0",
+    ownerId: null,
+    creatorInfo: null,
+    initialLanguage: "javascript",
+    initialFontSize: 14,
+    initialTheme: "dark",
+    mediaCapability: {
+      audio: input.mediaBlob ? "available" : "not-found",
+      camera: "not-found",
+      selectedAudioDeviceId: null,
+      selectedCameraDeviceId: null,
+    },
+  };
+  const indexes: RecordingIndexes | undefined = input.includeIndexes === false
+    ? undefined
+    : {
+        generatedAt: "2026-05-29T00:01:00.000Z",
+        eventsByType: { "content-change": [1] } as RecordingIndexes["eventsByType"],
+        snapshotSeqsByTime: [1],
+        markers: [],
+      };
+  return { manifest, meta, events, snapshots, indexes };
+}
+
+function makeDescriptor(overrides: Partial<CloudPlaybackDescriptor> = {}): CloudPlaybackDescriptor {
+  return {
+    id: "rec-1",
+    title: "Cloud Demo",
+    durationMs: 1000,
+    schemaVersion: "0.1.0",
+    manifestUrl: "https://assets.example.com/manifest.json",
+    metaUrl: "https://assets.example.com/meta.json",
+    eventsUrl: "https://assets.example.com/events.json",
+    snapshotsUrl: "https://assets.example.com/snapshots.json",
+    indexesUrl: "https://assets.example.com/indexes.json",
+    mediaUrl: "https://assets.example.com/media.webm",
+    thumbnailUrl: null,
+    expiresAt: "2026-05-29T00:10:00.000Z",
+    ...overrides,
+  };
+}
+
+function makeRepository(
+  result: Awaited<ReturnType<DescriptorRepository["getPlaybackDescriptor"]>>,
+): DescriptorRepository {
+  return {
+    getPlaybackDescriptor: vi.fn().mockResolvedValue(result),
+  };
+}
+
+function makeAssetFetch(responses: Record<string, Response>): typeof fetch {
+  return vi.fn(async (input: RequestInfo | URL) => {
+    const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+    const response = responses[url];
+    if (!response) return new Response("missing test response", { status: 404, statusText: "Not Found" });
+    return response;
+  }) as typeof fetch;
+}
+
+function jsonResponse(value: unknown): Response {
+  return new Response(canonicalStringify(value), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function expectInvalidManifestMessage(error: PackageLoadError, text: string): void {
+  expect(error.code).toBe("invalid-manifest");
+  if (error.code !== "invalid-manifest") throw new Error("expected invalid-manifest");
+  expect(error.message).toContain(text);
+}
+
+async function blobResponse(blob: Blob): Promise<Response> {
+  return new Response(await blob.arrayBuffer(), {
+    status: 200,
+    headers: { "content-type": blob.type },
+  });
+}
+
+function readBlobText(blob: Blob): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(String(reader.result));
+    reader.onerror = () => reject(reader.error ?? new Error("failed to read blob"));
+    reader.readAsText(blob);
+  });
+}

--- a/apps/web/src/features/player/cloudPackageLoader.ts
+++ b/apps/web/src/features/player/cloudPackageLoader.ts
@@ -1,0 +1,149 @@
+import {
+  verifyRecordingPackageIntegrity,
+  type PackageLoadError,
+  type PackageLoadResult,
+  type RecordingEvent,
+  type RecordingIndexes,
+  type RecordingManifest,
+  type RecordingMedia,
+  type RecordingMeta,
+  type RecordingPackageV1,
+  type RecordingSnapshot,
+} from "@/shared/recording-schema";
+import type {
+  CloudApiError,
+  CloudPlaybackDescriptor,
+  CloudRecordingRepository,
+} from "@/features/cloud/types";
+
+export type CloudPackageLoaderOptions = {
+  repository: Pick<CloudRecordingRepository, "getPlaybackDescriptor">;
+  fetch?: typeof fetch;
+};
+
+export type CloudPackageLoader = {
+  load(recordingId: string): Promise<PackageLoadResult>;
+};
+
+export function createCloudPackageLoader(
+  options: CloudPackageLoaderOptions,
+): CloudPackageLoader {
+  const fetchImpl = options.fetch ?? globalThis.fetch?.bind(globalThis);
+
+  return {
+    async load(recordingId: string): Promise<PackageLoadResult> {
+      if (!fetchImpl) {
+        return toInvalidManifest("cloud package fetch is unavailable");
+      }
+
+      const descriptor = await options.repository.getPlaybackDescriptor(recordingId);
+      if (!descriptor.ok) {
+        return { ok: false, error: cloudErrorToLoadError(descriptor.error) };
+      }
+
+      return loadFromDescriptor(descriptor.value, fetchImpl);
+    },
+  };
+}
+
+async function loadFromDescriptor(
+  descriptor: CloudPlaybackDescriptor,
+  fetchImpl: typeof fetch,
+): Promise<PackageLoadResult> {
+  try {
+    const [manifest, meta, events, snapshots, indexes] = await Promise.all([
+      loadJsonAsset<RecordingManifest>(fetchImpl, "manifest", descriptor.manifestUrl),
+      loadJsonAsset<RecordingMeta>(fetchImpl, "meta", descriptor.metaUrl),
+      loadJsonAsset<RecordingEvent[]>(fetchImpl, "events", descriptor.eventsUrl),
+      loadJsonAsset<RecordingSnapshot[]>(fetchImpl, "snapshots", descriptor.snapshotsUrl),
+      descriptor.indexesUrl
+        ? loadJsonAsset<RecordingIndexes>(fetchImpl, "indexes", descriptor.indexesUrl)
+        : Promise.resolve(undefined),
+    ]);
+    const mediaBlob = await loadOptionalMedia(fetchImpl, descriptor.mediaUrl);
+    const media = buildCloudMedia({ descriptor, manifest, meta, mediaBlob });
+    const pkg: RecordingPackageV1 = {
+      schemaVersion: descriptor.schemaVersion,
+      manifest,
+      meta,
+      events,
+      snapshots,
+      media,
+      indexes,
+    };
+    return verifyRecordingPackageIntegrity(pkg, mediaBlob);
+  } catch (error) {
+    return toInvalidManifest(formatError(error));
+  }
+}
+
+async function loadJsonAsset<T>(
+  fetchImpl: typeof fetch,
+  label: string,
+  url: string,
+): Promise<T> {
+  const response = await fetchImpl(url);
+  if (!response.ok) {
+    throw new Error(`${label} download failed: ${response.status} ${response.statusText}`);
+  }
+  try {
+    return JSON.parse(await response.text()) as T;
+  } catch (error) {
+    throw new Error(`${label} json parse failed: ${formatError(error)}`);
+  }
+}
+
+async function loadOptionalMedia(
+  fetchImpl: typeof fetch,
+  url: string | null,
+): Promise<Blob | null> {
+  if (!url) return null;
+  try {
+    const response = await fetchImpl(url);
+    if (!response.ok) return null;
+    const contentType = response.headers.get("content-type") ?? "application/octet-stream";
+    return new Blob([await response.arrayBuffer()], { type: contentType });
+  } catch {
+    return null;
+  }
+}
+
+function buildCloudMedia(input: {
+  descriptor: CloudPlaybackDescriptor;
+  manifest: RecordingManifest;
+  meta: RecordingMeta;
+  mediaBlob: Blob | null;
+}): RecordingMedia | null {
+  const shouldDeclareMedia =
+    Boolean(input.mediaBlob) ||
+    Boolean(input.descriptor.mediaUrl) ||
+    Boolean(input.manifest.checksums.mediaSha256);
+  if (!shouldDeclareMedia) return null;
+  return {
+    blobId: "cloud-media",
+    mimeType: input.mediaBlob?.type || "video/webm",
+    durationMs: input.meta.durationMs,
+    sizeBytes: input.mediaBlob?.size ?? 0,
+    timelineOffsetMs: 0,
+    hasAudio: input.meta.mediaCapability.audio === "available",
+    hasCamera: input.meta.mediaCapability.camera === "available",
+  };
+}
+
+function cloudErrorToLoadError(error: CloudApiError): PackageLoadError {
+  const request = error.requestId ? ` requestId=${error.requestId}` : "";
+  return {
+    code: "invalid-manifest",
+    message: `playback descriptor failed: ${error.code}: ${error.message}${request}`,
+  };
+}
+
+function toInvalidManifest(message: string): PackageLoadResult {
+  return { ok: false, error: { code: "invalid-manifest", message } };
+}
+
+function formatError(error: unknown): string {
+  if (error instanceof Error) return error.message || error.name;
+  if (typeof error === "string") return error;
+  return "unknown error";
+}

--- a/apps/web/src/features/player/index.ts
+++ b/apps/web/src/features/player/index.ts
@@ -19,3 +19,8 @@ export {
   type TickListener,
 } from "./replayScheduler";
 export { createPackageLoader, type PackageLoaderOptions } from "./packageLoader";
+export {
+  createCloudPackageLoader,
+  type CloudPackageLoader,
+  type CloudPackageLoaderOptions,
+} from "./cloudPackageLoader";


### PR DESCRIPTION
## 关联

Closes #147
Refs #92

## 改动点

- 新增 `createCloudPackageLoader(recordingId)`，通过 `CloudRecordingRepository.getPlaybackDescriptor()` 拉取云端 playback descriptor。
- 下载并解析 manifest/meta/events/snapshots，按需加载 indexes/media，并复用 `verifyRecordingPackageIntegrity()` 返回统一 `PackageLoadResult`。
- 覆盖 descriptor 失败、必需 JSON 下载失败/畸形、缺 indexes、缺 media warning、checksum mismatch 等验收场景。

## 影响范围

- 影响前端 player 包加载能力与 player barrel export。
- 不改 UI、路由、上传流程、后端接口、对象存储、分享链路或进度文档。

## GitNexus 影响分析摘要

- 风险等级: 低。
- 关键骨架变更: 否；仅新增 cloud loader，并从 player index 导出。
- GitNexus 影响面: `npm run quality:predev` / commit hook / `quality:local` 均运行本地 GitNexus contract，结果为 contract passed；当前 diff 未触发 critical contract surface 阻断。
- 验证结果: focused loader test、precommit hook、`npm run quality:local` 均通过。

## 自检

- [x] 未修改 `docs/progress.json` 或 `docs/progress.md`
- [x] 已运行 `npm run quality:local`，或说明无法运行的原因
- [x] 涉及 AI 字幕时，已记录一次 `npm run subtitle:postprocess:evaluate` 的“纠错并生成章节”效果验证结果，包含 `representativeOutputSource`、`overallEvaluationDurationMs`，并区分输出校验耗时与真实端到端耗时（不涉及）
- [x] 涉及 AI 字幕点击链路、LLM worker、模型加载或性能时，已记录一次 `npm run subtitle:postprocess:runtime-benchmark` 结果，包含 `postprocessClickToResultReadyDurationMs` 和 `playbackProbeResponsiveDuringPostprocess`（不涉及）
- [x] 已说明改动点和影响范围
- [x] 如果改动关键骨架，已补充契约测试并填写 GitNexus 影响分析摘要（不涉及关键骨架）
- [ ] 已等待 repo-guard、codex 和 Copilot 评论，并完成必要审查
