### PR TITLE
[P1] AI 字幕长轨分块后处理

### DIFF
--- a/apps/web/src/features/subtitles/__tests__/subtitlePostProcessor.test.ts
+++ b/apps/web/src/features/subtitles/__tests__/subtitlePostProcessor.test.ts
@@ -73,6 +73,27 @@ function readUserPayloadFromMessages(messages: unknown): {
   };
 }
 
+function readPostProcessorPayload(messages: unknown): {
+  inputSegments: Array<{ id: string; text: string }>;
+  timeline: Array<{ startMs: number; endMs: number }>;
+} {
+  if (!Array.isArray(messages)) throw new Error("messages must be an array");
+  const userMessage = messages.find(
+    (message): message is { role: string; content: string } =>
+      typeof message === "object" &&
+      message !== null &&
+      "role" in message &&
+      "content" in message &&
+      message.role === "user" &&
+      typeof message.content === "string",
+  );
+  if (!userMessage) throw new Error("missing user message");
+  return JSON.parse(userMessage.content) as {
+    inputSegments: Array<{ id: string; text: string }>;
+    timeline: Array<{ startMs: number; endMs: number }>;
+  };
+}
+
 describe("createHuggingFaceSubtitlePostProcessor", () => {
   beforeEach(() => {
     transformersMock.env.useBrowserCache = true;
@@ -734,14 +755,129 @@ describe("createHuggingFaceSubtitlePostProcessor", () => {
     expect(result.segments).toHaveLength(100);
   });
 
-  it("rejects oversized subtitle tracks before loading the local LLM", async () => {
-    const pipelineFactory = vi.fn();
+  it("chunks oversized subtitle tracks before calling the local LLM", async () => {
+    const track = makeTrackWithSegments(121);
+    const pipeline = vi.fn(async (messages: unknown) => {
+      const payload = readPostProcessorPayload(messages);
+      const firstSegment = payload.inputSegments[0];
+      const firstTimeline = payload.timeline[0];
+      const lastTimeline = payload.timeline.at(-1);
+      if (!firstSegment || !firstTimeline || !lastTimeline) throw new Error("empty chunk");
+      return [
+        {
+          generated_text: JSON.stringify({
+            segments: [{ id: firstSegment.id, text: `${firstSegment.text} corrected` }],
+            chapters: [
+              {
+                title: `分块 ${pipeline.mock.calls.length}`,
+                startMs: firstTimeline.startMs,
+                endMs: lastTimeline.endMs,
+              },
+            ],
+          }),
+        },
+      ];
+    });
+    const pipelineFactory = vi.fn(async () => pipeline);
     const postProcessor = createHuggingFaceSubtitlePostProcessor({ pipelineFactory });
 
-    await expect(postProcessor.process({ track: makeTrackWithSegments(121) })).rejects.toThrow(
-      /字幕段过多/,
-    );
-    expect(pipelineFactory).not.toHaveBeenCalled();
+    await expect(postProcessor.process({ track })).resolves.toEqual({
+      segments: [
+        { id: "subtitle-1", text: "segment 1 corrected" },
+        { id: "subtitle-61", text: "segment 61 corrected" },
+        { id: "subtitle-121", text: "segment 121 corrected" },
+      ],
+      chapters: [
+        { title: "分块 1", startMs: 0, endMs: 60_000 },
+        { title: "分块 2", startMs: 60_000, endMs: 120_000 },
+        { title: "分块 3", startMs: 120_000, endMs: 121_000 },
+      ],
+    });
+    expect(pipelineFactory).toHaveBeenCalledTimes(1);
+    expect(pipeline).toHaveBeenCalledTimes(3);
+    for (const call of pipeline.mock.calls) {
+      const payload = readPostProcessorPayload(call[0]);
+      expect(payload.inputSegments.length).toBeLessThanOrEqual(60);
+    }
+  });
+
+  it("drops out-of-window and repeated corrections while chunking oversized tracks", async () => {
+    const track = makeTrackWithSegments(121);
+    const debug = vi.spyOn(console, "debug").mockImplementation(() => {});
+    const pipeline = vi.fn(async (messages: unknown) => {
+      const payload = readPostProcessorPayload(messages);
+      const firstSegment = payload.inputSegments[0];
+      const firstTimeline = payload.timeline[0];
+      const lastTimeline = payload.timeline.at(-1);
+      if (!firstSegment || !firstTimeline || !lastTimeline) throw new Error("empty chunk");
+      return [
+        {
+          generated_text: JSON.stringify({
+            segments: [
+              { id: firstSegment.id, text: `${firstSegment.text} corrected` },
+              { id: firstSegment.id, text: `${firstSegment.text} duplicate` },
+              { id: "subtitle-999", text: "invented segment" },
+            ],
+            chapters: [
+              { title: "越界章节", startMs: lastTimeline.endMs + 10_000, endMs: lastTimeline.endMs + 12_000 },
+              { title: "有效章节", startMs: firstTimeline.startMs, endMs: lastTimeline.endMs },
+            ],
+          }),
+        },
+      ];
+    });
+    const postProcessor = createHuggingFaceSubtitlePostProcessor({
+      pipelineFactory: vi.fn(async () => pipeline),
+    });
+
+    try {
+      await expect(postProcessor.process({ track })).resolves.toEqual({
+        segments: [
+          { id: "subtitle-1", text: "segment 1 corrected" },
+          { id: "subtitle-61", text: "segment 61 corrected" },
+          { id: "subtitle-121", text: "segment 121 corrected" },
+        ],
+        chapters: [
+          { title: "有效章节", startMs: 0, endMs: 60_000 },
+          { title: "有效章节", startMs: 60_000, endMs: 120_000 },
+          { title: "有效章节", startMs: 120_000, endMs: 121_000 },
+        ],
+      });
+      expect(debug).toHaveBeenCalledWith(
+        "[code-tape] dropped subtitle correction",
+        expect.objectContaining({ reason: "duplicate-segment" }),
+      );
+      expect(debug).toHaveBeenCalledWith(
+        "[code-tape] dropped subtitle correction",
+        expect.objectContaining({ reason: "unknown-segment", segmentId: "subtitle-999" }),
+      );
+    } finally {
+      debug.mockRestore();
+    }
+  });
+
+  it("stops chunked local LLM processing after aborting between oversized track windows", async () => {
+    const abortController = new AbortController();
+    const pipeline = vi.fn(async () => {
+      abortController.abort();
+      return [
+        {
+          generated_text:
+            '{"segments":[{"id":"subtitle-1","text":"segment 1 corrected"}],"chapters":[{"title":"第一段","startMs":0,"endMs":60000}]}',
+        },
+      ];
+    });
+    const postProcessor = createHuggingFaceSubtitlePostProcessor({
+      pipelineFactory: vi.fn(async () => pipeline),
+    });
+
+    await expect(
+      postProcessor.process({
+        track: makeTrackWithSegments(121),
+        signal: abortController.signal,
+      }),
+    ).rejects.toThrow(/字幕纠错已取消/);
+    expect(pipeline).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/apps/web/src/features/subtitles/__tests__/subtitlePostProcessor.test.ts
+++ b/apps/web/src/features/subtitles/__tests__/subtitlePostProcessor.test.ts
@@ -856,6 +856,54 @@ describe("createHuggingFaceSubtitlePostProcessor", () => {
     }
   });
 
+  it("keeps merged chunk chapters ordered and scoped to each subtitle window", async () => {
+    const track = makeTrackWithSegments(121);
+    const pipeline = vi.fn(async (messages: unknown) => {
+      const payload = readPostProcessorPayload(messages);
+      const firstTimeline = payload.timeline[0];
+      const lastTimeline = payload.timeline.at(-1);
+      if (!firstTimeline || !lastTimeline) throw new Error("empty chunk");
+      const callIndex = pipeline.mock.calls.length;
+      const chapters =
+        callIndex === 2
+          ? [
+              { title: "重复片段", startMs: 0, endMs: 10_000 },
+              { title: "窗口前污染", startMs: 50_000, endMs: 55_000 },
+              { title: "第二段", startMs: firstTimeline.startMs, endMs: lastTimeline.endMs },
+            ]
+          : [
+              {
+                title: `靠后 ${callIndex}`,
+                startMs: firstTimeline.startMs + 30_000,
+                endMs: Math.min(firstTimeline.startMs + 45_000, lastTimeline.endMs),
+              },
+              { title: `靠前 ${callIndex}`, startMs: firstTimeline.startMs, endMs: firstTimeline.startMs + 10_000 },
+            ];
+      return [
+        {
+          generated_text: JSON.stringify({
+            segments: [],
+            chapters,
+          }),
+        },
+      ];
+    });
+    const postProcessor = createHuggingFaceSubtitlePostProcessor({
+      pipelineFactory: vi.fn(async () => pipeline),
+    });
+
+    await expect(postProcessor.process({ track })).resolves.toEqual({
+      segments: [],
+      chapters: [
+        { title: "靠前 1", startMs: 0, endMs: 10_000 },
+        { title: "靠后 1", startMs: 30_000, endMs: 45_000 },
+        { title: "第二段", startMs: 60_000, endMs: 120_000 },
+        { title: "靠前 3", startMs: 120_000, endMs: 121_000 },
+      ],
+    });
+    expect(pipeline).toHaveBeenCalledTimes(3);
+  });
+
   it("stops chunked local LLM processing after aborting between oversized track windows", async () => {
     const abortController = new AbortController();
     const pipeline = vi.fn(async () => {

--- a/apps/web/src/features/subtitles/subtitlePostProcessor.ts
+++ b/apps/web/src/features/subtitles/subtitlePostProcessor.ts
@@ -11,6 +11,7 @@ const MAX_PROMPT_CODE_CHARS = 6_000;
 const MAX_PROMPT_RUNTIME_OUTPUT_CHARS = 2_000;
 const BASE_MAX_NEW_TOKENS = 128;
 const MAX_POSTPROCESSOR_SEGMENTS = 120;
+const POSTPROCESSOR_CHUNK_SEGMENTS = 60;
 const MAX_DYNAMIC_NEW_TOKENS = 768;
 const NEW_TOKENS_PER_SEGMENT = 5;
 const CHAPTER_OUTPUT_TOKEN_RESERVE = 96;
@@ -97,51 +98,111 @@ export function createHuggingFaceSubtitlePostProcessor(
     },
     async process(input) {
       if (input.signal?.aborted) throw new DOMException("字幕纠错已取消", "AbortError");
-      const maxNewTokens = estimateMaxNewTokens(input.track);
       const pipeline = await getPipeline();
       if (input.signal?.aborted) throw new DOMException("字幕纠错已取消", "AbortError");
-      const output = await pipeline(buildSubtitlePostProcessorMessages(input), {
-        max_new_tokens: maxNewTokens,
-        do_sample: false,
-        repetition_penalty: 1.05,
-        return_full_text: false,
-        ...buildChatTemplateOption(model),
-      });
-      if (input.signal?.aborted) throw new DOMException("字幕纠错已取消", "AbortError");
-      const generatedText = readGeneratedText(output);
-      try {
-        return constrainCorrectionToTrack(
-          extractSubtitleCorrectionResult(generatedText),
-          input.track,
-        );
-      } catch (error) {
-        if (!isRecoverableJsonOutputError(error)) throw error;
-        const recovered = recoverSubtitleCorrectionResult(generatedText, input.track);
-        if (recovered) return recovered;
-      }
-      if (input.signal?.aborted) throw new DOMException("字幕纠错已取消", "AbortError");
-      const retryOutput = await pipeline(buildSubtitlePostProcessorMessages(input, { previousOutput: generatedText }), {
-        max_new_tokens: maxNewTokens,
-        do_sample: false,
-        repetition_penalty: 1.05,
-        return_full_text: false,
-        ...buildChatTemplateOption(model),
-      });
-      if (input.signal?.aborted) throw new DOMException("字幕纠错已取消", "AbortError");
-      const retryGeneratedText = readGeneratedText(retryOutput);
-      try {
-        return constrainCorrectionToTrack(
-          extractSubtitleCorrectionResult(retryGeneratedText),
-          input.track,
-        );
-      } catch (error) {
-        if (!isRecoverableJsonOutputError(error)) throw error;
-        const recovered = recoverSubtitleCorrectionResult(retryGeneratedText, input.track);
-        if (recovered) return recovered;
-        throw error;
-      }
+      return processSubtitleTrack({ input, model, pipeline });
     },
   };
+}
+
+async function processSubtitleTrack({
+  input,
+  model,
+  pipeline,
+}: {
+  input: {
+    track: SubtitleTrack;
+    context?: SubtitlePostProcessorContext;
+    signal?: AbortSignal;
+  };
+  model: string;
+  pipeline: TextGenerationPipeline;
+}): Promise<SubtitleCorrectionResult> {
+  if (input.track.segments.length <= MAX_POSTPROCESSOR_SEGMENTS) {
+    return processSubtitleTrackChunk({ input, model, pipeline });
+  }
+
+  const chunks = chunkSubtitleTrack(input.track, POSTPROCESSOR_CHUNK_SEGMENTS);
+  const merged: SubtitleCorrectionResult = { segments: [], chapters: [] };
+  for (const chunk of chunks) {
+    if (input.signal?.aborted) throw new DOMException("字幕纠错已取消", "AbortError");
+    const result = await processSubtitleTrackChunk({
+      input: { ...input, track: chunk },
+      model,
+      pipeline,
+    });
+    merged.segments.push(...result.segments);
+    merged.chapters?.push(...(result.chapters ?? []));
+  }
+  if (input.signal?.aborted) throw new DOMException("字幕纠错已取消", "AbortError");
+  return constrainCorrectionToTrack(merged, input.track);
+}
+
+async function processSubtitleTrackChunk({
+  input,
+  model,
+  pipeline,
+}: {
+  input: {
+    track: SubtitleTrack;
+    context?: SubtitlePostProcessorContext;
+    signal?: AbortSignal;
+  };
+  model: string;
+  pipeline: TextGenerationPipeline;
+}): Promise<SubtitleCorrectionResult> {
+  const maxNewTokens = estimateMaxNewTokens(input.track);
+  const output = await pipeline(buildSubtitlePostProcessorMessages(input), {
+    max_new_tokens: maxNewTokens,
+    do_sample: false,
+    repetition_penalty: 1.05,
+    return_full_text: false,
+    ...buildChatTemplateOption(model),
+  });
+  if (input.signal?.aborted) throw new DOMException("字幕纠错已取消", "AbortError");
+  const generatedText = readGeneratedText(output);
+  try {
+    return constrainCorrectionToTrack(
+      extractSubtitleCorrectionResult(generatedText),
+      input.track,
+    );
+  } catch (error) {
+    if (!isRecoverableJsonOutputError(error)) throw error;
+    const recovered = recoverSubtitleCorrectionResult(generatedText, input.track);
+    if (recovered) return recovered;
+  }
+  if (input.signal?.aborted) throw new DOMException("字幕纠错已取消", "AbortError");
+  const retryOutput = await pipeline(buildSubtitlePostProcessorMessages(input, { previousOutput: generatedText }), {
+    max_new_tokens: maxNewTokens,
+    do_sample: false,
+    repetition_penalty: 1.05,
+    return_full_text: false,
+    ...buildChatTemplateOption(model),
+  });
+  if (input.signal?.aborted) throw new DOMException("字幕纠错已取消", "AbortError");
+  const retryGeneratedText = readGeneratedText(retryOutput);
+  try {
+    return constrainCorrectionToTrack(
+      extractSubtitleCorrectionResult(retryGeneratedText),
+      input.track,
+    );
+  } catch (error) {
+    if (!isRecoverableJsonOutputError(error)) throw error;
+    const recovered = recoverSubtitleCorrectionResult(retryGeneratedText, input.track);
+    if (recovered) return recovered;
+    throw error;
+  }
+}
+
+function chunkSubtitleTrack(track: SubtitleTrack, maxSegments: number): SubtitleTrack[] {
+  const chunks: SubtitleTrack[] = [];
+  for (let index = 0; index < track.segments.length; index += maxSegments) {
+    chunks.push({
+      ...track,
+      segments: track.segments.slice(index, index + maxSegments),
+    });
+  }
+  return chunks;
 }
 
 async function loadPipelineWithFallback({

--- a/apps/web/src/features/subtitles/subtitlePostProcessor.ts
+++ b/apps/web/src/features/subtitles/subtitlePostProcessor.ts
@@ -448,12 +448,14 @@ function constrainCorrectionChaptersToTrack(
   chapters: NonNullable<SubtitleCorrectionResult["chapters"]>,
   track: SubtitleTrack,
 ): NonNullable<SubtitleCorrectionResult["chapters"]> {
+  const subtitleStartMs = Math.min(Number.POSITIVE_INFINITY, ...track.segments.map((segment) => segment.startMs));
   const subtitleEndMs = Math.max(0, ...track.segments.map((segment) => segment.endMs));
   const timelineState = {
     previousEndMs: Number.NEGATIVE_INFINITY,
     seenTimelines: new Set<string>(),
   };
   return chapters
+    .filter((chapter) => chapter.startMs >= subtitleStartMs)
     .filter((chapter) => chapter.startMs < subtitleEndMs)
     .filter((chapter) => !chapter.title.includes("\uFFFD"))
     .map((chapter) => ({

--- a/docs/技术方案.md
+++ b/docs/技术方案.md
@@ -3102,7 +3102,7 @@ export type SubtitleCorrectionResult = {
 - LLM 生成阶段必须在浏览器 Web Worker 中运行；`SubtitlePanel` 只能更新后台处理状态和接收最终结果，字幕行、章节跳转和播放器进度条仍留在主线程响应用户操作。录制切换、用户取消或组件卸载时，主线程通过 `AbortController` 终止未完成 worker 请求，避免旧结果污染当前字幕。
 - 点击“纠错并生成章节”的后处理请求默认使用 60s 超时预算；超时后必须取消 worker 请求、保留当前字幕轨和已有合法章节、展示可恢复错误，并允许用户继续 seek 或再次重试。该预算偏保守，用于防止无限卡死，不作为真实模型性能达标阈值。
 - Worker-backed LLM client 应上报不含字幕正文、代码正文和运行输出正文的阶段耗时 metrics，至少包含 `phase`、`status`、`model`、`workerLoadDurationMs`、`workerRequestDurationMs` 和 `totalDurationMs`，用于定位 worker 创建、warm-up 和 process 阶段的性能瓶颈。
-- 本地小模型输出采用稀疏 `segments` 契约，因此动态 `max_new_tokens` 必须以章节和少量变更为预算，而不是按“每个字幕都完整重写”估算；长字幕轨也要把单次输出上限控制在浏览器可接受范围内。
+- 本地小模型输出采用稀疏 `segments` 契约，因此动态 `max_new_tokens` 必须以章节和少量变更为预算，而不是按“每个字幕都完整重写”估算；长字幕轨要按时间连续的 segment 窗口分块后处理，每个窗口独立输出稀疏 corrections 和章节，应用层再合并并做全局 segment/章节校验，避免单次 prompt、输出 token 和 JSON 稳定性超出浏览器本地小模型可接受范围。
 - 输出 schema 校验必须在应用层完成，不能相信模型自报格式正确。
 
 LLM 输出必须经过 schema 校验和安全兜底：JSON 解析失败、缺失 `segments` 或 `chapters` 时，保留原始 ASR 字幕并记录 warning，不阻断播放；出现未知 segment id、重复 segment id、空文本或替换字符噪声时，应用层先丢弃对应非法稀疏 correction，保留同一 id 的首个合法修正和原始未返回字幕段。章节时间戳越界、章节重叠或章节不按时间排序时，可以丢弃非法章节或保留上一版合法章节，但不能污染字幕轨。模型省略未改变的 segment 属于性能优化路径，不视为非法。

--- a/scripts/tests/workflow-rules.test.mjs
+++ b/scripts/tests/workflow-rules.test.mjs
@@ -618,6 +618,8 @@ test('technical plan owns P1 plus AI subtitle architecture and HF token boundary
   assert.match(technicalPlan, /WASM `q8` ONNX 资产/u);
   assert.match(technicalPlan, /`q4f16` \/ `q4` 资产/u);
   assert.match(technicalPlan, /`segments` 是稀疏变更集/u);
+  assert.match(technicalPlan, /长字幕轨要按时间连续的 segment 窗口分块后处理/u);
+  assert.match(technicalPlan, /应用层再合并并做全局 segment\/章节校验/u);
   assert.match(technicalPlan, /前端领域术语、组件名、变量名、函数名/u);
   assert.match(technicalPlan, /章节跳转点/u);
   assert.match(technicalPlan, /点击章节调用现有播放器 `seek\(startMs\)`/u);


### PR DESCRIPTION
## 关联

Refs #2（总控 issue，不在本 PR 中关闭）
Closes #157

## 改动点

- 将本地 LLM 字幕后处理的长字幕轨从“超过 120 段直接拒绝”改为按时间连续 segment 窗口分块处理。
- 每个窗口复用现有稀疏 `segments` + `chapters` 输出契约，最终在应用层合并并执行全局 segment / 章节校验。
- 章节校验同时限制在当前窗口起止时间内，避免后续 chunk 生成窗口前章节后污染全局章节列表。
- 补充分块、越界/重复 correction 丢弃、跨窗口章节排序/去重/窗口作用域、分块间 abort 的回归测试，并把长轨分块约束沉淀到 `docs/技术方案.md` 与工作流契约测试。

## 影响范围

- 主要影响“纠错并生成章节”的长轨本地 LLM 后处理路径。
- 短字幕轨仍走原单次处理路径；worker 入口和 UI 交互契约不变。
- 长轨场景减少单次 prompt / 输出 token 压力，降低 JSON 失败和未知 segment 引用失败概率。

## GitNexus 影响分析摘要

- 风险等级: CRITICAL
- 关键骨架变更: 更新 docs/技术方案.md 的 P1+ AI 字幕运行约束，明确长字幕轨按时间连续 segment 窗口分块后处理；同步修改 subtitlePostProcessor 的长轨执行路径与契约测试。
- GitNexus 影响面: detect_changes --scope compare --base-ref origin/main --repo 当前 worktree 显示 3 files / 17 symbols / 16 affected processes，critical 来自权威技术方案文档和 subtitlePostProcessor 执行路径；impact createHuggingFaceSubtitlePostProcessor --depth 2 为 LOW，上游仅 subtitlePostProcessorWorker.getPostProcessor 和 handleRequest。
- 验证结果: subtitlePostProcessor targeted tests 38 passed；subtitle postprocessor worker/runtime targeted tests 44 passed；subtitle:postprocess:evaluate representativeOutputSource=postprocessor-runner，representative rates 均为 1，overallEvaluationDurationMs=1.6917；runtime benchmark postprocessClickToResultReadyDurationMs=32.572, postProcessTimeoutBudgetMs=60000, playbackProbeResponsiveDuringPostprocess=true；workflow-rules technical plan contract test passed；npm run quality:local 通过；GitHub Contract Guard、Workflow Tests、Repo Guard 均通过。

## 自检

- [x] 未修改 `docs/progress.json` 或 `docs/progress.md`
- [x] 已运行 `npm run quality:local`，或说明无法运行的原因
- [x] 涉及 AI 字幕时，已记录一次 `npm run subtitle:postprocess:evaluate` 的“纠错并生成章节”效果验证结果，包含 `representativeOutputSource`、`overallEvaluationDurationMs`，并区分输出校验耗时与真实端到端耗时
- [x] 涉及 AI 字幕点击链路、LLM worker、模型加载或性能时，已记录一次 `npm run subtitle:postprocess:runtime-benchmark` 结果，包含 `postprocessClickToResultReadyDurationMs`、`postProcessTimeoutBudgetMs` 和 `playbackProbeResponsiveDuringPostprocess`
- [x] 已说明改动点和影响范围
- [x] 如果改动关键骨架，已补充契约测试并填写 GitNexus 影响分析摘要
- [x] 已等待 repo-guard、codex 和 Copilot 评论，并完成必要审查
