### PR TITLE
[P1] 云端播放页接入

### DIFF
--- a/apps/web/src/app/__tests__/routes.test.tsx
+++ b/apps/web/src/app/__tests__/routes.test.tsx
@@ -1,0 +1,11 @@
+import { describe, expect, it } from "vitest";
+import { appRoutes } from "../routes";
+
+describe("appRoutes", () => {
+  it("registers cloud replay routes", () => {
+    const childPaths = appRoutes[0]?.children?.map((route) => route.path) ?? [];
+
+    expect(childPaths).toContain("replays/:id");
+    expect(childPaths).toContain("cloud/replay/:id");
+  });
+});

--- a/apps/web/src/app/routes.tsx
+++ b/apps/web/src/app/routes.tsx
@@ -17,6 +17,8 @@ export const appRoutes: RouteObject[] = [
       { path: "record", element: <RecorderPage /> },
       { path: "replay/:id", element: <ReplayPage /> },
       { path: "interview/candidate/:roomId?", element: <CandidateInterviewPage /> },
+      { path: "replays/:id", element: <ReplayPage source="cloud" /> },
+      { path: "cloud/replay/:id", element: <ReplayPage source="cloud" /> },
       { path: "interview/interviewer/:roomId", element: <RemoteInterviewWorkbenchPage /> },
       { path: "*", element: <NotFoundPage /> },
     ],

--- a/apps/web/src/features/player/ReplayPage.tsx
+++ b/apps/web/src/features/player/ReplayPage.tsx
@@ -8,7 +8,7 @@ import {
   type MutableRefObject,
   type SetStateAction,
 } from "react";
-import { Link, useParams } from "react-router-dom";
+import { Link, useParams, useSearchParams } from "react-router-dom";
 import { Camera, Captions, CircleAlert, Keyboard, MousePointer2, TerminalSquare } from "lucide-react";
 import { createReplayScheduler, defaultTickStrategy } from "./replayScheduler";
 import { createTimelineClock } from "./timelineClock";
@@ -18,16 +18,19 @@ import { CodeEditor } from "@/features/editor/CodeEditor";
 import { PreviewPane } from "@/features/runtime-preview/PreviewPane";
 import { createIframeRuntime } from "@/features/runtime-preview/iframeRuntime";
 import { createRecordingStore } from "@/features/library/recordingStore";
+import { createCloudRecordingRepository } from "@/features/cloud/cloudRecordingRepository";
 import { SubtitlePanel } from "@/features/subtitles";
 import { Toggle } from "@/shared/ui";
 import type {
   PackageWarning,
   MediaTimelineSegment,
+  PackageLoadResult,
   RecordingEvent,
   RecordingPackageV1,
   ReplaySchedulerState,
   ReplayStableState,
 } from "@/shared/recording-schema";
+import { createCloudPackageLoader } from "./cloudPackageLoader";
 
 const INITIAL_SCHEDULER_STATE: ReplaySchedulerState = {
   status: "loading",
@@ -85,6 +88,10 @@ const DEFAULT_DISPLAY_OPTIONS: ReplayDisplayOptions = {
   runtime: true,
   subtitles: true,
 };
+type ReplaySource = "local" | "cloud";
+type ReplayPackageLoader = {
+  load(recordingId: string): Promise<PackageLoadResult>;
+};
 
 function isEventOnlyMediaDegraded(
   pkg: RecordingPackageV1,
@@ -95,13 +102,31 @@ function isEventOnlyMediaDegraded(
   return warnings.some((warning) => warning.code === "media-missing");
 }
 
+function parseInitialSeekTimeMs(value: string | null): number | null {
+  if (!value) return null;
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed < 0) return null;
+  return Math.floor(parsed);
+}
+
 /**
  * ReplayPage — wires the replay core (scheduler + clock + repository + runtime)
  * and renders the playback layout.
  */
-export function ReplayPage() {
+export type ReplayPageProps = {
+  source?: ReplaySource;
+};
+
+export function ReplayPage({ source = "local" }: ReplayPageProps) {
   const { id } = useParams();
-  const repository = useMemo(() => createRecordingStore(), []);
+  const [searchParams] = useSearchParams();
+  const initialSeekTimeMs = parseInitialSeekTimeMs(searchParams.get("t"));
+  const packageLoader = useMemo<ReplayPackageLoader>(() => {
+    if (source === "cloud") {
+      return createCloudPackageLoader({ repository: createCloudRecordingRepository() });
+    }
+    return createRecordingStore();
+  }, [source]);
   const runtime = useMemo(() => createIframeRuntime(), []);
   const [schedulerState, setSchedulerState] =
     useState<ReplaySchedulerState>(INITIAL_SCHEDULER_STATE);
@@ -208,7 +233,7 @@ export function ReplayPage() {
     clearOverlayTimers();
     recordedMediaVideoRef.current?.pause();
     (async () => {
-      const result = await repository.load(id);
+      const result = await packageLoader.load(id);
       if (cancelled) return;
       if (!result.ok) {
         setLoadError(
@@ -227,11 +252,20 @@ export function ReplayPage() {
         isEventOnlyMediaDegraded(result.package, result.mediaBlob, result.warnings),
       );
       await scheduler.load(result.package);
+      if (cancelled) return;
+      if (initialSeekTimeMs !== null) await scheduler.seek(initialSeekTimeMs);
     })();
     return () => {
       cancelled = true;
     };
-  }, [clearOverlayTimers, createRecordedMediaAdapter, id, repository, scheduler]);
+  }, [
+    clearOverlayTimers,
+    createRecordedMediaAdapter,
+    id,
+    initialSeekTimeMs,
+    packageLoader,
+    scheduler,
+  ]);
 
   if (loadError) {
     return (

--- a/apps/web/src/features/player/__tests__/ReplayPage.cloudLoader.integration.test.tsx
+++ b/apps/web/src/features/player/__tests__/ReplayPage.cloudLoader.integration.test.tsx
@@ -1,0 +1,266 @@
+import { render, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { CodeEditorProps } from "@/features/editor/CodeEditor";
+import type { PreviewPaneProps } from "@/features/runtime-preview/PreviewPane";
+import type { SubtitlePanelProps } from "@/features/subtitles";
+import type { CloudPlaybackDescriptor } from "@/features/cloud/types";
+import type {
+  RecordingPackageV1,
+  ReplaySchedulerState,
+  ReplayStableState,
+} from "@/shared/recording-schema";
+import { canonicalStringify, sha256Hex } from "@/shared/util/hash";
+import type * as ReactRouterDom from "react-router-dom";
+
+const replayIntegrationMock = vi.hoisted(() => {
+  const schedulerState: ReplaySchedulerState = {
+    status: "ready",
+    timelineTimeMs: 0,
+    playbackRate: 1,
+    lastAppliedSeq: 0,
+    mediaStatus: "none",
+    driftMs: 0,
+  };
+  const scheduler = {
+    load: vi.fn(async () => {}),
+    play: vi.fn(),
+    pause: vi.fn(),
+    seek: vi.fn(async () => {}),
+    setRate: vi.fn(),
+    setVolume: vi.fn(),
+    setMuted: vi.fn(),
+    setMediaAdapter: vi.fn(),
+    destroy: vi.fn(),
+    subscribe: vi.fn((listener: (state: ReplaySchedulerState) => void) => {
+      listener(schedulerState);
+      return vi.fn();
+    }),
+  };
+  const descriptorRepository = {
+    getPlaybackDescriptor: vi.fn(),
+  };
+  const localRepository = {
+    load: vi.fn(),
+  };
+  return {
+    scheduler,
+    descriptorRepository,
+    localRepository,
+    routeId: "cloud-rec-1",
+    search: "",
+    reset() {
+      scheduler.load.mockClear();
+      scheduler.setMediaAdapter.mockClear();
+      scheduler.destroy.mockClear();
+      scheduler.subscribe.mockClear();
+      descriptorRepository.getPlaybackDescriptor.mockReset();
+      localRepository.load.mockReset();
+      this.routeId = "cloud-rec-1";
+      this.search = "";
+    },
+  };
+});
+
+vi.mock("react-router-dom", async () => {
+  const actual = await vi.importActual<typeof ReactRouterDom>("react-router-dom");
+  return {
+    ...actual,
+    useParams: () => ({ id: replayIntegrationMock.routeId }),
+    useSearchParams: () => [new URLSearchParams(replayIntegrationMock.search), vi.fn()],
+  };
+});
+
+vi.mock("@/features/editor/CodeEditor", () => ({
+  CodeEditor: (_props: CodeEditorProps) => <div aria-label="Mock code editor" />,
+}));
+
+vi.mock("@/features/runtime-preview/PreviewPane", () => ({
+  PreviewPane: (_props: PreviewPaneProps) => <div aria-label="Mock preview pane" />,
+}));
+
+vi.mock("@/features/subtitles", () => ({
+  SubtitlePanel: (_props: SubtitlePanelProps) => <div aria-label="Mock subtitle panel" />,
+}));
+
+vi.mock("@/features/runtime-preview/iframeRuntime", () => ({
+  createIframeRuntime: vi.fn(() => ({})),
+}));
+
+vi.mock("@/features/library/recordingStore", () => ({
+  createRecordingStore: vi.fn(() => replayIntegrationMock.localRepository),
+}));
+
+vi.mock("@/features/cloud/cloudRecordingRepository", () => ({
+  createCloudRecordingRepository: vi.fn(() => replayIntegrationMock.descriptorRepository),
+}));
+
+vi.mock("../replayScheduler", () => ({
+  createReplayScheduler: vi.fn((options: { onTick?: (state: ReplayStableState) => void }) => {
+    options.onTick?.({
+      editor: {
+        code: "",
+        language: "javascript",
+        cursor: null,
+        selection: null,
+        scrollTop: 0,
+        scrollLeft: 0,
+        fontSize: 14,
+        theme: "dark",
+      },
+      pointer: null,
+      media: { microphoneEnabled: false, cameraEnabled: false, cameraPosition: { x: 0, y: 0 } },
+      runtime: { status: "idle", stdout: [], stderr: [], previewHtml: null, errorMessage: null },
+    });
+    return replayIntegrationMock.scheduler;
+  }),
+  defaultTickStrategy: vi.fn(() => ({})),
+}));
+
+vi.mock("../ReplayControls", () => ({
+  ReplayControls: () => <div aria-label="Mock replay controls" />,
+}));
+
+describe("ReplayPage cloud package loader integration", () => {
+  beforeEach(() => {
+    replayIntegrationMock.reset();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("loads cloud recordings through the real CloudPackageLoader descriptor lookup", async () => {
+    const parts = await makePackageParts();
+    replayIntegrationMock.descriptorRepository.getPlaybackDescriptor.mockResolvedValue({
+      ok: true,
+      value: makeDescriptor(),
+    });
+    vi.stubGlobal("fetch", makeAssetFetch({
+      "https://assets.example.com/manifest.json": jsonResponse(parts.manifest),
+      "https://assets.example.com/meta.json": jsonResponse(parts.meta),
+      "https://assets.example.com/events.json": jsonResponse(parts.events),
+      "https://assets.example.com/snapshots.json": jsonResponse(parts.snapshots),
+    }));
+    const { ReplayPage } = await import("../ReplayPage");
+
+    render(<ReplayPage source="cloud" />);
+
+    await waitFor(() => {
+      expect(replayIntegrationMock.descriptorRepository.getPlaybackDescriptor).toHaveBeenCalledWith("cloud-rec-1");
+    });
+    await waitFor(() => {
+      expect(replayIntegrationMock.scheduler.load).toHaveBeenCalledWith(
+        expect.objectContaining({
+          meta: expect.objectContaining({ id: "cloud-rec-1" }),
+        }),
+      );
+    });
+    expect(replayIntegrationMock.localRepository.load).not.toHaveBeenCalled();
+  });
+});
+
+async function makePackageParts() {
+  const events: RecordingPackageV1["events"] = [
+    {
+      id: "event-1",
+      seq: 1,
+      timestampMs: 100,
+      source: "editor",
+      track: "main",
+      type: "content-change",
+      payload: {
+        fileId: "main",
+        version: 1,
+        code: "console.log('cloud replay');",
+        contentHash: "hash-1",
+        language: "javascript",
+        changeReason: "input",
+        changeCount: 1,
+        flushedBy: "debounce",
+      },
+    },
+  ];
+  const snapshots: RecordingPackageV1["snapshots"] = [
+    {
+      id: "snapshot-1",
+      timestampMs: 0,
+      eventSeq: 1,
+      state: {
+        editor: {
+          code: "console.log('cloud replay');",
+          language: "javascript",
+          cursor: null,
+          selection: null,
+          scrollTop: 0,
+          scrollLeft: 0,
+          fontSize: 14,
+          theme: "dark",
+        },
+        pointer: null,
+        media: { microphoneEnabled: false, cameraEnabled: false, cameraPosition: { x: 0, y: 0 } },
+        runtime: { status: "idle", stdout: [], stderr: [], previewHtml: null, errorMessage: null },
+      },
+    },
+  ];
+  const manifest: RecordingPackageV1["manifest"] = {
+    packageId: "cloud-rec-1",
+    schemaVersion: "0.1.0",
+    status: "complete",
+    createdAt: "2026-05-29T00:00:00.000Z",
+    completedAt: "2026-05-29T00:01:00.000Z",
+    checksums: {
+      eventsSha256: await sha256Hex(canonicalStringify(events)),
+      snapshotsSha256: await sha256Hex(canonicalStringify(snapshots)),
+    },
+  };
+  const meta: RecordingPackageV1["meta"] = {
+    id: "cloud-rec-1",
+    title: "Cloud Replay",
+    createdAt: "2026-05-29T00:00:00.000Z",
+    durationMs: 1_000,
+    appVersion: "0.0.0",
+    ownerId: null,
+    creatorInfo: null,
+    initialLanguage: "javascript",
+    initialFontSize: 14,
+    initialTheme: "dark",
+    mediaCapability: {
+      audio: "not-found",
+      camera: "not-found",
+      selectedAudioDeviceId: null,
+      selectedCameraDeviceId: null,
+    },
+  };
+  return { manifest, meta, events, snapshots };
+}
+
+function makeDescriptor(): CloudPlaybackDescriptor {
+  return {
+    id: "cloud-rec-1",
+    title: "Cloud Replay",
+    durationMs: 1_000,
+    schemaVersion: "0.1.0",
+    manifestUrl: "https://assets.example.com/manifest.json",
+    metaUrl: "https://assets.example.com/meta.json",
+    eventsUrl: "https://assets.example.com/events.json",
+    snapshotsUrl: "https://assets.example.com/snapshots.json",
+    indexesUrl: null,
+    mediaUrl: null,
+    thumbnailUrl: null,
+    expiresAt: "2026-05-29T00:10:00.000Z",
+  };
+}
+
+function makeAssetFetch(responses: Record<string, Response>): typeof fetch {
+  return vi.fn(async (input: RequestInfo | URL) => {
+    const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+    return responses[url] ?? new Response("missing test response", { status: 404, statusText: "Not Found" });
+  }) as typeof fetch;
+}
+
+function jsonResponse(value: unknown): Response {
+  return new Response(canonicalStringify(value), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
+}

--- a/apps/web/src/features/player/__tests__/ReplayPage.test.tsx
+++ b/apps/web/src/features/player/__tests__/ReplayPage.test.tsx
@@ -86,13 +86,31 @@ const replayPageMock = vi.hoisted(() => {
       warnings: [],
     })),
   };
+  const cloudRepository = {
+    getPlaybackDescriptor: vi.fn(),
+  };
+  const cloudLoader = {
+    load: vi.fn<RecordingRepository["load"]>(async () => ({
+      ok: true as const,
+      package: packageData,
+      mediaBlob: new Blob(["webm"], { type: "video/webm" }),
+      warnings: [],
+    })),
+  };
+  const createCloudRecordingRepository = vi.fn(() => cloudRepository);
+  const createCloudPackageLoader = vi.fn(() => cloudLoader);
 
   return {
     scheduler,
     schedulerState,
     repository,
+    cloudRepository,
+    cloudLoader,
+    createCloudRecordingRepository,
+    createCloudPackageLoader,
     packageData,
     routeId: "recording-1",
+    search: "",
     controlsProps: null as ReplayControlsProps | null,
     codeEditorProps: null as CodeEditorProps | null,
     previewPaneProps: null as PreviewPaneProps | null,
@@ -116,7 +134,12 @@ const replayPageMock = vi.hoisted(() => {
       schedulerState.mediaStatus = "none";
       schedulerState.driftMs = 0;
       repository.load.mockClear();
+      cloudRepository.getPlaybackDescriptor.mockClear();
+      cloudLoader.load.mockClear();
+      createCloudRecordingRepository.mockClear();
+      createCloudPackageLoader.mockClear();
       this.routeId = "recording-1";
+      this.search = "";
       this.controlsProps = null;
       this.codeEditorProps = null;
       this.previewPaneProps = null;
@@ -131,6 +154,7 @@ vi.mock("react-router-dom", async () => {
   return {
     ...actual,
     useParams: () => ({ id: replayPageMock.routeId }),
+    useSearchParams: () => [new URLSearchParams(replayPageMock.search), vi.fn()],
   };
 });
 
@@ -163,6 +187,14 @@ vi.mock("@/features/library/recordingStore", () => ({
   createRecordingStore: vi.fn(() => replayPageMock.repository),
 }));
 
+vi.mock("@/features/cloud/cloudRecordingRepository", () => ({
+  createCloudRecordingRepository: replayPageMock.createCloudRecordingRepository,
+}));
+
+vi.mock("../cloudPackageLoader", () => ({
+  createCloudPackageLoader: replayPageMock.createCloudPackageLoader,
+}));
+
 vi.mock("../replayScheduler", () => ({
   createReplayScheduler: vi.fn((options: { onTick?: (state: ReplayStableState, events?: RecordingEvent[], timelineTimeMs?: number) => void }) => {
     replayPageMock.onTick = options.onTick ?? null;
@@ -181,6 +213,73 @@ vi.mock("../ReplayControls", () => ({
 describe("ReplayPage", () => {
   beforeEach(() => {
     replayPageMock.reset();
+  });
+
+  it("loads cloud replays through the cloud package loader when source is cloud", async () => {
+    const { ReplayPage } = await import("../ReplayPage");
+
+    render(<ReplayPage source="cloud" />);
+
+    await waitFor(() => expect(replayPageMock.cloudLoader.load).toHaveBeenCalledWith("recording-1"));
+    expect(replayPageMock.createCloudRecordingRepository).toHaveBeenCalledTimes(1);
+    expect(replayPageMock.createCloudPackageLoader).toHaveBeenCalledWith({
+      repository: replayPageMock.cloudRepository,
+    });
+    expect(replayPageMock.repository.load).not.toHaveBeenCalled();
+    expect(replayPageMock.scheduler.load).toHaveBeenCalledWith(replayPageMock.packageData);
+  });
+
+  it("keeps local replays on IndexedDB by default", async () => {
+    const { ReplayPage } = await import("../ReplayPage");
+
+    render(<ReplayPage />);
+
+    await waitFor(() => expect(replayPageMock.repository.load).toHaveBeenCalledWith("recording-1"));
+    expect(replayPageMock.cloudLoader.load).not.toHaveBeenCalled();
+    expect(replayPageMock.createCloudRecordingRepository).not.toHaveBeenCalled();
+  });
+
+  it("shows the event-only notice for cloud replays with missing media", async () => {
+    replayPageMock.cloudLoader.load.mockResolvedValueOnce({
+      ok: true,
+      package: replayPageMock.packageData,
+      mediaBlob: null,
+      warnings: [{ code: "media-missing", blobId: "cloud-media" }],
+    });
+    const { ReplayPage } = await import("../ReplayPage");
+
+    render(<ReplayPage source="cloud" />);
+
+    await waitFor(() => expect(replayPageMock.scheduler.load).toHaveBeenCalledWith(replayPageMock.packageData));
+    expect(screen.getByText("音视频不可用，已切换为纯事件流回放")).toBeInTheDocument();
+  });
+
+  it("seeks to the cloud replay timestamp from the query string after loading", async () => {
+    replayPageMock.search = "?t=42000";
+    const { ReplayPage } = await import("../ReplayPage");
+
+    render(<ReplayPage source="cloud" />);
+
+    await waitFor(() => expect(replayPageMock.scheduler.load).toHaveBeenCalledWith(replayPageMock.packageData));
+    await waitFor(() => expect(replayPageMock.scheduler.seek).toHaveBeenCalledWith(42_000));
+  });
+
+  it("blocks cloud replay when the cloud loader fails", async () => {
+    replayPageMock.cloudLoader.load.mockResolvedValueOnce({
+      ok: false,
+      error: { code: "invalid-manifest", message: "descriptor failed" },
+    });
+    const { ReplayPage } = await import("../ReplayPage");
+    const { MemoryRouter } = await import("react-router-dom");
+
+    render(
+      <MemoryRouter future={{ v7_relativeSplatPath: true, v7_startTransition: true }}>
+        <ReplayPage source="cloud" />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => expect(screen.getByText(/加载失败：invalid-manifest/)).toBeInTheDocument());
+    expect(replayPageMock.scheduler.load).not.toHaveBeenCalled();
   });
 
   it("wires replay control callbacks to scheduler commands", async () => {


### PR DESCRIPTION
## Summary
- add documented `/replays/:id` cloud playback route and keep `/cloud/replay/:id` as the issue-scoped cloud route
- let `ReplayPage` select the cloud package loader when rendered from cloud routes
- honor `?t=<milliseconds>` replay URLs by calling `scheduler.seek(t)` after the package is loaded
- cover cloud/local loader selection, cloud event-only playback degradation, loader failure, route registration, real `CloudPackageLoader` descriptor lookup, and initial query seek

## Issue
Closes #158
Refs #92

## Review Follow-ups
- repo-guard: added `ReplayPage.cloudLoader.integration.test.tsx` to use the real `CloudPackageLoader` and assert `getPlaybackDescriptor(recordingId)` is called from cloud playback
- codex: added the documented `/replays/:id` cloud route from `docs/技术方案.md` while preserving `/cloud/replay/:id`
- codex: implemented `?t=` time-offset handling through the existing `ReplayScheduler.seek()` path after load

## GitNexus
- index status: up to date at commit `3952a91`
- `quality:local` contract check passed after GitNexus re-index
- note: direct `detect-changes --repo <worktree path>` currently fails on a stale GitNexus CLI registry list, while `status` and contract checks resolve the current worktree successfully

## Verification
- `npm run quality:predev`
- `npm run agent:bootstrap`
- `npm run test:web -- ReplayPage.cloudLoader.integration ReplayPage routes`
- `npm run quality:precommit`
- `npm run quality:local`
- pre-push hook (`npm run quality:local`) passed after the `?t=` seek fix
