### PR TITLE
fix: recover subtitle transformers chunk loading

### DIFF
--- a/apps/web/src/features/subtitles/__tests__/transformersLoader.test.ts
+++ b/apps/web/src/features/subtitles/__tests__/transformersLoader.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  configureQuietBrowserCache,
+  loadTransformersModule,
+  loadTransformersPipeline,
+  type TransformersEnvironment,
+  type TransformersModule,
+} from "../transformersLoader";
+
+describe("transformersLoader", () => {
+  it("retries transient dynamic import failures before loading Transformers.js", async () => {
+    const module = makeTransformersModule();
+    const importer = vi
+      .fn<() => Promise<TransformersModule>>()
+      .mockRejectedValueOnce(
+        new TypeError(
+          "Failed to fetch dynamically imported module: https://ceilf6.github.io/code-tape/assets/transformers.web-Ddnr203B.js",
+        ),
+      )
+      .mockResolvedValueOnce(module);
+    const onRetry = vi.fn();
+
+    await expect(loadTransformersModule({ importer, retryDelayMs: 0, onRetry })).resolves.toBe(
+      module,
+    );
+
+    expect(importer).toHaveBeenCalledTimes(2);
+    expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not retry non-network module errors", async () => {
+    const importer = vi
+      .fn<() => Promise<TransformersModule>>()
+      .mockRejectedValue(new SyntaxError("Unexpected token"));
+
+    await expect(loadTransformersModule({ importer, retryDelayMs: 0 })).rejects.toThrow(
+      "Unexpected token",
+    );
+
+    expect(importer).toHaveBeenCalledTimes(1);
+  });
+
+  it("loads a pipeline after a recovered import and applies the quiet browser cache", async () => {
+    const loadedPipeline = vi.fn();
+    const pipelineFactory = vi.fn(async () => loadedPipeline);
+    const module = makeTransformersModule({ pipeline: pipelineFactory });
+    const cache = {
+      match: vi.fn(async () => undefined),
+      put: vi.fn(async () => undefined),
+    };
+    const open = vi.fn(async () => cache);
+    vi.stubGlobal("caches", { open });
+
+    await expect(
+      loadTransformersPipeline<typeof loadedPipeline>(
+        "automatic-speech-recognition",
+        "onnx-community/whisper-tiny",
+        {
+          device: "wasm",
+          dtype: "fp32",
+        },
+        { importer: async () => module },
+      ),
+    ).resolves.toBe(loadedPipeline);
+
+    expect(pipelineFactory).toHaveBeenCalledWith(
+      "automatic-speech-recognition",
+      "onnx-community/whisper-tiny",
+      {
+        device: "wasm",
+        dtype: "fp32",
+      },
+    );
+    expect(module.env?.useCustomCache).toBe(true);
+  });
+
+  it("keeps inference available when CacheStorage writes reject", async () => {
+    const env: TransformersEnvironment = {
+      useBrowserCache: true,
+      useCustomCache: false,
+      customCache: null,
+      cacheKey: "transformers-cache",
+    };
+    const cache = {
+      match: vi.fn(async () => undefined),
+      put: vi.fn(async () => {
+        throw new DOMException("Unexpected internal error.", "UnknownError");
+      }),
+    };
+    const open = vi.fn(async () => cache);
+    vi.stubGlobal("caches", { open });
+
+    configureQuietBrowserCache(env);
+
+    await expect(
+      env.customCache?.put("model-cache-key", new Response("weights")),
+    ).resolves.toBeUndefined();
+    expect(open).toHaveBeenCalledWith("transformers-cache");
+  });
+});
+
+function makeTransformersModule(overrides: Partial<TransformersModule> = {}): TransformersModule {
+  const pipeline = overrides.pipeline ?? vi.fn(async () => vi.fn());
+  return {
+    env: {
+      useBrowserCache: true,
+      useCustomCache: false,
+      customCache: null,
+      cacheKey: "transformers-cache",
+    },
+    pipeline,
+    ...overrides,
+  };
+}

--- a/apps/web/src/features/subtitles/__tests__/transformersLoader.test.ts
+++ b/apps/web/src/features/subtitles/__tests__/transformersLoader.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   configureQuietBrowserCache,
   loadTransformersModule,
@@ -6,6 +6,11 @@ import {
   type TransformersEnvironment,
   type TransformersModule,
 } from "../transformersLoader";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
 
 describe("transformersLoader", () => {
   it("retries transient dynamic import failures before loading Transformers.js", async () => {
@@ -38,6 +43,19 @@ describe("transformersLoader", () => {
     );
 
     expect(importer).toHaveBeenCalledTimes(1);
+  });
+
+  it("stops retrying after the configured import attempts", async () => {
+    const error = new TypeError("Failed to fetch dynamically imported module");
+    const importer = vi.fn<() => Promise<TransformersModule>>().mockRejectedValue(error);
+    const onRetry = vi.fn();
+
+    await expect(
+      loadTransformersModule({ importer, attempts: 2, retryDelayMs: 0, onRetry }),
+    ).rejects.toBe(error);
+
+    expect(importer).toHaveBeenCalledTimes(2);
+    expect(onRetry).toHaveBeenCalledTimes(1);
   });
 
   it("loads a pipeline after a recovered import and applies the quiet browser cache", async () => {

--- a/apps/web/src/features/subtitles/subtitlePostProcessor.ts
+++ b/apps/web/src/features/subtitles/subtitlePostProcessor.ts
@@ -5,6 +5,7 @@ import type {
   SubtitleTrack,
 } from "./types";
 import { DEFAULT_POSTPROCESSOR_MODEL } from "./subtitlePostProcessorConfig";
+import { loadTransformersPipeline } from "./transformersLoader";
 
 export { DEFAULT_POSTPROCESSOR_MODEL } from "./subtitlePostProcessorConfig";
 const MAX_PROMPT_CODE_CHARS = 6_000;
@@ -50,19 +51,6 @@ type PipelineFactory = (
   model: string,
   options: TextGenerationPipelineOptions,
 ) => Promise<TextGenerationPipeline>;
-
-type TransformersEnvironment = {
-  useBrowserCache?: boolean;
-  useCustomCache?: boolean;
-  customCache?: QuietBrowserCache | null;
-  cacheKey?: string;
-};
-
-type QuietBrowserCache = {
-  __codeTapeQuietCache: true;
-  match(cacheKey: string): Promise<Response | undefined>;
-  put(cacheKey: string, response: Response): Promise<void>;
-};
 
 export type HuggingFaceSubtitlePostProcessorOptions = {
   model?: string;
@@ -664,38 +652,7 @@ async function loadDefaultPipeline(
   model: string,
   options: TextGenerationPipelineOptions,
 ): Promise<TextGenerationPipeline> {
-  const module = await import("@huggingface/transformers");
-  configureQuietBrowserCache(module.env as TransformersEnvironment | undefined);
-  const pipe = await module.pipeline(task, model, options);
-  return pipe as unknown as TextGenerationPipeline;
-}
-
-function configureQuietBrowserCache(env: TransformersEnvironment | undefined): void {
-  if (!env?.useBrowserCache || typeof globalThis.caches === "undefined") return;
-  if (env.useCustomCache && env.customCache) return;
-
-  const cacheKey = env.cacheKey ?? "transformers-cache";
-  env.useCustomCache = true;
-  env.customCache = {
-    __codeTapeQuietCache: true,
-    async match(resourceKey) {
-      try {
-        const cache = await globalThis.caches.open(cacheKey);
-        return (await cache.match(resourceKey)) ?? undefined;
-      } catch {
-        return undefined;
-      }
-    },
-    async put(resourceKey, response) {
-      try {
-        const cache = await globalThis.caches.open(cacheKey);
-        await cache.put(resourceKey, response.clone());
-      } catch {
-        // Cache API writes can fail for large model files or browser storage issues.
-        // Model loading has already succeeded, so keep inference available and avoid noisy warnings.
-      }
-    },
-  };
+  return loadTransformersPipeline<TextGenerationPipeline>(task, model, options);
 }
 
 function readGeneratedText(output: unknown): string {

--- a/apps/web/src/features/subtitles/subtitleTranscriber.ts
+++ b/apps/web/src/features/subtitles/subtitleTranscriber.ts
@@ -1,5 +1,6 @@
 import type { AutomaticSpeechRecognitionPipeline } from "@huggingface/transformers";
 import type { SubtitleSegment, SubtitleTranscriber } from "./types";
+import { loadTransformersPipeline } from "./transformersLoader";
 
 export const DEFAULT_TRANSCRIPTION_MODEL = "onnx-community/whisper-tiny";
 const DEFAULT_TRANSCRIPTION_LANGUAGE = "zh";
@@ -109,9 +110,7 @@ async function loadDefaultPipeline(
   model: string,
   options: AsrPipelineOptions,
 ): Promise<AsrPipeline> {
-  const module = await import("@huggingface/transformers");
-  const pipe = await module.pipeline(task, model, options);
-  return pipe as unknown as AsrPipeline;
+  return loadTransformersPipeline<AsrPipeline>(task, model, options);
 }
 
 function segmentFromChunk(

--- a/apps/web/src/features/subtitles/transformersLoader.ts
+++ b/apps/web/src/features/subtitles/transformersLoader.ts
@@ -1,0 +1,104 @@
+export type TransformersEnvironment = {
+  useBrowserCache?: boolean;
+  useCustomCache?: boolean;
+  customCache?: QuietBrowserCache | null;
+  cacheKey?: string;
+};
+
+type QuietBrowserCache = {
+  __codeTapeQuietCache: true;
+  match(cacheKey: string): Promise<Response | undefined>;
+  put(cacheKey: string, response: Response): Promise<void>;
+};
+
+export type TransformersModule = {
+  env?: TransformersEnvironment;
+  pipeline(task: string, model: string, options: unknown): Promise<unknown>;
+};
+
+export type TransformersModuleLoaderOptions = {
+  importer?: () => Promise<TransformersModule>;
+  attempts?: number;
+  retryDelayMs?: number;
+  onRetry?: (error: unknown, attempt: number) => void;
+};
+
+const DEFAULT_IMPORT_ATTEMPTS = 3;
+const DEFAULT_RETRY_DELAY_MS = 250;
+
+export async function loadTransformersModule(
+  options: TransformersModuleLoaderOptions = {},
+): Promise<TransformersModule> {
+  const importer = options.importer ?? defaultTransformersImporter;
+  const attempts = Math.max(1, Math.floor(options.attempts ?? DEFAULT_IMPORT_ATTEMPTS));
+  for (let attempt = 1; ; attempt += 1) {
+    try {
+      return await importer();
+    } catch (error) {
+      if (attempt >= attempts || !isRecoverableTransformersImportError(error)) {
+        throw error;
+      }
+      options.onRetry?.(error, attempt);
+      await waitBeforeRetry((options.retryDelayMs ?? DEFAULT_RETRY_DELAY_MS) * attempt);
+    }
+  }
+}
+
+export async function loadTransformersPipeline<TPipeline>(
+  task: string,
+  model: string,
+  options: unknown,
+  loaderOptions: TransformersModuleLoaderOptions = {},
+): Promise<TPipeline> {
+  const module = await loadTransformersModule(loaderOptions);
+  configureQuietBrowserCache(module.env);
+  const pipe = await module.pipeline(task, model, options);
+  return pipe as TPipeline;
+}
+
+export function configureQuietBrowserCache(env: TransformersEnvironment | undefined): void {
+  if (!env?.useBrowserCache || typeof globalThis.caches === "undefined") return;
+  if (env.useCustomCache && env.customCache) return;
+
+  const cacheKey = env.cacheKey ?? "transformers-cache";
+  env.useCustomCache = true;
+  env.customCache = {
+    __codeTapeQuietCache: true,
+    async match(resourceKey) {
+      try {
+        const cache = await globalThis.caches.open(cacheKey);
+        return (await cache.match(resourceKey)) ?? undefined;
+      } catch {
+        return undefined;
+      }
+    },
+    async put(resourceKey, response) {
+      try {
+        const cache = await globalThis.caches.open(cacheKey);
+        await cache.put(resourceKey, response.clone());
+      } catch {
+        // Cache API writes can fail for large model files or browser storage issues.
+        // Model loading has already succeeded, so keep inference available and avoid noisy warnings.
+      }
+    },
+  };
+}
+
+function isRecoverableTransformersImportError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return /Failed to fetch dynamically imported module|Importing a module script failed|error loading dynamically imported module|Load failed|NetworkError|Failed to fetch/iu.test(
+    message,
+  );
+}
+
+async function defaultTransformersImporter(): Promise<TransformersModule> {
+  const module = await import("@huggingface/transformers");
+  return module as unknown as TransformersModule;
+}
+
+function waitBeforeRetry(delayMs: number): Promise<void> {
+  if (delayMs <= 0) return Promise.resolve();
+  return new Promise((resolve) => {
+    globalThis.setTimeout(resolve, delayMs);
+  });
+}


### PR DESCRIPTION
## 关联

Refs #2（总控 issue，不在本 PR 中关闭）
Closes #164

## 改动点

- 新增 `transformersLoader`，统一 ASR 与字幕 LLM 的 Transformers.js 动态导入、可恢复重试和 CacheStorage 写入降噪。
- 将“生成字幕”的 ASR pipeline 与“纠错并生成章节”的 LLM pipeline 都切到统一 loader，避免临时 chunk/network failure 直接让用户操作失败。
- 补充 loader 回归测试，覆盖动态 import 首次失败后重试、非网络错误不重试、CacheStorage 写入失败不阻塞推理。

## 影响范围

- 影响 AI 字幕的模型运行库加载路径：ASR `生成字幕` 和本地 LLM `纠错并生成章节` 都会经过同一个 Transformers.js loader。
- 不改变 ASR 模型、语言参数、字幕纠错 prompt、章节生成逻辑和前端 UI。
- 根因说明：LLM 优化会影响 ASR，是因为两条链路都依赖 `@huggingface/transformers` 的浏览器动态 chunk；一次部署会同时替换这些 chunk，GitHub Pages 资源请求抖动或 chunk hash/cache 不一致时，ASR 点击链路也会暴露动态 import 失败。

## GitNexus 影响分析摘要

- 风险等级: medium
- 关键骨架变更: 无，GitNexus contract 标记为 advisory
- GitNexus 影响面: 4 files, 21 symbols；影响 `Transcribe -> isRecoverableTransformersImportError/waitBeforeRetry/configureQuietBrowserCache` 与 `Process -> configureQuietBrowserCache`
- 验证结果: `GITNEXUS_ANALYZE_TIMEOUT_MS=180000 npm run quality:local` 通过；`npx --yes gitnexus@1.6.5 detect_changes --repo ... --scope all` 已检查

## 字幕效果与性能验证

- `npm run subtitle:postprocess:evaluate`: representativeOutputSource=`postprocessor-runner`，representativePassRate=`1`，representativeJsonValidRate=`1`，representativeSegmentReferenceValidRate=`1`，representativeChapterTimelineValidRate=`1`，overallEvaluationDurationMs=`1.7272`；该耗时是 fixture 输出校验/runner 评估耗时，不代表真实端到端模型加载与推理耗时。
- `npm run subtitle:postprocess:runtime-benchmark`: postprocessClickToResultReadyDurationMs=`30.17`，postProcessTimeoutBudgetMs=`60000`，playbackProbeResponsiveDuringPostprocess=`true`。

## 自检

- [x] 未修改 `docs/progress.json` 或 `docs/progress.md`
- [x] 已运行 `npm run quality:local`，或说明无法运行的原因
- [x] 涉及 AI 字幕时，已记录一次 `npm run subtitle:postprocess:evaluate` 的“纠错并生成章节”效果验证结果，包含 `representativeOutputSource`、`overallEvaluationDurationMs`，并区分输出校验耗时与真实端到端耗时
- [x] 涉及 AI 字幕点击链路、LLM worker、模型加载或性能时，已记录一次 `npm run subtitle:postprocess:runtime-benchmark` 结果，包含 `postprocessClickToResultReadyDurationMs`、`postProcessTimeoutBudgetMs` 和 `playbackProbeResponsiveDuringPostprocess`
- [x] 已说明改动点和影响范围
- [x] 如果改动关键骨架，已补充契约测试并填写 GitNexus 影响分析摘要
- [ ] 已等待 repo-guard、codex 和 Copilot 评论，并完成必要审查
