### PR TITLE
[P1+] AI 字幕 LLM 空闲预热避免抢占 ASR

### DIFF
--- a/apps/web/src/features/subtitles/SubtitlePanel.tsx
+++ b/apps/web/src/features/subtitles/SubtitlePanel.tsx
@@ -37,6 +37,12 @@ export type SubtitlePanelProps = {
 
 type GenerationStatus = "idle" | "loading" | "generating" | "post-processing" | "ready" | "error";
 
+type PostProcessorWarmUpState = {
+  recordingId: string;
+  postProcessor: SubtitlePostProcessor;
+  status: "pending" | "running" | "completed";
+};
+
 export function SubtitlePanel({
   recordingId,
   mediaBlob,
@@ -75,7 +81,7 @@ export function SubtitlePanel({
   const requestVersionRef = useRef(0);
   const generationAbortRef = useRef<AbortController | null>(null);
   const warmUpRequestRef = useRef<{ recordingId: string; mediaBlob: Blob } | null>(null);
-  const postProcessorWarmUpRef = useRef<string | null>(null);
+  const postProcessorWarmUpRef = useRef<PostProcessorWarmUpState | null>(null);
 
   useEffect(() => {
     const requestVersion = requestVersionRef.current + 1;
@@ -143,14 +149,52 @@ export function SubtitlePanel({
   }, [hasAudio, mediaBlob, recordingId, transcriber]);
 
   useEffect(() => {
-    if (!recordingId || !hasAudio || !postProcessor?.warmUp) {
-      postProcessorWarmUpRef.current = null;
+    if (
+      !recordingId ||
+      !hasAudio ||
+      !track ||
+      track.recordingId !== recordingId ||
+      track.segments.length === 0 ||
+      status === "loading" ||
+      status === "generating" ||
+      status === "post-processing" ||
+      !postProcessor?.warmUp
+    ) {
       return;
     }
-    if (postProcessorWarmUpRef.current === recordingId) return;
-    postProcessorWarmUpRef.current = recordingId;
-    void postProcessor.warmUp().catch(() => undefined);
-  }, [hasAudio, postProcessor, recordingId]);
+    const existingWarmUp = postProcessorWarmUpRef.current;
+    if (
+      existingWarmUp?.recordingId === recordingId &&
+      existingWarmUp.postProcessor === postProcessor
+    ) {
+      return;
+    }
+    let cancelled = false;
+    const warmUpState: PostProcessorWarmUpState = {
+      recordingId,
+      postProcessor,
+      status: "pending",
+    };
+    postProcessorWarmUpRef.current = warmUpState;
+    const cancelIdleWarmUp = scheduleIdleWarmUp(() => {
+      if (cancelled) return;
+      warmUpState.status = "running";
+      void postProcessor.warmUp?.()
+        .catch(() => undefined)
+        .finally(() => {
+          if (postProcessorWarmUpRef.current === warmUpState) {
+            warmUpState.status = "completed";
+          }
+        });
+    });
+    return () => {
+      cancelled = true;
+      cancelIdleWarmUp();
+      if (postProcessorWarmUpRef.current === warmUpState && warmUpState.status === "pending") {
+        postProcessorWarmUpRef.current = null;
+      }
+    };
+  }, [hasAudio, postProcessor, recordingId, status, track]);
 
   const canGenerate = Boolean(
     recordingId &&
@@ -437,6 +481,17 @@ function runWithPostProcessTimeout<T>(
 
 function isPostProcessTimeoutError(error: unknown): error is PostProcessTimeoutError {
   return error instanceof Error && error.name === "PostProcessTimeoutError";
+}
+
+function scheduleIdleWarmUp(callback: () => void): () => void {
+  const requestIdle = globalThis.requestIdleCallback;
+  if (typeof requestIdle === "function") {
+    const handle = requestIdle(callback, { timeout: 2_000 });
+    return () => {
+      globalThis.cancelIdleCallback?.(handle);
+    };
+  }
+  return () => undefined;
 }
 
 function formatTimeoutBudget(timeoutMs: number): string {

--- a/apps/web/src/features/subtitles/SubtitlePanel.tsx
+++ b/apps/web/src/features/subtitles/SubtitlePanel.tsx
@@ -41,6 +41,7 @@ type PostProcessorWarmUpState = {
   recordingId: string;
   postProcessor: SubtitlePostProcessor;
   status: "pending" | "running" | "completed";
+  cancel(): void;
 };
 
 export function SubtitlePanel({
@@ -174,9 +175,10 @@ export function SubtitlePanel({
       recordingId,
       postProcessor,
       status: "pending",
+      cancel: () => undefined,
     };
     postProcessorWarmUpRef.current = warmUpState;
-    const cancelIdleWarmUp = scheduleIdleWarmUp(() => {
+    warmUpState.cancel = scheduleIdleWarmUp(() => {
       if (cancelled) return;
       warmUpState.status = "running";
       void postProcessor.warmUp?.()
@@ -189,10 +191,7 @@ export function SubtitlePanel({
     });
     return () => {
       cancelled = true;
-      cancelIdleWarmUp();
-      if (postProcessorWarmUpRef.current === warmUpState && warmUpState.status === "pending") {
-        postProcessorWarmUpRef.current = null;
-      }
+      cancelPostProcessorWarmUpState(postProcessorWarmUpRef, warmUpState);
     };
   }, [hasAudio, postProcessor, recordingId, status, track]);
 
@@ -218,6 +217,7 @@ export function SubtitlePanel({
     const requestVersion = requestVersionRef.current + 1;
     requestVersionRef.current = requestVersion;
     generationAbortRef.current?.abort();
+    cancelActivePostProcessorWarmUp(postProcessorWarmUpRef, postProcessor);
     const abortController = new AbortController();
     generationAbortRef.current = abortController;
     setStatus("generating");
@@ -256,6 +256,7 @@ export function SubtitlePanel({
     const requestVersion = requestVersionRef.current + 1;
     requestVersionRef.current = requestVersion;
     generationAbortRef.current?.abort();
+    cancelActivePostProcessorWarmUp(postProcessorWarmUpRef, postProcessor);
     const abortController = new AbortController();
     generationAbortRef.current = abortController;
     setStatus("post-processing");
@@ -481,6 +482,27 @@ function runWithPostProcessTimeout<T>(
 
 function isPostProcessTimeoutError(error: unknown): error is PostProcessTimeoutError {
   return error instanceof Error && error.name === "PostProcessTimeoutError";
+}
+
+function cancelActivePostProcessorWarmUp(
+  warmUpRef: MutableRefObject<PostProcessorWarmUpState | null>,
+  postProcessor: SubtitlePostProcessor | null,
+): void {
+  const warmUpState = warmUpRef.current;
+  if (!warmUpState || warmUpState.postProcessor !== postProcessor) return;
+  cancelPostProcessorWarmUpState(warmUpRef, warmUpState);
+}
+
+function cancelPostProcessorWarmUpState(
+  warmUpRef: MutableRefObject<PostProcessorWarmUpState | null>,
+  warmUpState: PostProcessorWarmUpState,
+): void {
+  warmUpState.cancel();
+  if (warmUpRef.current !== warmUpState || warmUpState.status === "completed") return;
+  warmUpRef.current = null;
+  if (warmUpState.status === "running") {
+    warmUpState.postProcessor.dispose?.();
+  }
 }
 
 function scheduleIdleWarmUp(callback: () => void): () => void {

--- a/apps/web/src/features/subtitles/SubtitlePanel.tsx
+++ b/apps/web/src/features/subtitles/SubtitlePanel.tsx
@@ -191,7 +191,7 @@ export function SubtitlePanel({
     });
     return () => {
       cancelled = true;
-      cancelPostProcessorWarmUpState(postProcessorWarmUpRef, warmUpState);
+      cancelPendingPostProcessorWarmUpState(postProcessorWarmUpRef, warmUpState);
     };
   }, [hasAudio, postProcessor, recordingId, status, track]);
 
@@ -256,7 +256,7 @@ export function SubtitlePanel({
     const requestVersion = requestVersionRef.current + 1;
     requestVersionRef.current = requestVersion;
     generationAbortRef.current?.abort();
-    cancelActivePostProcessorWarmUp(postProcessorWarmUpRef, postProcessor);
+    cancelPendingPostProcessorWarmUp(postProcessorWarmUpRef, postProcessor);
     const abortController = new AbortController();
     generationAbortRef.current = abortController;
     setStatus("post-processing");
@@ -502,6 +502,25 @@ function cancelPostProcessorWarmUpState(
   warmUpRef.current = null;
   if (warmUpState.status === "running") {
     warmUpState.postProcessor.dispose?.();
+  }
+}
+
+function cancelPendingPostProcessorWarmUp(
+  warmUpRef: MutableRefObject<PostProcessorWarmUpState | null>,
+  postProcessor: SubtitlePostProcessor | null,
+): void {
+  const warmUpState = warmUpRef.current;
+  if (!warmUpState || warmUpState.postProcessor !== postProcessor) return;
+  cancelPendingPostProcessorWarmUpState(warmUpRef, warmUpState);
+}
+
+function cancelPendingPostProcessorWarmUpState(
+  warmUpRef: MutableRefObject<PostProcessorWarmUpState | null>,
+  warmUpState: PostProcessorWarmUpState,
+): void {
+  warmUpState.cancel();
+  if (warmUpRef.current === warmUpState && warmUpState.status === "pending") {
+    warmUpRef.current = null;
   }
 }
 

--- a/apps/web/src/features/subtitles/__tests__/SubtitlePanel.test.tsx
+++ b/apps/web/src/features/subtitles/__tests__/SubtitlePanel.test.tsx
@@ -1333,6 +1333,82 @@ describe("SubtitlePanel", () => {
     });
   });
 
+  it("keeps a running local LLM warm-up instance when starting post-processing", async () => {
+    const store = createMemorySubtitleStore();
+    await store.save({
+      recordingId: "recording-1",
+      generatedAt: "2026-05-28T00:00:00.000Z",
+      model: "onnx-community/whisper-tiny",
+      source: "huggingface-local",
+      segments: [{ id: "subtitle-1", startMs: 0, endMs: 1_000, text: "use state hook" }],
+    });
+    const idleCallbacks: IdleRequestCallback[] = [];
+    vi.stubGlobal(
+      "requestIdleCallback",
+      vi.fn((callback: IdleRequestCallback) => {
+        idleCallbacks.push(callback);
+        return idleCallbacks.length;
+      }),
+    );
+    vi.stubGlobal("cancelIdleCallback", vi.fn());
+    const warmUpDeferred = createDeferred<void>();
+    const events: string[] = [];
+    const dispose = vi.fn(() => {
+      events.push("dispose");
+    });
+    const process = vi.fn(async () => {
+      events.push("process");
+      return {
+        segments: [{ id: "subtitle-1", text: "useState hook" }],
+        chapters: [{ title: "状态设计", startMs: 0, endMs: 1_000 }],
+      };
+    });
+
+    render(
+      <SubtitlePanel
+        recordingId="recording-1"
+        mediaBlob={new Blob(["webm"], { type: "video/webm" })}
+        hasAudio
+        durationMs={1_000}
+        currentTimeMs={0}
+        onSeek={vi.fn()}
+        store={store}
+        transcriber={{
+          transcribe: vi.fn(async () => ({
+            model: "onnx-community/whisper-tiny",
+            source: "huggingface-local" as const,
+            segments: [],
+          })),
+        }}
+        postProcessor={{
+          warmUp: vi.fn(() => {
+            events.push("warmUp");
+            return warmUpDeferred.promise;
+          }),
+          process,
+          dispose,
+        }}
+      />,
+    );
+
+    await waitFor(() => expect(screen.getByText("use state hook")).toBeInTheDocument());
+    await act(async () => {
+      idleCallbacks[0]?.({ didTimeout: false, timeRemaining: () => 10 });
+      await flushPromises();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "纠错并生成章节" }));
+
+    await waitFor(() => expect(process).toHaveBeenCalledTimes(1));
+    expect(events).toEqual(["warmUp", "process"]);
+    expect(dispose).not.toHaveBeenCalled();
+
+    await act(async () => {
+      warmUpDeferred.resolve();
+      await flushPromises();
+    });
+  });
+
   it("warms up a replacement local LLM post-processor instance for the same recording", async () => {
     const store = createMemorySubtitleStore();
     await store.save({

--- a/apps/web/src/features/subtitles/__tests__/SubtitlePanel.test.tsx
+++ b/apps/web/src/features/subtitles/__tests__/SubtitlePanel.test.tsx
@@ -1263,6 +1263,76 @@ describe("SubtitlePanel", () => {
     expect(postProcessorWarmUp).toHaveBeenCalledTimes(1);
   });
 
+  it("disposes a running local LLM warm-up before generating subtitles", async () => {
+    const store = createMemorySubtitleStore();
+    await store.save({
+      recordingId: "recording-1",
+      generatedAt: "2026-05-28T00:00:00.000Z",
+      model: "onnx-community/whisper-tiny",
+      source: "huggingface-local",
+      segments: [{ id: "subtitle-1", startMs: 0, endMs: 1_000, text: "Old subtitles." }],
+    });
+    const idleCallbacks: IdleRequestCallback[] = [];
+    vi.stubGlobal(
+      "requestIdleCallback",
+      vi.fn((callback: IdleRequestCallback) => {
+        idleCallbacks.push(callback);
+        return idleCallbacks.length;
+      }),
+    );
+    vi.stubGlobal("cancelIdleCallback", vi.fn());
+    const warmUpDeferred = createDeferred<void>();
+    const events: string[] = [];
+    const dispose = vi.fn(() => {
+      events.push("dispose");
+    });
+    const transcribe = vi.fn(async () => {
+      events.push("transcribe");
+      return {
+        model: "onnx-community/whisper-tiny",
+        source: "huggingface-local" as const,
+        segments: [{ id: "subtitle-1", startMs: 0, endMs: 2_000, text: "New subtitles." }],
+      };
+    });
+
+    render(
+      <SubtitlePanel
+        recordingId="recording-1"
+        mediaBlob={new Blob(["webm"], { type: "video/webm" })}
+        hasAudio
+        durationMs={2_000}
+        currentTimeMs={0}
+        onSeek={vi.fn()}
+        store={store}
+        transcriber={{ transcribe }}
+        postProcessor={{
+          warmUp: vi.fn(() => {
+            events.push("warmUp");
+            return warmUpDeferred.promise;
+          }),
+          process: vi.fn(async () => ({ segments: [], chapters: [] })),
+          dispose,
+        }}
+      />,
+    );
+
+    await waitFor(() => expect(screen.getByText("Old subtitles.")).toBeInTheDocument());
+    await act(async () => {
+      idleCallbacks[0]?.({ didTimeout: false, timeRemaining: () => 10 });
+      await flushPromises();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "生成字幕" }));
+
+    await waitFor(() => expect(transcribe).toHaveBeenCalledTimes(1));
+    expect(events).toEqual(["warmUp", "dispose", "transcribe"]);
+
+    await act(async () => {
+      warmUpDeferred.resolve();
+      await flushPromises();
+    });
+  });
+
   it("warms up a replacement local LLM post-processor instance for the same recording", async () => {
     const store = createMemorySubtitleStore();
     await store.save({

--- a/apps/web/src/features/subtitles/__tests__/SubtitlePanel.test.tsx
+++ b/apps/web/src/features/subtitles/__tests__/SubtitlePanel.test.tsx
@@ -56,6 +56,8 @@ async function flushPromises() {
 
 describe("SubtitlePanel", () => {
   afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
     vi.useRealTimers();
   });
 
@@ -741,7 +743,7 @@ describe("SubtitlePanel", () => {
     await waitFor(() => expect(warmUp).toHaveBeenCalledTimes(1));
   });
 
-  it("warms up the local LLM when audio is available before subtitles are generated", async () => {
+  it("does not warm up the local LLM before subtitles exist", async () => {
     const transcriberWarmUp = vi.fn(async () => undefined);
     const postProcessorWarmUp = vi.fn(async () => undefined);
     const process = vi.fn(async () => ({ segments: [], chapters: [] }));
@@ -770,11 +772,77 @@ describe("SubtitlePanel", () => {
       />,
     );
 
-    await waitFor(() => expect(postProcessorWarmUp).toHaveBeenCalledTimes(1));
+    await act(async () => {
+      await flushPromises();
+    });
+
+    expect(postProcessorWarmUp).not.toHaveBeenCalled();
     expect(process).not.toHaveBeenCalled();
   });
 
-  it("disposes the local LLM post-processor on unmount after warm-up starts", async () => {
+  it("does not warm up the local LLM for no-audio recordings with saved subtitles", async () => {
+    const store = createMemorySubtitleStore();
+    await store.save({
+      recordingId: "recording-1",
+      generatedAt: "2026-05-28T00:00:00.000Z",
+      model: "onnx-community/whisper-tiny",
+      source: "huggingface-local",
+      segments: [{ id: "subtitle-1", startMs: 0, endMs: 1_000, text: "Saved subtitles." }],
+    });
+    const requestIdleCallback = vi.fn((callback: IdleRequestCallback) => {
+      callback({ didTimeout: false, timeRemaining: () => 10 });
+      return 1;
+    });
+    vi.stubGlobal("requestIdleCallback", requestIdleCallback);
+    vi.stubGlobal("cancelIdleCallback", vi.fn());
+    const postProcessorWarmUp = vi.fn(async () => undefined);
+
+    render(
+      <SubtitlePanel
+        recordingId="recording-1"
+        mediaBlob={null}
+        hasAudio={false}
+        durationMs={1_000}
+        currentTimeMs={0}
+        onSeek={vi.fn()}
+        store={store}
+        transcriber={{
+          transcribe: vi.fn(async () => ({
+            model: "onnx-community/whisper-tiny",
+            source: "huggingface-local" as const,
+            segments: [],
+          })),
+        }}
+        postProcessor={{
+          warmUp: postProcessorWarmUp,
+          process: vi.fn(async () => ({ segments: [], chapters: [] })),
+        }}
+      />,
+    );
+
+    await waitFor(() => expect(screen.getByText("onnx-community/whisper-tiny")).toBeInTheDocument());
+    expect(screen.getByText("无音频轨道")).toBeInTheDocument();
+    expect(requestIdleCallback).not.toHaveBeenCalled();
+    expect(postProcessorWarmUp).not.toHaveBeenCalled();
+  });
+
+  it("cancels pending idle local LLM warm-up on unmount", async () => {
+    const store = createMemorySubtitleStore();
+    await store.save({
+      recordingId: "recording-1",
+      generatedAt: "2026-05-28T00:00:00.000Z",
+      model: "onnx-community/whisper-tiny",
+      source: "huggingface-local",
+      segments: [{ id: "subtitle-1", startMs: 0, endMs: 1_000, text: "Saved subtitles." }],
+    });
+    const idleCallbacks: IdleRequestCallback[] = [];
+    const requestIdleCallback = vi.fn((callback: IdleRequestCallback) => {
+      idleCallbacks.push(callback);
+      return 7;
+    });
+    const cancelIdleCallback = vi.fn();
+    vi.stubGlobal("requestIdleCallback", requestIdleCallback);
+    vi.stubGlobal("cancelIdleCallback", cancelIdleCallback);
     const postProcessorWarmUp = vi.fn(async () => undefined);
     const dispose = vi.fn();
 
@@ -786,7 +854,7 @@ describe("SubtitlePanel", () => {
         durationMs={3_000}
         currentTimeMs={0}
         onSeek={vi.fn()}
-        store={createMemorySubtitleStore()}
+        store={store}
         transcriber={{
           transcribe: vi.fn(async () => ({
             model: "onnx-community/whisper-tiny",
@@ -802,14 +870,45 @@ describe("SubtitlePanel", () => {
       />,
     );
 
-    await waitFor(() => expect(postProcessorWarmUp).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(screen.getByText("Saved subtitles.")).toBeInTheDocument());
+    expect(requestIdleCallback).toHaveBeenCalledTimes(1);
+    expect(postProcessorWarmUp).not.toHaveBeenCalled();
 
     unmount();
 
+    expect(cancelIdleCallback).toHaveBeenCalledWith(7);
     expect(dispose).toHaveBeenCalledTimes(1);
+    await act(async () => {
+      idleCallbacks[0]?.({ didTimeout: false, timeRemaining: () => 10 });
+      await flushPromises();
+    });
+    expect(postProcessorWarmUp).not.toHaveBeenCalled();
   });
 
-  it("disposes the local LLM post-processor when switching recordings", async () => {
+  it("cancels pending idle local LLM warm-up when switching recordings", async () => {
+    const store = createMemorySubtitleStore();
+    await store.save({
+      recordingId: "recording-1",
+      generatedAt: "2026-05-28T00:00:00.000Z",
+      model: "onnx-community/whisper-tiny",
+      source: "huggingface-local",
+      segments: [{ id: "subtitle-1", startMs: 0, endMs: 1_000, text: "First recording." }],
+    });
+    await store.save({
+      recordingId: "recording-2",
+      generatedAt: "2026-05-28T00:00:01.000Z",
+      model: "onnx-community/whisper-tiny",
+      source: "huggingface-local",
+      segments: [{ id: "subtitle-1", startMs: 0, endMs: 1_000, text: "Second recording." }],
+    });
+    const idleCallbacks: IdleRequestCallback[] = [];
+    const requestIdleCallback = vi.fn((callback: IdleRequestCallback) => {
+      idleCallbacks.push(callback);
+      return idleCallbacks.length;
+    });
+    const cancelIdleCallback = vi.fn();
+    vi.stubGlobal("requestIdleCallback", requestIdleCallback);
+    vi.stubGlobal("cancelIdleCallback", cancelIdleCallback);
     const postProcessorWarmUp = vi.fn(async () => undefined);
     const dispose = vi.fn();
     const postProcessor: SubtitlePostProcessor = {
@@ -827,7 +926,7 @@ describe("SubtitlePanel", () => {
         durationMs={3_000}
         currentTimeMs={0}
         onSeek={vi.fn()}
-        store={createMemorySubtitleStore()}
+        store={store}
         transcriber={{
           transcribe: vi.fn(async () => ({
             model: "onnx-community/whisper-tiny",
@@ -839,7 +938,9 @@ describe("SubtitlePanel", () => {
       />,
     );
 
-    await waitFor(() => expect(postProcessorWarmUp).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(screen.getByText("First recording.")).toBeInTheDocument());
+    expect(requestIdleCallback).toHaveBeenCalledTimes(1);
+    expect(postProcessorWarmUp).not.toHaveBeenCalled();
 
     rerender(
       <SubtitlePanel
@@ -849,7 +950,7 @@ describe("SubtitlePanel", () => {
         durationMs={3_000}
         currentTimeMs={0}
         onSeek={vi.fn()}
-        store={createMemorySubtitleStore()}
+        store={store}
         transcriber={{
           transcribe: vi.fn(async () => ({
             model: "onnx-community/whisper-tiny",
@@ -862,10 +963,39 @@ describe("SubtitlePanel", () => {
     );
 
     expect(dispose).toHaveBeenCalledTimes(1);
-    await waitFor(() => expect(postProcessorWarmUp).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(screen.getByText("Second recording.")).toBeInTheDocument());
+    expect(cancelIdleCallback).toHaveBeenCalledWith(1);
+    expect(requestIdleCallback).toHaveBeenCalledTimes(2);
+
+    await act(async () => {
+      idleCallbacks[0]?.({ didTimeout: false, timeRemaining: () => 10 });
+      await flushPromises();
+    });
+    expect(postProcessorWarmUp).not.toHaveBeenCalled();
+
+    await act(async () => {
+      idleCallbacks[1]?.({ didTimeout: false, timeRemaining: () => 10 });
+      await flushPromises();
+    });
+    expect(postProcessorWarmUp).toHaveBeenCalledTimes(1);
   });
 
-  it("warms up the local LLM before the media blob finishes loading", async () => {
+  it("schedules local LLM warm-up after saved subtitles load even before the media blob finishes loading", async () => {
+    const store = createMemorySubtitleStore();
+    await store.save({
+      recordingId: "recording-1",
+      generatedAt: "2026-05-28T00:00:00.000Z",
+      model: "onnx-community/whisper-tiny",
+      source: "huggingface-local",
+      segments: [{ id: "subtitle-1", startMs: 0, endMs: 1_000, text: "Saved subtitles." }],
+    });
+    const idleCallbacks: IdleRequestCallback[] = [];
+    const requestIdleCallback = vi.fn((callback: IdleRequestCallback) => {
+      idleCallbacks.push(callback);
+      return 1;
+    });
+    vi.stubGlobal("requestIdleCallback", requestIdleCallback);
+    vi.stubGlobal("cancelIdleCallback", vi.fn());
     const postProcessorWarmUp = vi.fn(async () => undefined);
 
     render(
@@ -876,7 +1006,7 @@ describe("SubtitlePanel", () => {
         durationMs={3_000}
         currentTimeMs={0}
         onSeek={vi.fn()}
-        store={createMemorySubtitleStore()}
+        store={store}
         transcriber={{
           transcribe: vi.fn(async () => ({
             model: "onnx-community/whisper-tiny",
@@ -891,7 +1021,328 @@ describe("SubtitlePanel", () => {
       />,
     );
 
+    await waitFor(() => expect(screen.getByText("Saved subtitles.")).toBeInTheDocument());
+    expect(requestIdleCallback).toHaveBeenCalledTimes(1);
+    expect(postProcessorWarmUp).not.toHaveBeenCalled();
+
+    await act(async () => {
+      idleCallbacks[0]?.({ didTimeout: false, timeRemaining: () => 10 });
+      await flushPromises();
+    });
+
     await waitFor(() => expect(postProcessorWarmUp).toHaveBeenCalledTimes(1));
+  });
+
+  it("skips local LLM warm-up when the browser has no idle callback API", async () => {
+    const store = createMemorySubtitleStore();
+    await store.save({
+      recordingId: "recording-1",
+      generatedAt: "2026-05-28T00:00:00.000Z",
+      model: "onnx-community/whisper-tiny",
+      source: "huggingface-local",
+      segments: [{ id: "subtitle-1", startMs: 0, endMs: 1_000, text: "Saved subtitles." }],
+    });
+    vi.stubGlobal("requestIdleCallback", undefined);
+    vi.stubGlobal("cancelIdleCallback", undefined);
+    const postProcessorWarmUp = vi.fn(async () => undefined);
+
+    render(
+      <SubtitlePanel
+        recordingId="recording-1"
+        mediaBlob={new Blob(["webm"], { type: "video/webm" })}
+        hasAudio
+        durationMs={3_000}
+        currentTimeMs={0}
+        onSeek={vi.fn()}
+        store={store}
+        transcriber={{
+          transcribe: vi.fn(async () => ({
+            model: "onnx-community/whisper-tiny",
+            source: "huggingface-local" as const,
+            segments: [],
+          })),
+        }}
+        postProcessor={{
+          warmUp: postProcessorWarmUp,
+          process: vi.fn(async () => ({ segments: [], chapters: [] })),
+        }}
+      />,
+    );
+
+    await waitFor(() => expect(screen.getByText("Saved subtitles.")).toBeInTheDocument());
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 20));
+      await flushPromises();
+    });
+
+    expect(postProcessorWarmUp).not.toHaveBeenCalled();
+  });
+
+  it("starts local LLM post-processing even if idle warm-up has not run yet", async () => {
+    const store = createMemorySubtitleStore();
+    await store.save({
+      recordingId: "recording-1",
+      generatedAt: "2026-05-28T00:00:00.000Z",
+      model: "onnx-community/whisper-tiny",
+      source: "huggingface-local",
+      segments: [{ id: "subtitle-1", startMs: 0, endMs: 1_000, text: "use state hook" }],
+    });
+    const requestIdleCallback = vi.fn(() => 1);
+    vi.stubGlobal("requestIdleCallback", requestIdleCallback);
+    vi.stubGlobal("cancelIdleCallback", vi.fn());
+    const postProcessorWarmUp = vi.fn(async () => undefined);
+    const process = vi.fn(async () => ({
+      segments: [{ id: "subtitle-1", text: "useState hook" }],
+      chapters: [{ title: "状态设计", startMs: 0, endMs: 1_000 }],
+    }));
+
+    render(
+      <SubtitlePanel
+        recordingId="recording-1"
+        mediaBlob={new Blob(["webm"], { type: "video/webm" })}
+        hasAudio
+        durationMs={1_000}
+        currentTimeMs={0}
+        onSeek={vi.fn()}
+        store={store}
+        transcriber={{
+          transcribe: vi.fn(async () => ({
+            model: "onnx-community/whisper-tiny",
+            source: "huggingface-local" as const,
+            segments: [],
+          })),
+        }}
+        postProcessor={{
+          warmUp: postProcessorWarmUp,
+          process,
+        }}
+      />,
+    );
+
+    await waitFor(() => expect(screen.getByText("use state hook")).toBeInTheDocument());
+    expect(requestIdleCallback).toHaveBeenCalledTimes(1);
+    expect(postProcessorWarmUp).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole("button", { name: "纠错并生成章节" }));
+
+    await waitFor(() => expect(process).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(screen.getByText("useState hook")).toBeInTheDocument());
+    expect(postProcessorWarmUp).not.toHaveBeenCalled();
+  });
+
+  it("reschedules local LLM warm-up when a pending idle warm-up is canceled by a new subtitle track", async () => {
+    const store = createMemorySubtitleStore();
+    await store.save({
+      recordingId: "recording-1",
+      generatedAt: "2026-05-28T00:00:00.000Z",
+      model: "onnx-community/whisper-tiny",
+      source: "huggingface-local",
+      segments: [{ id: "subtitle-1", startMs: 0, endMs: 1_000, text: "Old subtitles." }],
+    });
+    const idleCallbacks: IdleRequestCallback[] = [];
+    const requestIdleCallback = vi.fn((callback: IdleRequestCallback) => {
+      idleCallbacks.push(callback);
+      return idleCallbacks.length;
+    });
+    const cancelIdleCallback = vi.fn();
+    vi.stubGlobal("requestIdleCallback", requestIdleCallback);
+    vi.stubGlobal("cancelIdleCallback", cancelIdleCallback);
+    const postProcessorWarmUp = vi.fn(async () => undefined);
+
+    render(
+      <SubtitlePanel
+        recordingId="recording-1"
+        mediaBlob={new Blob(["webm"], { type: "video/webm" })}
+        hasAudio
+        durationMs={2_000}
+        currentTimeMs={0}
+        onSeek={vi.fn()}
+        store={store}
+        transcriber={{
+          transcribe: vi.fn(async () => ({
+            model: "onnx-community/whisper-tiny",
+            source: "huggingface-local" as const,
+            segments: [{ id: "subtitle-1", startMs: 0, endMs: 2_000, text: "New subtitles." }],
+          })),
+        }}
+        postProcessor={{
+          warmUp: postProcessorWarmUp,
+          process: vi.fn(async () => ({ segments: [], chapters: [] })),
+        }}
+      />,
+    );
+
+    await waitFor(() => expect(screen.getByText("Old subtitles.")).toBeInTheDocument());
+    expect(requestIdleCallback).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(screen.getByRole("button", { name: "生成字幕" }));
+
+    await waitFor(() => expect(screen.getByText("New subtitles.")).toBeInTheDocument());
+    expect(cancelIdleCallback).toHaveBeenCalledWith(1);
+    expect(requestIdleCallback).toHaveBeenCalledTimes(2);
+
+    await act(async () => {
+      idleCallbacks[0]?.({ didTimeout: false, timeRemaining: () => 10 });
+      await flushPromises();
+    });
+    expect(postProcessorWarmUp).not.toHaveBeenCalled();
+
+    await act(async () => {
+      idleCallbacks[1]?.({ didTimeout: false, timeRemaining: () => 10 });
+      await flushPromises();
+    });
+    expect(postProcessorWarmUp).toHaveBeenCalledTimes(1);
+  });
+
+  it("cancels pending idle local LLM warm-up while subtitles are generating", async () => {
+    const store = createMemorySubtitleStore();
+    await store.save({
+      recordingId: "recording-1",
+      generatedAt: "2026-05-28T00:00:00.000Z",
+      model: "onnx-community/whisper-tiny",
+      source: "huggingface-local",
+      segments: [{ id: "subtitle-1", startMs: 0, endMs: 1_000, text: "Old subtitles." }],
+    });
+    const idleCallbacks: IdleRequestCallback[] = [];
+    const requestIdleCallback = vi.fn((callback: IdleRequestCallback) => {
+      idleCallbacks.push(callback);
+      return idleCallbacks.length;
+    });
+    const cancelIdleCallback = vi.fn();
+    vi.stubGlobal("requestIdleCallback", requestIdleCallback);
+    vi.stubGlobal("cancelIdleCallback", cancelIdleCallback);
+    const postProcessorWarmUp = vi.fn(async () => undefined);
+    const generatedTrack = createDeferred<SubtitleTrackDraft>();
+
+    render(
+      <SubtitlePanel
+        recordingId="recording-1"
+        mediaBlob={new Blob(["webm"], { type: "video/webm" })}
+        hasAudio
+        durationMs={2_000}
+        currentTimeMs={0}
+        onSeek={vi.fn()}
+        store={store}
+        transcriber={{
+          transcribe: vi.fn(() => generatedTrack.promise),
+        }}
+        postProcessor={{
+          warmUp: postProcessorWarmUp,
+          process: vi.fn(async () => ({ segments: [], chapters: [] })),
+        }}
+      />,
+    );
+
+    await waitFor(() => expect(screen.getByText("Old subtitles.")).toBeInTheDocument());
+    expect(requestIdleCallback).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(screen.getByRole("button", { name: "生成字幕" }));
+
+    await waitFor(() => expect(cancelIdleCallback).toHaveBeenCalledWith(1));
+    await act(async () => {
+      idleCallbacks[0]?.({ didTimeout: false, timeRemaining: () => 10 });
+      await flushPromises();
+    });
+    expect(postProcessorWarmUp).not.toHaveBeenCalled();
+
+    await act(async () => {
+      generatedTrack.resolve({
+        model: "onnx-community/whisper-tiny",
+        source: "huggingface-local",
+        segments: [{ id: "subtitle-1", startMs: 0, endMs: 2_000, text: "New subtitles." }],
+      });
+      await flushPromises();
+    });
+    await waitFor(() => expect(screen.getByText("New subtitles.")).toBeInTheDocument());
+    expect(requestIdleCallback).toHaveBeenCalledTimes(2);
+
+    await act(async () => {
+      idleCallbacks[1]?.({ didTimeout: false, timeRemaining: () => 10 });
+      await flushPromises();
+    });
+    expect(postProcessorWarmUp).toHaveBeenCalledTimes(1);
+  });
+
+  it("warms up a replacement local LLM post-processor instance for the same recording", async () => {
+    const store = createMemorySubtitleStore();
+    await store.save({
+      recordingId: "recording-1",
+      generatedAt: "2026-05-28T00:00:00.000Z",
+      model: "onnx-community/whisper-tiny",
+      source: "huggingface-local",
+      segments: [{ id: "subtitle-1", startMs: 0, endMs: 1_000, text: "Saved subtitles." }],
+    });
+    const idleCallbacks: IdleRequestCallback[] = [];
+    const requestIdleCallback = vi.fn((callback: IdleRequestCallback) => {
+      idleCallbacks.push(callback);
+      return idleCallbacks.length;
+    });
+    vi.stubGlobal("requestIdleCallback", requestIdleCallback);
+    vi.stubGlobal("cancelIdleCallback", vi.fn());
+    const firstWarmUp = vi.fn(async () => undefined);
+    const secondWarmUp = vi.fn(async () => undefined);
+    const createPostProcessor = (warmUp: () => Promise<void>): SubtitlePostProcessor => ({
+      warmUp,
+      process: vi.fn(async () => ({ segments: [], chapters: [] })),
+      dispose: vi.fn(),
+    });
+
+    const { rerender } = render(
+      <SubtitlePanel
+        recordingId="recording-1"
+        mediaBlob={new Blob(["webm"], { type: "video/webm" })}
+        hasAudio
+        durationMs={1_000}
+        currentTimeMs={0}
+        onSeek={vi.fn()}
+        store={store}
+        transcriber={{
+          transcribe: vi.fn(async () => ({
+            model: "onnx-community/whisper-tiny",
+            source: "huggingface-local" as const,
+            segments: [],
+          })),
+        }}
+        postProcessor={createPostProcessor(firstWarmUp)}
+      />,
+    );
+
+    await waitFor(() => expect(screen.getByText("Saved subtitles.")).toBeInTheDocument());
+    expect(requestIdleCallback).toHaveBeenCalledTimes(1);
+
+    rerender(
+      <SubtitlePanel
+        recordingId="recording-1"
+        mediaBlob={new Blob(["webm"], { type: "video/webm" })}
+        hasAudio
+        durationMs={1_000}
+        currentTimeMs={0}
+        onSeek={vi.fn()}
+        store={store}
+        transcriber={{
+          transcribe: vi.fn(async () => ({
+            model: "onnx-community/whisper-tiny",
+            source: "huggingface-local" as const,
+            segments: [],
+          })),
+        }}
+        postProcessor={createPostProcessor(secondWarmUp)}
+      />,
+    );
+
+    await act(async () => {
+      await flushPromises();
+    });
+    await waitFor(() => expect(requestIdleCallback.mock.calls.length).toBeGreaterThanOrEqual(2));
+    await act(async () => {
+      for (const idleCallback of idleCallbacks) {
+        idleCallback({ didTimeout: false, timeRemaining: () => 10 });
+      }
+      await flushPromises();
+    });
+
+    expect(firstWarmUp).not.toHaveBeenCalled();
+    await waitFor(() => expect(secondWarmUp).toHaveBeenCalledTimes(1));
   });
 
   it("does not repeat warm-up for the same recording media when transcriber identity changes", async () => {

--- a/apps/web/src/features/subtitles/__tests__/subtitlePostProcessorRuntimeBenchmark.test.tsx
+++ b/apps/web/src/features/subtitles/__tests__/subtitlePostProcessorRuntimeBenchmark.test.tsx
@@ -1,5 +1,5 @@
 import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   DEFAULT_SUBTITLE_POSTPROCESS_TIMEOUT_MS,
   SubtitlePanel,
@@ -60,6 +60,11 @@ function roundDuration(value: number): number {
 }
 
 describe("subtitle postprocessor runtime benchmark", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
   it("measures click-to-ready timing without blocking subtitle and chapter seeking", async () => {
     const originalTrack: SubtitleTrack = {
       recordingId: "recording-1",
@@ -105,6 +110,14 @@ describe("subtitle postprocessor runtime benchmark", () => {
       })),
     };
     const onSeek = vi.fn();
+    vi.stubGlobal(
+      "requestIdleCallback",
+      vi.fn((callback: IdleRequestCallback) => {
+        callback({ didTimeout: false, timeRemaining: () => 10 });
+        return 1;
+      }),
+    );
+    vi.stubGlobal("cancelIdleCallback", vi.fn());
 
     render(
       <SubtitlePanel


### PR DESCRIPTION
## 关联

Closes #168
Refs #2（总控 issue，不在本 PR 中关闭）

## 改动点

- 将 `SubtitlePanel` 的本地 LLM `postProcessor.warmUp()` 从“有音频录制加载即预热”改为“当前录制已有字幕轨后再预热”，避免首次 ASR 生成字幕前抢占同一个 Transformers.js runtime / WASM / WebGPU 初始化资源。
- LLM 预热通过 `requestIdleCallback` 调度；缺失 idle API 时跳过投机预热，避免用 timer 立即抢占 ASR。录制切换或组件卸载会取消旧 idle 任务。
- 增加回归测试覆盖：无字幕轨不预热、已加载字幕后 idle 预热、idle 未执行时点击“纠错并生成章节”仍立即 process、切换/卸载不会让旧 warm-up 污染新录制。

## 影响范围

- 影响 `SubtitlePanel` 内本地 LLM 后处理模型预热时机；不修改 ASR 模型、ASR `language: "chinese"`、默认后处理模型、prompt、JSON 输出契约或字幕/章节持久化 schema。
- 对“生成字幕”路径更保守：未有字幕前不主动加载 LLM，降低 ASR 与 LLM 同时争抢浏览器模型运行时的概率。
- 对“纠错并生成章节”路径保持可恢复：如果 idle 预热尚未完成，点击按钮仍走现有 `postProcessor.process` 加载/推理路径。

## GitNexus 影响分析摘要

- 风险等级: LOW
- 关键骨架变更: 无；本次只改 `apps/web/src/features/subtitles/SubtitlePanel.tsx` 的 LLM warm-up effect 与对应单测，不触碰录制包 schema、ASR、LLM prompt 或 worker 协议。
- GitNexus 影响面: `detect_changes --scope all` 显示 2 files / 8 symbols / 0 affected processes / risk low；`context SubtitlePanel` 显示直接上游为 `ReplayPage`；`impact SubtitlePanel` 显示 direct=1、processes_affected=1、affected module=Player、risk LOW。
- 验证结果: TDD RED 先看到 `SubtitlePanel.test.tsx` 5 个 warm-up 时机断言失败；GREEN 后 `SubtitlePanel.test.tsx` 19/19 通过；`subtitlePostProcessor.test.ts` + `subtitlePostProcessorWorkerClient.test.ts` + runtime benchmark 共 44/44 通过；`npm run subtitle:postprocess:evaluate` 通过，`representativeOutputSource=postprocessor-runner`、`overallEvaluationDurationMs=1.762`、代表性 JSON/segment/term/chapter 指标均为 1；`npm run subtitle:postprocess:runtime-benchmark` 通过，`postprocessClickToResultReadyDurationMs=33.215`、`postProcessTimeoutBudgetMs=60000`、`playbackProbeResponsiveDuringPostprocess=true`；rebase 最新 main 后 `npm run quality:local` 通过；commit hook `quality:precommit` 和 pre-push hook `quality:local` 均通过。

## Issue review

- repo-guard 对 #168 的 issue 分析评分 5/5，维护者下一步动作：可以开始。
- 唯一建议是可选补充实现入口位置；本 PR 已直接修改并在改动点中说明 `SubtitlePanel` 入口。

## 自检

- [x] 未修改 `docs/progress.json` 或 `docs/progress.md`
- [x] 已运行 `npm run quality:local`，或说明无法运行的原因
- [x] 涉及 AI 字幕时，已记录一次 `npm run subtitle:postprocess:evaluate` 的“纠错并生成章节”效果验证结果，包含 `representativeOutputSource`、`overallEvaluationDurationMs`，并区分输出校验耗时与真实端到端耗时
- [x] 涉及 AI 字幕点击链路、LLM worker、模型加载或性能时，已记录一次 `npm run subtitle:postprocess:runtime-benchmark` 结果，包含 `postprocessClickToResultReadyDurationMs`、`postProcessTimeoutBudgetMs` 和 `playbackProbeResponsiveDuringPostprocess`
- [x] 已说明改动点和影响范围
- [x] 如果改动关键骨架，已补充契约测试并填写 GitNexus 影响分析摘要
- [ ] 已等待 repo-guard、codex 和 Copilot 评论，并完成必要审查

