### PR TITLE
feat: add cloud recording share links

### DIFF
--- a/apps/api/src/cloud/__tests__/uploadSession.test.ts
+++ b/apps/api/src/cloud/__tests__/uploadSession.test.ts
@@ -834,6 +834,38 @@ test("delete returns the persisted deletedAt when a concurrent soft-delete wins 
   assert.equal(persisted?.deletedAt, persistedDeletedAt);
 });
 
+test("createShareLink marks the ready recording as unlisted", async () => {
+  const metadata = createMemoryMetadataRepository();
+  const service = createCloudRecordingService({
+    metadata,
+    objectStorage: createMemoryObjectStorage(),
+    now: () => new Date("2026-05-29T00:00:00.000Z"),
+  });
+  const pkg = await makePackage();
+  const request = await makeCreateSessionRequest(pkg);
+  const created = await service.createUploadSession({ ownerId: "owner-1", input: request });
+  assert.equal(created.ok, true);
+  if (!created.ok) return;
+  const recording = await metadata.getRecording(created.value.recordingId);
+  assert.ok(recording);
+  await metadata.updateRecording({
+    ...recording,
+    status: "ready",
+    updatedAt: "2026-05-29T00:00:00.000Z",
+    completedAt: "2026-05-29T00:00:00.000Z",
+  });
+
+  const result = await service.createShareLink({
+    ownerId: "owner-1",
+    recordingId: created.value.recordingId,
+    input: {},
+  });
+  const sharedRecording = await metadata.getRecording(created.value.recordingId);
+
+  assert.equal(result.ok, true);
+  assert.equal(sharedRecording?.visibility, "unlisted");
+});
+
 test("createShareLink rejects parseable non-ISO expiresAt strings", async () => {
   const metadata = createMemoryMetadataRepository();
   const service = createCloudRecordingService({

--- a/apps/api/src/cloud/__tests__/uploadSession.test.ts
+++ b/apps/api/src/cloud/__tests__/uploadSession.test.ts
@@ -834,6 +834,39 @@ test("delete returns the persisted deletedAt when a concurrent soft-delete wins 
   assert.equal(persisted?.deletedAt, persistedDeletedAt);
 });
 
+test("createShareLink rejects parseable non-ISO expiresAt strings", async () => {
+  const metadata = createMemoryMetadataRepository();
+  const service = createCloudRecordingService({
+    metadata,
+    objectStorage: createMemoryObjectStorage(),
+    now: () => new Date("2026-05-29T00:00:00.000Z"),
+  });
+  const pkg = await makePackage();
+  const request = await makeCreateSessionRequest(pkg);
+  const created = await service.createUploadSession({ ownerId: "owner-1", input: request });
+  assert.equal(created.ok, true);
+  if (!created.ok) return;
+  const recording = await metadata.getRecording(created.value.recordingId);
+  assert.ok(recording);
+  await metadata.updateRecording({
+    ...recording,
+    status: "ready",
+    updatedAt: "2026-05-29T00:00:00.000Z",
+    completedAt: "2026-05-29T00:00:00.000Z",
+  });
+
+  const result = await service.createShareLink({
+    ownerId: "owner-1",
+    recordingId: created.value.recordingId,
+    input: { expiresAt: "May 30, 2026" },
+  });
+
+  assert.equal(result.ok, false);
+  if (result.ok) return;
+  assert.equal(result.error.code, "bad-request");
+  assert.equal(result.error.message, "expiresAt must be an ISO date string or null");
+});
+
 async function makePackage(): Promise<RecordingPackageV1> {
   const events: RecordingPackageV1["events"] = [];
   const snapshots: RecordingPackageV1["snapshots"] = [];

--- a/apps/api/src/cloud/cloudRecordingService.ts
+++ b/apps/api/src/cloud/cloudRecordingService.ts
@@ -414,6 +414,14 @@ export function createCloudRecordingService(deps: {
           revokedAt: null,
         });
         if (write.status === "created") {
+          await deps.metadata.updateRecordingIfStatus({
+            recordingId: recording.id,
+            expectedStatus: "ready",
+            patch: {
+              visibility: "unlisted",
+              updatedAt: createdAt,
+            },
+          });
           return {
             ok: true,
             value: {

--- a/apps/api/src/cloud/cloudRecordingService.ts
+++ b/apps/api/src/cloud/cloudRecordingService.ts
@@ -1,6 +1,7 @@
 import { randomBytes } from "node:crypto";
 import { RECORDING_SCHEMA_VERSION, type RecordingLanguage } from "@code-tape/recording-schema";
 import { sha256Hex } from "@code-tape/recording-schema/hash";
+import { parseIsoUtcInstantMs } from "./isoDate.js";
 import type { MetadataRepository } from "./metadataRepository.js";
 import type { ObjectStorage } from "./objectStorage.js";
 import {
@@ -756,8 +757,8 @@ function validateCreateShareLinkInput(
   currentTime: Date,
 ): CloudApiError | null {
   if (input.expiresAt !== undefined && input.expiresAt !== null) {
-    const expiresAtMs = Date.parse(input.expiresAt);
-    if (!Number.isFinite(expiresAtMs)) {
+    const expiresAtMs = parseIsoUtcInstantMs(input.expiresAt);
+    if (expiresAtMs === null) {
       return { code: "bad-request", message: "expiresAt must be an ISO date string or null" };
     }
     if (expiresAtMs <= currentTime.getTime()) {

--- a/apps/api/src/cloud/cloudRecordingService.ts
+++ b/apps/api/src/cloud/cloudRecordingService.ts
@@ -1,4 +1,6 @@
+import { randomBytes } from "node:crypto";
 import { RECORDING_SCHEMA_VERSION, type RecordingLanguage } from "@code-tape/recording-schema";
+import { sha256Hex } from "@code-tape/recording-schema/hash";
 import type { MetadataRepository } from "./metadataRepository.js";
 import type { ObjectStorage } from "./objectStorage.js";
 import {
@@ -18,6 +20,8 @@ import type {
   CloudResult,
   CompleteUploadSessionRequest,
   CompleteUploadSessionResponse,
+  CreateShareLinkRequest,
+  CreateShareLinkResponse,
   CreateUploadSessionRequest,
   CreateUploadSessionResponse,
   DeleteRecordingResponse,
@@ -42,6 +46,8 @@ const RECORDING_LANGUAGE_SET = new Set<string>(RECORDING_LANGUAGES);
 const MAX_UPLOAD_SCALAR_LENGTH = 128;
 const SHA256_HEX_PATTERN = /^[a-f0-9]{64}$/u;
 const DEFAULT_LIST_LIMIT = 20;
+const SHARE_TOKEN_BYTES = 32;
+const MAX_SHARE_TOKEN_ATTEMPTS = 5;
 
 export type CloudRecordingService = {
   createUploadSession(input: {
@@ -71,9 +77,17 @@ export type CloudRecordingService = {
     ownerId: string;
     recordingId: string;
   }): Promise<CloudResult<DeleteRecordingResponse>>;
+  createShareLink(input: {
+    ownerId: string;
+    recordingId: string;
+    input: CreateShareLinkRequest;
+  }): Promise<CloudResult<CreateShareLinkResponse>>;
   getPlaybackDescriptor(input: {
     ownerId: string;
     recordingId: string;
+  }): Promise<CloudResult<CloudPlaybackDescriptor>>;
+  getSharedPlaybackDescriptor(input: {
+    token: string;
   }): Promise<CloudResult<CloudPlaybackDescriptor>>;
 };
 
@@ -82,9 +96,11 @@ export function createCloudRecordingService(deps: {
   objectStorage: ObjectStorage;
   now?: () => Date;
   createId?: (prefix: string) => string;
+  createShareToken?: () => string;
 }): CloudRecordingService {
   const now = deps.now ?? (() => new Date());
   const createId = deps.createId ?? createCounterIdFactory();
+  const createShareToken = deps.createShareToken ?? createSecureShareToken;
 
   return {
     async createUploadSession({ ownerId, input }) {
@@ -302,6 +318,10 @@ export function createCloudRecordingService(deps: {
         if (!deletedAt) {
           return { ok: false, error: { code: "not-found", message: "recording not found" } };
         }
+        await deps.metadata.revokeShareLinksByRecordingId({
+          recordingId: recording.id,
+          revokedAt: deletedAt,
+        });
         return {
           ok: true,
           value: {
@@ -330,6 +350,10 @@ export function createCloudRecordingService(deps: {
           },
         });
         if (write.status === "updated") {
+          await deps.metadata.revokeShareLinksByRecordingId({
+            recordingId: write.recording.id,
+            revokedAt: deletedAt,
+          });
           return {
             ok: true,
             value: { id: write.recording.id, status: "soft_deleted" as const, deletedAt },
@@ -350,6 +374,10 @@ export function createCloudRecordingService(deps: {
           if (!latestDeletedAt) {
             return { ok: false, error: { code: "not-found", message: "recording not found" } };
           }
+          await deps.metadata.revokeShareLinksByRecordingId({
+            recordingId: latest.id,
+            revokedAt: latestDeletedAt,
+          });
           return {
             ok: true,
             value: { id: latest.id, status: "soft_deleted" as const, deletedAt: latestDeletedAt },
@@ -361,44 +389,80 @@ export function createCloudRecordingService(deps: {
         current = latest;
       }
     },
+    async createShareLink({ ownerId, recordingId, input }) {
+      const recording = await deps.metadata.getRecording(recordingId);
+      if (!recording || recording.ownerId !== ownerId || recording.status !== "ready") {
+        return { ok: false, error: { code: "not-found", message: "recording not found" } };
+      }
+
+      const invalid = validateCreateShareLinkInput(input, recording, now());
+      if (invalid) return { ok: false, error: invalid };
+
+      const createdAt = now().toISOString();
+      const expiresAt = input.expiresAt ?? null;
+      for (let attempt = 0; attempt < MAX_SHARE_TOKEN_ATTEMPTS; attempt += 1) {
+        const token = createShareToken();
+        const tokenHash = await sha256Hex(token);
+        const write = await deps.metadata.createShareLink({
+          id: createId("share"),
+          recordingId: recording.id,
+          tokenHash,
+          createdBy: ownerId,
+          createdAt,
+          expiresAt,
+          revokedAt: null,
+        });
+        if (write.status === "created") {
+          return {
+            ok: true,
+            value: {
+              url: buildShareUrl(token, input.startTimeMs),
+              expiresAt,
+            },
+          };
+        }
+      }
+
+      return {
+        ok: false,
+        error: { code: "rate-limited", message: "share token collision retry budget exceeded" },
+      };
+    },
     async getPlaybackDescriptor({ ownerId, recordingId }) {
       const recording = await deps.metadata.getRecording(recordingId);
       if (!recording || recording.ownerId !== ownerId || recording.status !== "ready") {
         return { ok: false, error: { code: "not-found", message: "recording not found" } };
       }
 
-      const assets = await deps.metadata.listAssets(recordingId);
-      const assetsByKind = new Map(assets.map((asset) => [asset.kind, asset]));
-      const missingRequired = REQUIRED_ASSETS.filter((kind) => !assetsByKind.has(kind));
-      if (missingRequired.length > 0) {
-        return {
-          ok: false,
-          error: { code: "not-found", message: "playback descriptor not available" },
-        };
+      return buildPlaybackDescriptor({
+        metadata: deps.metadata,
+        objectStorage: deps.objectStorage,
+        recording,
+        now,
+      });
+    },
+    async getSharedPlaybackDescriptor({ token }) {
+      const tokenHash = await sha256Hex(token);
+      const shareLink = await deps.metadata.findShareLinkByTokenHash(tokenHash);
+      if (
+        !shareLink ||
+        shareLink.revokedAt !== null ||
+        (shareLink.expiresAt !== null && Date.parse(shareLink.expiresAt) <= now().getTime())
+      ) {
+        return { ok: false, error: { code: "not-found", message: "share link not found" } };
       }
 
-      const getUrl = (kind: RecordingAssetKind): string | null => {
-        const asset = assetsByKind.get(kind);
-        return asset ? deps.objectStorage.getAssetUrl(asset.objectKey) : null;
-      };
+      const recording = await deps.metadata.getRecording(shareLink.recordingId);
+      if (!recording || recording.status !== "ready") {
+        return { ok: false, error: { code: "not-found", message: "share link not found" } };
+      }
 
-      return {
-        ok: true,
-        value: {
-          id: recording.id,
-          title: recording.title,
-          durationMs: recording.durationMs,
-          schemaVersion: recording.schemaVersion,
-          manifestUrl: getUrl("manifest")!,
-          metaUrl: getUrl("meta")!,
-          eventsUrl: getUrl("events")!,
-          snapshotsUrl: getUrl("snapshots")!,
-          indexesUrl: getUrl("indexes"),
-          mediaUrl: getUrl("media"),
-          thumbnailUrl: getUrl("thumbnail"),
-          expiresAt: new Date(now().getTime() + PLAYBACK_DESCRIPTOR_TTL_MS).toISOString(),
-        },
-      };
+      return buildPlaybackDescriptor({
+        metadata: deps.metadata,
+        objectStorage: deps.objectStorage,
+        recording,
+        now,
+      });
     },
   };
 }
@@ -446,6 +510,46 @@ function toAssetSummary(asset: CloudRecordingAssetRecord) {
     sizeBytes: asset.sizeBytes,
     mimeType: asset.mimeType,
     validatedAt: asset.validatedAt,
+  };
+}
+
+async function buildPlaybackDescriptor(input: {
+  metadata: MetadataRepository;
+  objectStorage: ObjectStorage;
+  recording: CloudRecordingRecord;
+  now: () => Date;
+}): Promise<CloudResult<CloudPlaybackDescriptor>> {
+  const assets = await input.metadata.listAssets(input.recording.id);
+  const assetsByKind = new Map(assets.map((asset) => [asset.kind, asset]));
+  const missingRequired = REQUIRED_ASSETS.filter((kind) => !assetsByKind.has(kind));
+  if (missingRequired.length > 0) {
+    return {
+      ok: false,
+      error: { code: "not-found", message: "playback descriptor not available" },
+    };
+  }
+
+  const getUrl = (kind: RecordingAssetKind): string | null => {
+    const asset = assetsByKind.get(kind);
+    return asset ? input.objectStorage.getAssetUrl(asset.objectKey) : null;
+  };
+
+  return {
+    ok: true,
+    value: {
+      id: input.recording.id,
+      title: input.recording.title,
+      durationMs: input.recording.durationMs,
+      schemaVersion: input.recording.schemaVersion,
+      manifestUrl: getUrl("manifest")!,
+      metaUrl: getUrl("meta")!,
+      eventsUrl: getUrl("events")!,
+      snapshotsUrl: getUrl("snapshots")!,
+      indexesUrl: getUrl("indexes"),
+      mediaUrl: getUrl("media"),
+      thumbnailUrl: getUrl("thumbnail"),
+      expiresAt: new Date(input.now().getTime() + PLAYBACK_DESCRIPTOR_TTL_MS).toISOString(),
+    },
   };
 }
 
@@ -644,6 +748,44 @@ function validateRenameTitle(title: unknown): CloudApiError | null {
     };
   }
   return null;
+}
+
+function validateCreateShareLinkInput(
+  input: CreateShareLinkRequest,
+  recording: CloudRecordingRecord,
+  currentTime: Date,
+): CloudApiError | null {
+  if (input.expiresAt !== undefined && input.expiresAt !== null) {
+    const expiresAtMs = Date.parse(input.expiresAt);
+    if (!Number.isFinite(expiresAtMs)) {
+      return { code: "bad-request", message: "expiresAt must be an ISO date string or null" };
+    }
+    if (expiresAtMs <= currentTime.getTime()) {
+      return { code: "bad-request", message: "expiresAt must be in the future" };
+    }
+  }
+  if (input.startTimeMs !== undefined) {
+    if (
+      !Number.isSafeInteger(input.startTimeMs) ||
+      input.startTimeMs < 0 ||
+      input.startTimeMs > recording.durationMs
+    ) {
+      return {
+        code: "bad-request",
+        message: "startTimeMs must be a non-negative safe integer within the recording duration",
+      };
+    }
+  }
+  return null;
+}
+
+function buildShareUrl(token: string, startTimeMs: number | undefined): string {
+  const path = `/s/${encodeURIComponent(token)}`;
+  return startTimeMs === undefined ? path : `${path}?t=${startTimeMs}`;
+}
+
+function createSecureShareToken(): string {
+  return randomBytes(SHARE_TOKEN_BYTES).toString("base64url");
 }
 
 function isRecordingAssetKind(value: string): value is RecordingAssetKind {

--- a/apps/api/src/cloud/isoDate.ts
+++ b/apps/api/src/cloud/isoDate.ts
@@ -1,0 +1,8 @@
+const ISO_UTC_INSTANT_PATTERN = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/u;
+
+export function parseIsoUtcInstantMs(value: string): number | null {
+  if (!ISO_UTC_INSTANT_PATTERN.test(value)) return null;
+  const timestamp = Date.parse(value);
+  if (!Number.isFinite(timestamp)) return null;
+  return new Date(timestamp).toISOString() === value ? timestamp : null;
+}

--- a/apps/api/src/cloud/memoryMetadataRepository.ts
+++ b/apps/api/src/cloud/memoryMetadataRepository.ts
@@ -1,7 +1,12 @@
-import type { CreateUploadWriteResult, MetadataRepository } from "./metadataRepository.js";
+import type {
+  CreateShareLinkWriteResult,
+  CreateUploadWriteResult,
+  MetadataRepository,
+} from "./metadataRepository.js";
 import type {
   CloudRecordingAssetRecord,
   CloudRecordingRecord,
+  CloudRecordingShareLinkRecord,
   UploadSessionRecord,
 } from "./types.js";
 
@@ -10,6 +15,8 @@ export function createMemoryMetadataRepository(): MetadataRepository {
   const sessions = new Map<string, UploadSessionRecord>();
   const assetsByRecording = new Map<string, CloudRecordingAssetRecord[]>();
   const sessionIdByIdempotencyKey = new Map<string, string>();
+  const shareLinks = new Map<string, CloudRecordingShareLinkRecord>();
+  const shareLinkIdByTokenHash = new Map<string, string>();
 
   return {
     async findSessionByOwnerAndIdempotencyKey(
@@ -69,6 +76,35 @@ export function createMemoryMetadataRepository(): MetadataRepository {
         input.assets.map((asset) => ({ ...asset })),
       );
       return { status: "created" };
+    },
+    async createShareLink(
+      shareLink: CloudRecordingShareLinkRecord,
+    ): Promise<CreateShareLinkWriteResult> {
+      const existingShareLinkId = shareLinkIdByTokenHash.get(shareLink.tokenHash);
+      if (existingShareLinkId && shareLinks.has(existingShareLinkId)) {
+        return { status: "token-hash-exists" };
+      }
+      shareLinks.set(shareLink.id, { ...shareLink });
+      shareLinkIdByTokenHash.set(shareLink.tokenHash, shareLink.id);
+      return { status: "created" };
+    },
+    async findShareLinkByTokenHash(
+      tokenHash: string,
+    ): Promise<CloudRecordingShareLinkRecord | null> {
+      const shareLinkId = shareLinkIdByTokenHash.get(tokenHash);
+      if (!shareLinkId) return null;
+      const shareLink = shareLinks.get(shareLinkId);
+      return shareLink ? { ...shareLink } : null;
+    },
+    async revokeShareLinksByRecordingId(input: {
+      recordingId: string;
+      revokedAt: string;
+    }): Promise<void> {
+      for (const shareLink of shareLinks.values()) {
+        if (shareLink.recordingId === input.recordingId && shareLink.revokedAt === null) {
+          shareLinks.set(shareLink.id, { ...shareLink, revokedAt: input.revokedAt });
+        }
+      }
     },
     async markUploadCompleted(input: {
       sessionId: string;

--- a/apps/api/src/cloud/metadataRepository.ts
+++ b/apps/api/src/cloud/metadataRepository.ts
@@ -1,12 +1,17 @@
 import type {
   CloudRecordingAssetRecord,
   CloudRecordingRecord,
+  CloudRecordingShareLinkRecord,
   UploadSessionRecord,
 } from "./types.js";
 
 export type CreateUploadWriteResult =
   | { status: "created" }
   | { status: "idempotency-key-exists"; existingSession: UploadSessionRecord };
+
+export type CreateShareLinkWriteResult =
+  | { status: "created" }
+  | { status: "token-hash-exists" };
 
 export type UpdateRecordingIfStatusResult =
   | { status: "updated"; recording: CloudRecordingRecord }
@@ -36,6 +41,14 @@ export type MetadataRepository = {
     assets: CloudRecordingAssetRecord[];
     session: UploadSessionRecord;
   }): Promise<CreateUploadWriteResult>;
+  createShareLink(
+    shareLink: CloudRecordingShareLinkRecord,
+  ): Promise<CreateShareLinkWriteResult>;
+  findShareLinkByTokenHash(tokenHash: string): Promise<CloudRecordingShareLinkRecord | null>;
+  revokeShareLinksByRecordingId(input: {
+    recordingId: string;
+    revokedAt: string;
+  }): Promise<void>;
   markUploadCompleted(input: {
     sessionId: string;
     completedAt: string;

--- a/apps/api/src/cloud/types.ts
+++ b/apps/api/src/cloud/types.ts
@@ -171,6 +171,16 @@ export type DeleteRecordingResponse = {
   deletedAt: string;
 };
 
+export type CreateShareLinkRequest = {
+  expiresAt?: string | null;
+  startTimeMs?: number;
+};
+
+export type CreateShareLinkResponse = {
+  url: string;
+  expiresAt: string | null;
+};
+
 export type ListRecordingsResponse = {
   items: CloudRecordingListItem[];
   nextCursor: string | null;
@@ -220,4 +230,14 @@ export type UploadSessionRecord = {
   idempotencyKey: string;
   createdAt: string;
   completedAt: string | null;
+};
+
+export type CloudRecordingShareLinkRecord = {
+  id: string;
+  recordingId: string;
+  tokenHash: string;
+  createdBy: string | null;
+  createdAt: string;
+  expiresAt: string | null;
+  revokedAt: string | null;
 };

--- a/apps/api/src/http/__tests__/cloudApiHandler.test.ts
+++ b/apps/api/src/http/__tests__/cloudApiHandler.test.ts
@@ -568,6 +568,44 @@ test("POST /api/recordings/:recordingId/share-links creates a timestamped unlist
   assert.equal(body.expiresAt, null);
 });
 
+test("POST /api/recordings/:recordingId/share-links rejects parseable non-ISO expiresAt strings", async () => {
+  const metadata = createMemoryMetadataRepository();
+  await seedRecordingWithAssets(metadata, {
+    id: "rec-share-non-iso-expiry",
+    ownerId: "owner-1",
+    status: "ready",
+  }, ["manifest", "meta", "events", "snapshots"]);
+  const handler = createCloudApiHandler({
+    service: createCloudRecordingService({
+      metadata,
+      objectStorage: createMemoryObjectStorage(),
+      now: () => new Date("2026-05-29T00:00:00.000Z"),
+    }),
+    createRequestId: () => "req-share-non-iso-expiry",
+  });
+
+  const response = await handler(
+    new Request("http://localhost/api/recordings/rec-share-non-iso-expiry/share-links", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-owner-token": "owner-1",
+      },
+      body: JSON.stringify({ expiresAt: "May 30, 2026" }),
+    }),
+  );
+  const body = (await response.json()) as { error: { code: string; message: string; requestId: string } };
+
+  assert.equal(response.status, 400);
+  assert.deepEqual(body, {
+    error: {
+      code: "bad-request",
+      message: "expiresAt must be an ISO date string or null",
+      requestId: "req-share-non-iso-expiry",
+    },
+  });
+});
+
 test("GET /api/share/:token/playback returns a shared playback descriptor without owner token", async () => {
   const metadata = createMemoryMetadataRepository();
   const objectStorage = createLocalDevObjectStorage({ publicBaseUrl: "http://localhost" });

--- a/apps/api/src/http/__tests__/cloudApiHandler.test.ts
+++ b/apps/api/src/http/__tests__/cloudApiHandler.test.ts
@@ -561,11 +561,22 @@ test("POST /api/recordings/:recordingId/share-links creates a timestamped unlist
     }),
   );
   const body = (await response.json()) as { url: string; expiresAt: string | null };
+  const detailResponse = await handler(
+    new Request("http://localhost/api/recordings/rec-share-ready", {
+      method: "GET",
+      headers: { "x-owner-token": "owner-1" },
+    }),
+  );
+  const detailBody = (await detailResponse.json()) as {
+    recording: { visibility: string };
+  };
 
   assert.equal(response.status, 201);
   assert.equal(response.headers.get("x-request-id"), "req-share-create");
   assert.match(body.url, /^\/s\/[A-Za-z0-9_-]+\?t=4200$/u);
   assert.equal(body.expiresAt, null);
+  assert.equal(detailResponse.status, 200);
+  assert.equal(detailBody.recording.visibility, "unlisted");
 });
 
 test("POST /api/recordings/:recordingId/share-links rejects parseable non-ISO expiresAt strings", async () => {
@@ -646,6 +657,40 @@ test("GET /api/share/:token/playback returns a shared playback descriptor withou
   assert.equal(response.status, 200);
   assert.equal(body.id, "rec-shared-playback");
   assert.equal(body.mediaUrl, buildLocalDevObjectUrl("http://localhost", "recordings/rec-shared-playback/media/media.webm"));
+});
+
+test("GET /api/share/:token/playback returns the same 404 for random and malformed tokens", async () => {
+  const handler = createCloudApiHandler({
+    service: createCloudRecordingService({
+      metadata: createMemoryMetadataRepository(),
+      objectStorage: createMemoryObjectStorage(),
+    }),
+    createRequestId: () => "req-shared-invalid",
+  });
+
+  const randomTokenResponse = await handler(
+    new Request("http://localhost/api/share/not-a-real-token/playback", { method: "GET" }),
+  );
+  const malformedTokenResponse = await handler(
+    new Request("http://localhost/api/share/%E0%A4%A/playback", { method: "GET" }),
+  );
+  const randomTokenBody = (await randomTokenResponse.json()) as {
+    error: { code: string; message: string; requestId: string };
+  };
+  const malformedTokenBody = (await malformedTokenResponse.json()) as {
+    error: { code: string; message: string; requestId: string };
+  };
+
+  assert.equal(randomTokenResponse.status, 404);
+  assert.equal(malformedTokenResponse.status, 404);
+  assert.deepEqual(randomTokenBody, {
+    error: {
+      code: "not-found",
+      message: "share link not found",
+      requestId: "req-shared-invalid",
+    },
+  });
+  assert.deepEqual(malformedTokenBody, randomTokenBody);
 });
 
 test("POST /api/recordings/:recordingId/share-links returns 404 for owner mismatch and non-ready recordings", async () => {

--- a/apps/api/src/http/__tests__/cloudApiHandler.test.ts
+++ b/apps/api/src/http/__tests__/cloudApiHandler.test.ts
@@ -534,6 +534,195 @@ test("GET /api/recordings/:recordingId/playback requires owner token", async () 
   });
 });
 
+test("POST /api/recordings/:recordingId/share-links creates a timestamped unlisted link for a ready owner recording", async () => {
+  const metadata = createMemoryMetadataRepository();
+  await seedRecordingWithAssets(metadata, {
+    id: "rec-share-ready",
+    ownerId: "owner-1",
+    status: "ready",
+  }, ["manifest", "meta", "events", "snapshots"]);
+  const handler = createCloudApiHandler({
+    service: createCloudRecordingService({
+      metadata,
+      objectStorage: createMemoryObjectStorage(),
+      now: () => new Date("2026-05-29T00:00:00.000Z"),
+    }),
+    createRequestId: () => "req-share-create",
+  });
+
+  const response = await handler(
+    new Request("http://localhost/api/recordings/rec-share-ready/share-links", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-owner-token": "owner-1",
+      },
+      body: JSON.stringify({ expiresAt: null, startTimeMs: 4_200 }),
+    }),
+  );
+  const body = (await response.json()) as { url: string; expiresAt: string | null };
+
+  assert.equal(response.status, 201);
+  assert.equal(response.headers.get("x-request-id"), "req-share-create");
+  assert.match(body.url, /^\/s\/[A-Za-z0-9_-]+\?t=4200$/u);
+  assert.equal(body.expiresAt, null);
+});
+
+test("GET /api/share/:token/playback returns a shared playback descriptor without owner token", async () => {
+  const metadata = createMemoryMetadataRepository();
+  const objectStorage = createLocalDevObjectStorage({ publicBaseUrl: "http://localhost" });
+  await seedRecordingWithAssets(metadata, {
+    id: "rec-shared-playback",
+    ownerId: "owner-1",
+    status: "ready",
+    hasAudio: true,
+  }, ["manifest", "meta", "events", "snapshots", "media"]);
+  const handler = createCloudApiHandler({
+    service: createCloudRecordingService({
+      metadata,
+      objectStorage,
+      now: () => new Date("2026-05-29T00:00:00.000Z"),
+    }),
+    createRequestId: () => "req-shared-playback",
+  });
+
+  const shareResponse = await handler(
+    new Request("http://localhost/api/recordings/rec-shared-playback/share-links", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-owner-token": "owner-1",
+      },
+      body: JSON.stringify({ startTimeMs: 12_000 }),
+    }),
+  );
+  const shareBody = (await shareResponse.json()) as { url: string };
+  const token = shareBody.url.split("/s/")[1]!.split("?")[0]!;
+
+  const response = await handler(
+    new Request(`http://localhost/api/share/${token}/playback`, { method: "GET" }),
+  );
+  const body = (await response.json()) as { id: string; mediaUrl: string | null };
+
+  assert.equal(shareResponse.status, 201);
+  assert.equal(response.status, 200);
+  assert.equal(body.id, "rec-shared-playback");
+  assert.equal(body.mediaUrl, buildLocalDevObjectUrl("http://localhost", "recordings/rec-shared-playback/media/media.webm"));
+});
+
+test("POST /api/recordings/:recordingId/share-links returns 404 for owner mismatch and non-ready recordings", async () => {
+  const metadata = createMemoryMetadataRepository();
+  await seedRecordingWithAssets(metadata, {
+    id: "rec-share-other-owner",
+    ownerId: "owner-2",
+    status: "ready",
+  }, ["manifest", "meta", "events", "snapshots"]);
+  await seedRecordingWithAssets(metadata, {
+    id: "rec-share-processing",
+    ownerId: "owner-1",
+    status: "processing",
+  }, ["manifest", "meta", "events", "snapshots"]);
+  const handler = createCloudApiHandler({
+    service: createCloudRecordingService({
+      metadata,
+      objectStorage: createMemoryObjectStorage(),
+      now: () => new Date("2026-05-29T00:00:00.000Z"),
+    }),
+    createRequestId: () => "req-share-not-found",
+  });
+
+  for (const id of ["rec-share-other-owner", "rec-share-processing", "rec-share-missing"]) {
+    const response = await handler(
+      new Request(`http://localhost/api/recordings/${id}/share-links`, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-owner-token": "owner-1",
+        },
+        body: JSON.stringify({}),
+      }),
+    );
+    const body = (await response.json()) as { error: { code: string; message: string; requestId: string } };
+
+    assert.equal(response.status, 404);
+    assert.deepEqual(body, {
+      error: {
+        code: "not-found",
+        message: "recording not found",
+        requestId: "req-share-not-found",
+      },
+    });
+  }
+});
+
+test("GET /api/share/:token/playback returns 404 after the share expires or the recording is deleted", async () => {
+  const metadata = createMemoryMetadataRepository();
+  await seedRecordingWithAssets(metadata, {
+    id: "rec-share-expiring",
+    ownerId: "owner-1",
+    status: "ready",
+  }, ["manifest", "meta", "events", "snapshots"]);
+  await seedRecordingWithAssets(metadata, {
+    id: "rec-share-deleted",
+    ownerId: "owner-1",
+    status: "ready",
+  }, ["manifest", "meta", "events", "snapshots"]);
+  let now = new Date("2026-05-29T00:00:00.000Z");
+  const handler = createCloudApiHandler({
+    service: createCloudRecordingService({
+      metadata,
+      objectStorage: createMemoryObjectStorage(),
+      now: () => now,
+    }),
+    createRequestId: () => "req-shared-expired",
+  });
+
+  const expiringShare = await handler(
+    new Request("http://localhost/api/recordings/rec-share-expiring/share-links", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-owner-token": "owner-1",
+      },
+      body: JSON.stringify({ expiresAt: "2026-05-30T00:00:00.000Z" }),
+    }),
+  );
+  const deletedShare = await handler(
+    new Request("http://localhost/api/recordings/rec-share-deleted/share-links", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-owner-token": "owner-1",
+      },
+      body: JSON.stringify({}),
+    }),
+  );
+  const expiringToken = ((await expiringShare.json()) as { url: string }).url.split("/s/")[1]!;
+  const deletedToken = ((await deletedShare.json()) as { url: string }).url.split("/s/")[1]!;
+
+  now = new Date("2026-05-31T00:00:00.000Z");
+  const expiredResponse = await handler(
+    new Request(`http://localhost/api/share/${expiringToken}/playback`, { method: "GET" }),
+  );
+
+  now = new Date("2026-05-29T00:01:00.000Z");
+  const deleteResponse = await handler(
+    new Request("http://localhost/api/recordings/rec-share-deleted", {
+      method: "DELETE",
+      headers: { "x-owner-token": "owner-1" },
+    }),
+  );
+  const deletedPlaybackResponse = await handler(
+    new Request(`http://localhost/api/share/${deletedToken}/playback`, { method: "GET" }),
+  );
+
+  assert.equal(expiringShare.status, 201);
+  assert.equal(deletedShare.status, 201);
+  assert.equal(deleteResponse.status, 200);
+  assert.equal(expiredResponse.status, 404);
+  assert.equal(deletedPlaybackResponse.status, 404);
+});
+
 test("GET /api/recordings/:recordingId requires owner token", async () => {
   const handler = createCloudApiHandler({
     service: createCloudRecordingService({

--- a/apps/api/src/http/cloudApiHandler.ts
+++ b/apps/api/src/http/cloudApiHandler.ts
@@ -5,6 +5,7 @@ import type {
   CloudApiErrorCode,
   CloudResult,
   CompleteUploadSessionRequest,
+  CreateShareLinkRequest,
   CreateUploadSessionRequest,
   RecordingAssetKind,
   RenameRecordingRequest,
@@ -32,6 +33,7 @@ const SHA256_HEX_PATTERN = /^[a-f0-9]{64}$/u;
 // POST .../complete 请求体严格字段白名单：只允许这些 key
 const COMPLETE_TOP_KEYS = new Set(["uploadedAssets"]);
 const COMPLETE_ASSET_KEYS = new Set(["kind", "sha256", "sizeBytes"]);
+const SHARE_TOP_KEYS = new Set(["expiresAt", "startTimeMs"]);
 
 export function createCloudApiHandler(deps: {
   service: CloudRecordingService;
@@ -76,6 +78,43 @@ export function createCloudApiHandler(deps: {
       });
       if (!result.ok) return jsonError({ ...result.error, requestId }, requestId);
       return jsonResponse(result.value, 200, requestId);
+    }
+
+    const sharedPlaybackMatch = url.pathname.match(/^\/api\/share\/([^/]+)\/playback$/);
+    if (request.method === "GET" && sharedPlaybackMatch) {
+      const token = safeDecodePathSegment(sharedPlaybackMatch[1]!, "share token");
+      if (!token.ok) {
+        return jsonError({ ...token.error, requestId }, requestId);
+      }
+      const result = await deps.service.getSharedPlaybackDescriptor({ token: token.value });
+      if (!result.ok) return jsonError({ ...result.error, requestId }, requestId);
+      return jsonResponse(result.value, 200, requestId);
+    }
+
+    const shareLinkMatch = url.pathname.match(/^\/api\/recordings\/([^/]+)\/share-links$/);
+    if (request.method === "POST" && shareLinkMatch) {
+      const ownerId = readOwnerToken(request);
+      if (!ownerId) {
+        return jsonError(
+          { code: "unauthorized", message: "missing owner token", requestId },
+          requestId,
+        );
+      }
+      const recordingId = safeDecodePathSegment(shareLinkMatch[1]!);
+      if (!recordingId.ok) {
+        return jsonError({ ...recordingId.error, requestId }, requestId);
+      }
+      const parsed = await readJsonObject(request);
+      if (!parsed.ok) return jsonError({ ...parsed.error, requestId }, requestId);
+      const input = parseCreateShareLinkRequest(parsed.value);
+      if (!input.ok) return jsonError({ ...input.error, requestId }, requestId);
+      const result = await deps.service.createShareLink({
+        ownerId,
+        recordingId: recordingId.value,
+        input: input.value,
+      });
+      if (!result.ok) return jsonError({ ...result.error, requestId }, requestId);
+      return jsonResponse(result.value, 201, requestId);
     }
 
     const recordingDetailMatch = url.pathname.match(/^\/api\/recordings\/([^/]+)$/);
@@ -356,6 +395,40 @@ function parseRenameRecordingRequest(
   return { ok: true, value: { title: value.title } };
 }
 
+function parseCreateShareLinkRequest(
+  value: Record<string, unknown>,
+): CloudResult<CreateShareLinkRequest> {
+  for (const key of Object.keys(value)) {
+    if (!SHARE_TOP_KEYS.has(key)) {
+      return { ok: false, error: badRequestError(`unknown field: ${key}`) };
+    }
+  }
+
+  const input: CreateShareLinkRequest = {};
+  if ("expiresAt" in value) {
+    if (value.expiresAt === null) {
+      input.expiresAt = null;
+    } else if (isString(value.expiresAt) && Number.isFinite(Date.parse(value.expiresAt))) {
+      input.expiresAt = value.expiresAt;
+    } else {
+      return {
+        ok: false,
+        error: badRequestError("expiresAt must be an ISO date string or null"),
+      };
+    }
+  }
+  if ("startTimeMs" in value) {
+    if (!isPositiveOrZeroSafeInteger(value.startTimeMs)) {
+      return {
+        ok: false,
+        error: badRequestError("startTimeMs must be a non-negative safe integer"),
+      };
+    }
+    input.startTimeMs = value.startTimeMs;
+  }
+  return { ok: true, value: input };
+}
+
 function isRecordingAssetKind(value: string): value is RecordingAssetKind {
   return RECORDING_ASSET_KIND_SET.has(value);
 }
@@ -372,18 +445,22 @@ function isPositiveSafeInteger(value: unknown): value is number {
   return typeof value === "number" && Number.isSafeInteger(value) && value > 0;
 }
 
+function isPositiveOrZeroSafeInteger(value: unknown): value is number {
+  return typeof value === "number" && Number.isSafeInteger(value) && value >= 0;
+}
+
 function readOwnerToken(request: Request): string | null {
   const token = request.headers.get("x-owner-token")?.trim();
   return token ? token : null;
 }
 
-function safeDecodePathSegment(segment: string): CloudResult<string> {
+function safeDecodePathSegment(segment: string, label = "recordingId"): CloudResult<string> {
   try {
     return { ok: true, value: decodeURIComponent(segment) };
   } catch {
     return {
       ok: false,
-      error: { code: "bad-request", message: "recordingId path segment is malformed" },
+      error: { code: "bad-request", message: `${label} path segment is malformed` },
     };
   }
 }

--- a/apps/api/src/http/cloudApiHandler.ts
+++ b/apps/api/src/http/cloudApiHandler.ts
@@ -85,7 +85,10 @@ export function createCloudApiHandler(deps: {
     if (request.method === "GET" && sharedPlaybackMatch) {
       const token = safeDecodePathSegment(sharedPlaybackMatch[1]!, "share token");
       if (!token.ok) {
-        return jsonError({ ...token.error, requestId }, requestId);
+        return jsonError(
+          { code: "not-found", message: "share link not found", requestId },
+          requestId,
+        );
       }
       const result = await deps.service.getSharedPlaybackDescriptor({ token: token.value });
       if (!result.ok) return jsonError({ ...result.error, requestId }, requestId);

--- a/apps/api/src/http/cloudApiHandler.ts
+++ b/apps/api/src/http/cloudApiHandler.ts
@@ -1,4 +1,5 @@
 import type { CloudRecordingService } from "../cloud/cloudRecordingService.js";
+import { parseIsoUtcInstantMs } from "../cloud/isoDate.js";
 import { RECORDING_ASSET_KINDS } from "../cloud/types.js";
 import type {
   CloudApiError,
@@ -408,7 +409,7 @@ function parseCreateShareLinkRequest(
   if ("expiresAt" in value) {
     if (value.expiresAt === null) {
       input.expiresAt = null;
-    } else if (isString(value.expiresAt) && Number.isFinite(Date.parse(value.expiresAt))) {
+    } else if (isString(value.expiresAt) && parseIsoUtcInstantMs(value.expiresAt) !== null) {
       input.expiresAt = value.expiresAt;
     } else {
       return {

--- a/apps/web/src/app/__tests__/routes.test.tsx
+++ b/apps/web/src/app/__tests__/routes.test.tsx
@@ -7,5 +7,6 @@ describe("appRoutes", () => {
 
     expect(childPaths).toContain("replays/:id");
     expect(childPaths).toContain("cloud/replay/:id");
+    expect(childPaths).toContain("s/:token");
   });
 });

--- a/apps/web/src/app/routes.tsx
+++ b/apps/web/src/app/routes.tsx
@@ -19,6 +19,7 @@ export const appRoutes: RouteObject[] = [
       { path: "interview/candidate/:roomId?", element: <CandidateInterviewPage /> },
       { path: "replays/:id", element: <ReplayPage source="cloud" /> },
       { path: "cloud/replay/:id", element: <ReplayPage source="cloud" /> },
+      { path: "s/:token", element: <ReplayPage source="share" /> },
       { path: "interview/interviewer/:roomId", element: <RemoteInterviewWorkbenchPage /> },
       { path: "*", element: <NotFoundPage /> },
     ],

--- a/apps/web/src/features/cloud/__tests__/cloudRecordingRepository.test.ts
+++ b/apps/web/src/features/cloud/__tests__/cloudRecordingRepository.test.ts
@@ -689,6 +689,69 @@ describe("CloudRecordingRepository", () => {
   });
 
   // ───────────────────────────────────────────────────────
+  // share links（云端分享）
+  // ───────────────────────────────────────────────────────
+
+  describe("share links", () => {
+    it("creates a share link with owner token and timestamp payload", async () => {
+      const repo = setupRepo();
+      mockFetch(201, { url: "/s/share-token?t=4200", expiresAt: null });
+
+      const result = await repo.createShareLink("rec_1", { startTimeMs: 4_200 });
+
+      expect(result.ok).toBe(true);
+      if (!result.ok) throw new Error("expected ok");
+      expect(result.value.url).toBe("/s/share-token?t=4200");
+      expect(result.value.expiresAt).toBe(null);
+      expect(fetch).toHaveBeenCalledWith(
+        "/api/recordings/rec_1/share-links",
+        expect.objectContaining({
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            "x-owner-token": repo.getOwnerToken(),
+          },
+          body: JSON.stringify({ startTimeMs: 4_200 }),
+        }),
+      );
+    });
+
+    it("loads shared playback descriptor without owner token", async () => {
+      const repo = setupRepo();
+      mockFetch(200, makePlaybackDescriptor({ id: "rec_shared" }));
+
+      const result = await repo.getSharedPlaybackDescriptor("share token");
+
+      expect(result.ok).toBe(true);
+      if (!result.ok) throw new Error("expected ok");
+      expect(result.value.id).toBe("rec_shared");
+      expect(fetch).toHaveBeenCalledWith(
+        "/api/share/share%20token/playback",
+        expect.objectContaining({
+          method: "GET",
+        }),
+      );
+      const [, init] = vi.mocked(fetch).mock.calls[0];
+      expect((init as RequestInit).headers).toBeUndefined();
+    });
+
+    it("returns structured errors when share link creation fails", async () => {
+      const repo = setupRepo();
+      mockFetch(404, {
+        error: { code: "not-found", message: "recording not found" },
+      }, { "x-request-id": "req-share-1" });
+
+      const result = await repo.createShareLink("rec_missing", {});
+
+      expect(result.ok).toBe(false);
+      if (result.ok) throw new Error("expected failure");
+      expect(result.error.code).toBe("not-found");
+      expect(result.error.message).toBe("recording not found");
+      expect(result.error.requestId).toBe("req-share-1");
+    });
+  });
+
+  // ───────────────────────────────────────────────────────
   // rename（云端重命名）
   // ───────────────────────────────────────────────────────
 

--- a/apps/web/src/features/cloud/cloudRecordingRepository.ts
+++ b/apps/web/src/features/cloud/cloudRecordingRepository.ts
@@ -30,6 +30,8 @@ import type {
   CompleteUploadSessionResponse,
   CreateUploadSessionRequest,
   CreateUploadSessionResponse,
+  CreateShareLinkRequest,
+  CreateShareLinkResponse,
   CloudPlaybackDescriptor,
   ListRecordingsInput,
   ListRecordingsResponse,
@@ -201,6 +203,45 @@ export function createCloudRecordingRepository(
         return handleJsonResponse<CloudPlaybackDescriptor>(response);
       } catch (err) {
         return { ok: false, error: networkError("get playback descriptor failed", err) };
+      }
+    },
+
+    // ── 创建分享链接 ──────────────────────────────────────
+    async createShareLink(
+      recordingId: string,
+      input: CreateShareLinkRequest,
+    ): Promise<CloudResult<CreateShareLinkResponse>> {
+      const token = repo.getOwnerToken();
+      try {
+        const response = await fetch(
+          `${apiBase}/api/recordings/${encodeURIComponent(recordingId)}/share-links`,
+          {
+            method: "POST",
+            headers: {
+              "content-type": "application/json",
+              "x-owner-token": token,
+            },
+            body: JSON.stringify(input),
+          },
+        );
+        return handleJsonResponse<CreateShareLinkResponse>(response);
+      } catch (err) {
+        return { ok: false, error: networkError("create share link failed", err) };
+      }
+    },
+
+    // ── 通过分享 token 获取播放描述 ───────────────────────
+    async getSharedPlaybackDescriptor(
+      token: string,
+    ): Promise<CloudResult<CloudPlaybackDescriptor>> {
+      try {
+        const response = await fetch(
+          `${apiBase}/api/share/${encodeURIComponent(token)}/playback`,
+          { method: "GET" },
+        );
+        return handleJsonResponse<CloudPlaybackDescriptor>(response);
+      } catch (err) {
+        return { ok: false, error: networkError("get shared playback descriptor failed", err) };
       }
     },
 

--- a/apps/web/src/features/cloud/types.ts
+++ b/apps/web/src/features/cloud/types.ts
@@ -114,6 +114,16 @@ export type CompleteUploadSessionResponse = {
   status: "processing" | "ready" | "failed";
 };
 
+export type CreateShareLinkRequest = {
+  expiresAt?: string | null;
+  startTimeMs?: number;
+};
+
+export type CreateShareLinkResponse = {
+  url: string;
+  expiresAt: string | null;
+};
+
 // ─────────────────────────────────────────────────────────────
 // 录制详情与列表（与后端 CloudRecordingListItem / CloudRecordingDetail 契约一致）
 // ─────────────────────────────────────────────────────────────
@@ -252,6 +262,15 @@ export type CloudRecordingRepository = {
 
   /** 获取 ready 录制的云端播放描述 */
   getPlaybackDescriptor(recordingId: string): Promise<CloudResult<CloudPlaybackDescriptor>>;
+
+  /** 为当前 owner 的 ready 云端录制创建分享链接 */
+  createShareLink(
+    recordingId: string,
+    input: CreateShareLinkRequest,
+  ): Promise<CloudResult<CreateShareLinkResponse>>;
+
+  /** 通过分享 token 获取只读播放描述，无需 owner token */
+  getSharedPlaybackDescriptor(token: string): Promise<CloudResult<CloudPlaybackDescriptor>>;
 
   /** 重命名当前 owner 可访问的云端录制 */
   rename(recordingId: string, title: string): Promise<CloudResult<void>>;

--- a/apps/web/src/features/library/RecordingLibraryPage.tsx
+++ b/apps/web/src/features/library/RecordingLibraryPage.tsx
@@ -1,5 +1,6 @@
 import { type ChangeEvent, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
+import { Share2 } from "lucide-react";
 import { downloadBlob, safeFilenameStem } from "./recordingDownload";
 import { createRecordingStore } from "./recordingStore";
 import { createCloudRecordingRepository } from "@/features/cloud/cloudRecordingRepository";
@@ -180,6 +181,20 @@ export function RecordingLibraryPage() {
       openFeedbackDialog("success", `已导出「${item.title}」。`);
     } catch (err) {
       openFeedbackDialog("error", `导出失败：${(err as Error).message}`);
+    } finally {
+      setBusyKey(null);
+    }
+  };
+
+  const handleShare = async (item: CloudRecordingListItem) => {
+    setBusyKey(`share-${item.id}`);
+    try {
+      const result = await cloudRepository.createShareLink(item.id, {});
+      if (!result.ok) throw new Error(formatCloudError(result.error));
+      await writeClipboard(buildAbsoluteShareUrl(result.value.url));
+      openFeedbackDialog("success", "分享链接已复制。");
+    } catch (err) {
+      openFeedbackDialog("error", `分享失败：${(err as Error).message}`);
     } finally {
       setBusyKey(null);
     }
@@ -410,6 +425,16 @@ export function RecordingLibraryPage() {
                         onClick={() => navigate(replayPath(view, item.id))}
                         disabled={busyKey !== null || importing}
                       />
+                      {view === "cloud" ? (
+                        <IconButton
+                          icon={<Share2 aria-hidden size={14} />}
+                          label="复制分享链接"
+                          variant="ghost"
+                          size="sm"
+                          onClick={() => void handleShare(item as CloudRecordingListItem)}
+                          disabled={busyKey !== null || importing}
+                        />
+                      ) : null}
                       <Popover
                         open={pendingRenameId === item.id}
                         onOpenChange={(open) => {
@@ -710,6 +735,25 @@ function buildSaveResultError(result: Extract<SaveResult, { ok: false }>): strin
 
 function replayPath(view: "local" | "cloud", recordingId: string): string {
   return view === "cloud" ? `/replays/${recordingId}` : `/replay/${recordingId}`;
+}
+
+function buildAbsoluteShareUrl(url: string): string {
+  const basePath = normalizeBasePath(import.meta.env.BASE_URL ?? "/");
+  const path = url.startsWith("/") ? `${basePath}${url}` : url;
+  return new URL(path, window.location.origin).toString();
+}
+
+function normalizeBasePath(baseUrl: string): string {
+  const normalized = baseUrl.trim();
+  if (!normalized || normalized === "/") return "";
+  return normalized.endsWith("/") ? normalized.slice(0, -1) : normalized;
+}
+
+async function writeClipboard(value: string): Promise<void> {
+  if (!navigator.clipboard?.writeText) {
+    throw new Error("浏览器不支持剪贴板写入");
+  }
+  await navigator.clipboard.writeText(value);
 }
 
 function tabClassName(active: boolean): string {

--- a/apps/web/src/features/library/__tests__/RecordingLibraryPage.test.tsx
+++ b/apps/web/src/features/library/__tests__/RecordingLibraryPage.test.tsx
@@ -30,6 +30,8 @@ const cloudRepositoryMocks = {
   pollUntilReady: vi.fn(),
   list: vi.fn(),
   getPlaybackDescriptor: vi.fn(),
+  getSharedPlaybackDescriptor: vi.fn(),
+  createShareLink: vi.fn(),
   rename: vi.fn(),
   remove: vi.fn(),
   getOwnerToken: vi.fn(),
@@ -113,6 +115,10 @@ describe("RecordingLibraryPage", () => {
     cloudRepositoryMocks.list.mockResolvedValue({
       ok: true,
       value: { items: [], nextCursor: null },
+    });
+    cloudRepositoryMocks.createShareLink.mockResolvedValue({
+      ok: true,
+      value: { url: "/s/share-token?t=4200", expiresAt: null },
     });
     cloudRepositoryMocks.rename.mockResolvedValue({ ok: true, value: undefined });
     cloudRepositoryMocks.remove.mockResolvedValue({ ok: true, value: undefined });
@@ -458,6 +464,30 @@ describe("RecordingLibraryPage", () => {
     expect(screen.getByText(/JavaScript/)).toBeInTheDocument();
     expect(screen.getByText(/\u65e0\u97f3\u9891/)).toBeInTheDocument();
     expect(screen.getByText(/\u6444\u50cf\u5934/)).toBeInTheDocument();
+  });
+
+  it("copies a cloud recording share link", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText },
+    });
+    cloudRepositoryMocks.list.mockResolvedValue({
+      ok: true,
+      value: { items: [CLOUD_ITEM], nextCursor: null },
+    });
+    renderPage();
+    await waitForElementToBeRemoved(() => screen.queryByRole("status"));
+
+    fireEvent.click(screen.getByRole("tab", { name: "云端录制" }));
+    await waitForElementToBeRemoved(() => screen.queryByRole("status"));
+    fireEvent.click(screen.getByRole("button", { name: "复制分享链接" }));
+
+    await waitFor(() => {
+      expect(cloudRepositoryMocks.createShareLink).toHaveBeenCalledWith("cloud-1", {});
+    });
+    expect(writeText).toHaveBeenCalledWith(expect.stringContaining("/s/share-token?t=4200"));
+    expect(await screen.findByRole("dialog")).toHaveTextContent("分享链接已复制");
   });
 
   it("renames and deletes cloud recordings through the cloud repository", async () => {

--- a/apps/web/src/features/player/ReplayPage.tsx
+++ b/apps/web/src/features/player/ReplayPage.tsx
@@ -9,7 +9,7 @@ import {
   type SetStateAction,
 } from "react";
 import { Link, useParams, useSearchParams } from "react-router-dom";
-import { Camera, Captions, CircleAlert, Keyboard, MousePointer2, TerminalSquare } from "lucide-react";
+import { Camera, Captions, CircleAlert, Keyboard, MousePointer2, Share2, TerminalSquare } from "lucide-react";
 import { createReplayScheduler, defaultTickStrategy } from "./replayScheduler";
 import { createTimelineClock } from "./timelineClock";
 import { ReplayControls } from "./ReplayControls";
@@ -88,7 +88,7 @@ const DEFAULT_DISPLAY_OPTIONS: ReplayDisplayOptions = {
   runtime: true,
   subtitles: true,
 };
-type ReplaySource = "local" | "cloud";
+type ReplaySource = "local" | "cloud" | "share";
 type ReplayPackageLoader = {
   load(recordingId: string): Promise<PackageLoadResult>;
 };
@@ -118,15 +118,23 @@ export type ReplayPageProps = {
 };
 
 export function ReplayPage({ source = "local" }: ReplayPageProps) {
-  const { id } = useParams();
+  const params = useParams();
+  const id = source === "share" ? params.token : params.id;
   const [searchParams] = useSearchParams();
   const initialSeekTimeMs = parseInitialSeekTimeMs(searchParams.get("t"));
+  const cloudRepository = useMemo(
+    () => (source === "cloud" || source === "share" ? createCloudRecordingRepository() : null),
+    [source],
+  );
   const packageLoader = useMemo<ReplayPackageLoader>(() => {
-    if (source === "cloud") {
-      return createCloudPackageLoader({ repository: createCloudRecordingRepository() });
+    if (source === "cloud" || source === "share") {
+      return createCloudPackageLoader({
+        repository: cloudRepository!,
+        descriptorSource: source === "share" ? "share" : "owner",
+      });
     }
     return createRecordingStore();
-  }, [source]);
+  }, [cloudRepository, source]);
   const runtime = useMemo(() => createIframeRuntime(), []);
   const [schedulerState, setSchedulerState] =
     useState<ReplaySchedulerState>(INITIAL_SCHEDULER_STATE);
@@ -136,6 +144,8 @@ export function ReplayPage({ source = "local" }: ReplayPageProps) {
   const [mediaBlob, setMediaBlob] = useState<Blob | null>(null);
   const [loadError, setLoadError] = useState<string | null>(null);
   const [eventOnlyNotice, setEventOnlyNotice] = useState(false);
+  const [shareBusy, setShareBusy] = useState(false);
+  const [shareFeedback, setShareFeedback] = useState<{ tone: "success" | "error"; message: string } | null>(null);
   const [volume, setVolume] = useState(100);
   const [muted, setMuted] = useState(false);
   const [displayOptions, setDisplayOptions] =
@@ -213,6 +223,25 @@ export function ReplayPage({ source = "local" }: ReplayPageProps) {
     },
     [],
   );
+  const handleShareCurrentTime = useCallback(async () => {
+    if (source !== "cloud" || !id || !cloudRepository) return;
+    setShareBusy(true);
+    setShareFeedback(null);
+    try {
+      const result = await cloudRepository.createShareLink(id, {
+        startTimeMs: Math.floor(schedulerState.timelineTimeMs),
+      });
+      if (!result.ok) {
+        throw new Error(`${result.error.message} (${result.error.code})`);
+      }
+      await writeClipboard(buildAbsoluteShareUrl(result.value.url));
+      setShareFeedback({ tone: "success", message: "分享链接已复制。" });
+    } catch (err) {
+      setShareFeedback({ tone: "error", message: `分享失败：${formatError(err)}` });
+    } finally {
+      setShareBusy(false);
+    }
+  }, [cloudRepository, id, schedulerState.timelineTimeMs, source]);
 
   useEffect(() => scheduler.subscribe(setSchedulerState), [scheduler]);
   useEffect(() => () => scheduler.destroy(), [scheduler]);
@@ -292,7 +321,28 @@ export function ReplayPage({ source = "local" }: ReplayPageProps) {
           </div>
         </div>
       ) : null}
-      <ReplayDisplayToolbar options={displayOptions} onChange={setDisplayOption} />
+      <ReplayDisplayToolbar
+        options={displayOptions}
+        onChange={setDisplayOption}
+        share={
+          source === "cloud"
+            ? { busy: shareBusy, onShare: handleShareCurrentTime }
+            : undefined
+        }
+      />
+      {shareFeedback ? (
+        <div
+          role="status"
+          className={[
+            "border-b px-4 py-2 text-sm",
+            shareFeedback.tone === "error"
+              ? "border-danger/40 bg-danger/10 text-danger"
+              : "border-border bg-surface text-foreground",
+          ].join(" ")}
+        >
+          {shareFeedback.message}
+        </div>
+      ) : null}
       <div
         aria-label="回放工作区"
         className={
@@ -504,9 +554,14 @@ function scheduleOverlayCleanup(
 function ReplayDisplayToolbar({
   options,
   onChange,
+  share,
 }: {
   options: ReplayDisplayOptions;
   onChange(key: keyof ReplayDisplayOptions, value: boolean): void;
+  share?: {
+    busy: boolean;
+    onShare(): void;
+  };
 }) {
   return (
     <div className="flex min-h-11 flex-wrap items-center gap-1 border-b border-border bg-background px-3 py-2">
@@ -540,6 +595,18 @@ function ReplayDisplayToolbar({
         label="显示字幕"
         icon={<Captions size={17} />}
       />
+      {share ? (
+        <button
+          type="button"
+          aria-label="复制当前时间分享链接"
+          title="复制当前时间分享链接"
+          className="inline-flex h-9 w-9 items-center justify-center rounded-md border border-transparent text-foreground/80 transition-[background-color,color] duration-150 ease-out-soft hover:bg-surface hover:text-foreground disabled:cursor-not-allowed disabled:opacity-40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+          onClick={share.onShare}
+          disabled={share.busy}
+        >
+          <Share2 aria-hidden size={17} />
+        </button>
+      ) : null}
     </div>
   );
 }
@@ -675,6 +742,31 @@ function RecordedMediaOverlay({
       />
     </div>
   );
+}
+
+function buildAbsoluteShareUrl(url: string): string {
+  const basePath = normalizeBasePath(import.meta.env.BASE_URL ?? "/");
+  const path = url.startsWith("/") ? `${basePath}${url}` : url;
+  return new URL(path, window.location.origin).toString();
+}
+
+function normalizeBasePath(baseUrl: string): string {
+  const normalized = baseUrl.trim();
+  if (!normalized || normalized === "/") return "";
+  return normalized.endsWith("/") ? normalized.slice(0, -1) : normalized;
+}
+
+async function writeClipboard(value: string): Promise<void> {
+  if (!navigator.clipboard?.writeText) {
+    throw new Error("浏览器不支持剪贴板写入");
+  }
+  await navigator.clipboard.writeText(value);
+}
+
+function formatError(err: unknown): string {
+  if (err instanceof Error) return err.message || err.name;
+  if (typeof err === "string") return err;
+  return "unknown error";
 }
 
 function RuntimeOutputPanel({ runtime }: { runtime: ReplayStableState["runtime"] }) {

--- a/apps/web/src/features/player/__tests__/ReplayPage.test.tsx
+++ b/apps/web/src/features/player/__tests__/ReplayPage.test.tsx
@@ -88,6 +88,8 @@ const replayPageMock = vi.hoisted(() => {
   };
   const cloudRepository = {
     getPlaybackDescriptor: vi.fn(),
+    getSharedPlaybackDescriptor: vi.fn(),
+    createShareLink: vi.fn(),
   };
   const cloudLoader = {
     load: vi.fn<RecordingRepository["load"]>(async () => ({
@@ -110,6 +112,7 @@ const replayPageMock = vi.hoisted(() => {
     createCloudPackageLoader,
     packageData,
     routeId: "recording-1",
+    routeToken: "share-token",
     search: "",
     controlsProps: null as ReplayControlsProps | null,
     codeEditorProps: null as CodeEditorProps | null,
@@ -135,10 +138,17 @@ const replayPageMock = vi.hoisted(() => {
       schedulerState.driftMs = 0;
       repository.load.mockClear();
       cloudRepository.getPlaybackDescriptor.mockClear();
+      cloudRepository.getSharedPlaybackDescriptor.mockClear();
+      cloudRepository.createShareLink.mockClear();
+      cloudRepository.createShareLink.mockResolvedValue({
+        ok: true,
+        value: { url: "/s/share-token", expiresAt: null },
+      });
       cloudLoader.load.mockClear();
       createCloudRecordingRepository.mockClear();
       createCloudPackageLoader.mockClear();
       this.routeId = "recording-1";
+      this.routeToken = "share-token";
       this.search = "";
       this.controlsProps = null;
       this.codeEditorProps = null;
@@ -153,7 +163,7 @@ vi.mock("react-router-dom", async () => {
   const actual = await vi.importActual<typeof ReactRouterDom>("react-router-dom");
   return {
     ...actual,
-    useParams: () => ({ id: replayPageMock.routeId }),
+    useParams: () => ({ id: replayPageMock.routeId, token: replayPageMock.routeToken }),
     useSearchParams: () => [new URLSearchParams(replayPageMock.search), vi.fn()],
   };
 });
@@ -224,9 +234,24 @@ describe("ReplayPage", () => {
     expect(replayPageMock.createCloudRecordingRepository).toHaveBeenCalledTimes(1);
     expect(replayPageMock.createCloudPackageLoader).toHaveBeenCalledWith({
       repository: replayPageMock.cloudRepository,
+      descriptorSource: "owner",
     });
     expect(replayPageMock.repository.load).not.toHaveBeenCalled();
     expect(replayPageMock.scheduler.load).toHaveBeenCalledWith(replayPageMock.packageData);
+  });
+
+  it("loads shared replays through the share descriptor route token", async () => {
+    const { ReplayPage } = await import("../ReplayPage");
+
+    render(<ReplayPage source="share" />);
+
+    await waitFor(() => expect(replayPageMock.cloudLoader.load).toHaveBeenCalledWith("share-token"));
+    expect(replayPageMock.createCloudRecordingRepository).toHaveBeenCalledTimes(1);
+    expect(replayPageMock.createCloudPackageLoader).toHaveBeenCalledWith({
+      repository: replayPageMock.cloudRepository,
+      descriptorSource: "share",
+    });
+    expect(replayPageMock.repository.load).not.toHaveBeenCalled();
   });
 
   it("keeps local replays on IndexedDB by default", async () => {
@@ -262,6 +287,32 @@ describe("ReplayPage", () => {
 
     await waitFor(() => expect(replayPageMock.scheduler.load).toHaveBeenCalledWith(replayPageMock.packageData));
     await waitFor(() => expect(replayPageMock.scheduler.seek).toHaveBeenCalledWith(42_000));
+  });
+
+  it("copies a cloud replay share link with the current timeline time", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText },
+    });
+    replayPageMock.schedulerState.timelineTimeMs = 37_500;
+    replayPageMock.cloudRepository.createShareLink.mockResolvedValueOnce({
+      ok: true,
+      value: { url: "/s/share-token?t=37500", expiresAt: null },
+    });
+    const { ReplayPage } = await import("../ReplayPage");
+
+    render(<ReplayPage source="cloud" />);
+    await waitFor(() => expect(replayPageMock.scheduler.load).toHaveBeenCalledWith(replayPageMock.packageData));
+    fireEvent.click(screen.getByRole("button", { name: "复制当前时间分享链接" }));
+
+    await waitFor(() => {
+      expect(replayPageMock.cloudRepository.createShareLink).toHaveBeenCalledWith(
+        "recording-1",
+        { startTimeMs: 37_500 },
+      );
+    });
+    expect(writeText).toHaveBeenCalledWith(expect.stringContaining("/s/share-token?t=37500"));
   });
 
   it("blocks cloud replay when the cloud loader fails", async () => {

--- a/apps/web/src/features/player/__tests__/cloudPackageLoader.test.ts
+++ b/apps/web/src/features/player/__tests__/cloudPackageLoader.test.ts
@@ -9,7 +9,10 @@ import { canonicalStringify, sha256Hex } from "@/shared/util/hash";
 import type { CloudPlaybackDescriptor, CloudRecordingRepository } from "@/features/cloud/types";
 import { createCloudPackageLoader } from "../cloudPackageLoader";
 
-type DescriptorRepository = Pick<CloudRecordingRepository, "getPlaybackDescriptor">;
+type DescriptorRepository = Pick<
+  CloudRecordingRepository,
+  "getPlaybackDescriptor" | "getSharedPlaybackDescriptor"
+>;
 
 describe("createCloudPackageLoader", () => {
   it("loads a ready cloud recording into a PackageLoadResult", async () => {
@@ -39,6 +42,30 @@ describe("createCloudPackageLoader", () => {
       expect(await readBlobText(result.mediaBlob!)).toBe("media");
       expect(result.warnings).toEqual([]);
     }
+  });
+
+  it("uses the shared playback descriptor lookup for share links", async () => {
+    const parts = await makePackageParts({ includeIndexes: false });
+    const repository = makeRepository({
+      ok: true,
+      value: makeDescriptor({ indexesUrl: null, mediaUrl: null }),
+    });
+    const loader = createCloudPackageLoader({
+      repository,
+      descriptorSource: "share",
+      fetch: makeAssetFetch({
+        "https://assets.example.com/manifest.json": jsonResponse(parts.manifest),
+        "https://assets.example.com/meta.json": jsonResponse(parts.meta),
+        "https://assets.example.com/events.json": jsonResponse(parts.events),
+        "https://assets.example.com/snapshots.json": jsonResponse(parts.snapshots),
+      }),
+    });
+
+    const result = await loader.load("share-token");
+
+    expect(repository.getSharedPlaybackDescriptor).toHaveBeenCalledWith("share-token");
+    expect(repository.getPlaybackDescriptor).not.toHaveBeenCalled();
+    expect(result.ok).toBe(true);
   });
 
   it("returns a load error with cloud request context when descriptor lookup fails", async () => {
@@ -308,6 +335,7 @@ function makeRepository(
 ): DescriptorRepository {
   return {
     getPlaybackDescriptor: vi.fn().mockResolvedValue(result),
+    getSharedPlaybackDescriptor: vi.fn().mockResolvedValue(result),
   };
 }
 

--- a/apps/web/src/features/player/cloudPackageLoader.ts
+++ b/apps/web/src/features/player/cloudPackageLoader.ts
@@ -17,7 +17,11 @@ import type {
 } from "@/features/cloud/types";
 
 export type CloudPackageLoaderOptions = {
-  repository: Pick<CloudRecordingRepository, "getPlaybackDescriptor">;
+  repository: Pick<
+    CloudRecordingRepository,
+    "getPlaybackDescriptor" | "getSharedPlaybackDescriptor"
+  >;
+  descriptorSource?: "owner" | "share";
   fetch?: typeof fetch;
 };
 
@@ -36,7 +40,10 @@ export function createCloudPackageLoader(
         return toInvalidManifest("cloud package fetch is unavailable");
       }
 
-      const descriptor = await options.repository.getPlaybackDescriptor(recordingId);
+      const descriptor =
+        options.descriptorSource === "share"
+          ? await options.repository.getSharedPlaybackDescriptor(recordingId)
+          : await options.repository.getPlaybackDescriptor(recordingId);
       if (!descriptor.ok) {
         return { ok: false, error: cloudErrorToLoadError(descriptor.error) };
       }


### PR DESCRIPTION
## 关联

Closes #169
Part of #92（云端总控 issue，不在本 PR 中关闭）

## 改动点

- 新增云端录制分享链接后端能力：owner 可为 ready 录制创建不可预测分享 token，服务端只保存 token hash。
- 新增 `GET /api/share/:token/playback` 只读播放描述接口，分享访问不需要 `x-owner-token`，无效/过期/删除后统一按不可见处理。
- 前端新增 `/s/:token` 分享播放入口，并让云端播放页和云端录制列表支持复制分享链接，其中播放页会带当前时间点 `?t=`。
- 复用现有云端 playback descriptor 和 P0 回放调度器，删除云端录制时同步失效分享链接。

## 影响范围

- 后端：`apps/api/src/cloud/*` 的 metadata/service/share link 存储与 HTTP handler。
- 前端：`apps/web/src/features/cloud/*` repository contract、`ReplayPage` 云端/分享加载、录制库分享入口、路由注册。
- 不改 P0 本地录制包事实源；不引入账号体系、分享管理 UI、真实 S3/CDN 或公开列表访问。

## GitNexus 影响分析摘要

- 风险等级: GitNexus local contract passed；`detect-changes` 在本分支早前识别到 19 files / 65 symbols / critical advisory，当前 `contract:local` 提示 no critical contract surface changed，analysis advisory for this diff。
- 关键骨架变更: API handler、cloud recording service、cloud repository、ReplayPage 和 route 层有扩展；未修改 shared schema 或 P0 本地录制包 contract。
- GitNexus 影响面: 已对 `createCloudRecordingService`、`ReplayPage`、`createCloudRecordingRepository` 做 impact 采样，结论均为 LOW；受影响面主要是 owner playback、shared playback、recording library/list route。
- 验证结果: 已补 API/service/repository/page/loader/route 测试覆盖 owner 隔离、token 访问、删除后失效、分享路由与 `?t=` 定位；`npm run quality:local` 通过。

## 自检

- [x] 未修改 `docs/progress.json` 或 `docs/progress.md`
- [x] 已运行 `npm run quality:local`，或说明无法运行的原因
- [x] 涉及 AI 字幕时，已记录一次 `npm run subtitle:postprocess:evaluate` 的“纠错并生成章节”效果验证结果，包含 `representativeOutputSource`、`overallEvaluationDurationMs`，并区分输出校验耗时与真实端到端耗时（不涉及 AI 字幕）
- [x] 涉及 AI 字幕点击链路、LLM worker、模型加载或性能时，已记录一次 `npm run subtitle:postprocess:runtime-benchmark` 结果，包含 `postprocessClickToResultReadyDurationMs`、`postProcessTimeoutBudgetMs` 和 `playbackProbeResponsiveDuringPostprocess`（不涉及 AI 字幕）
- [x] 已说明改动点和影响范围
- [x] 如果改动关键骨架，已补充契约测试并填写 GitNexus 影响分析摘要
- [ ] 已等待 repo-guard、codex 和 Copilot 评论，并完成必要审查

## 验证

- `npm run quality:predev`
- `npm run agent:bootstrap`
- `npm run test:api`
- `npm run test:web`
- `npm run quality:precommit`（commit hook）
- `npm run quality:local`
- `git push -u origin feature/169-cloud-share-links` 触发 pre-push `npm run quality:local` 并通过