### PR TITLE
[P1+ WebRTC] 候选人媒体会话与 SDP/ICE 信令接线

### DIFF
--- a/apps/web/src/features/interview/CandidateInterviewPage.tsx
+++ b/apps/web/src/features/interview/CandidateInterviewPage.tsx
@@ -13,7 +13,11 @@ import {
 } from "lucide-react";
 import { RecorderPage } from "@/features/recorder/RecorderPage";
 import { Toggle, Tooltip } from "@/shared/ui";
-import type { InterviewMediaSessionState } from "./interviewMediaSession";
+import {
+  createInterviewMediaSession,
+  type InterviewMediaSession,
+  type InterviewMediaSessionState,
+} from "./interviewMediaSession";
 import {
   createInterviewRoomClient,
   type InterviewRoomClient,
@@ -60,6 +64,7 @@ export type CandidateInterviewPageProps = {
     createSignalingClient?: (
       options: InterviewSignalingClientOptions,
     ) => InterviewSignalingClient;
+    createMediaSession?: () => InterviewMediaSession;
   };
 };
 
@@ -81,17 +86,19 @@ export function CandidateInterviewPage({ deps = {} }: CandidateInterviewPageProp
     [deps.roomClient],
   );
   const createSignalingClient = deps.createSignalingClient ?? createInterviewSignalingClient;
+  const createMediaSession = deps.createMediaSession ?? createInterviewMediaSession;
   const session = useCandidateInterviewRoomSession({
     routeRoomId: roomId,
     roomClient,
     createSignalingClient,
+    createMediaSession,
   });
 
   return (
     <CandidateInterviewView
       roomId={session.roomId}
       roomState={session.roomState}
-      mediaState={EMPTY_CANDIDATE_MEDIA_STATE}
+      mediaState={session.mediaState}
       recordingWorkspace={<RecorderPage />}
     />
   );
@@ -101,13 +108,19 @@ function useCandidateInterviewRoomSession({
   routeRoomId,
   roomClient,
   createSignalingClient,
+  createMediaSession,
 }: {
   routeRoomId: string | null;
   roomClient: InterviewRoomClient;
   createSignalingClient: (
     options: InterviewSignalingClientOptions,
   ) => InterviewSignalingClient;
-}): { roomId: string | null; roomState: CandidateInterviewRoomState } {
+  createMediaSession: () => InterviewMediaSession;
+}): {
+  roomId: string | null;
+  roomState: CandidateInterviewRoomState;
+  mediaState: InterviewMediaSessionState;
+} {
   const [session, setSession] = useState<{
     roomId: string | null;
     roomState: CandidateInterviewRoomState;
@@ -115,6 +128,9 @@ function useCandidateInterviewRoomSession({
     roomId: routeRoomId,
     roomState: initialCandidateRoomState(routeRoomId),
   }));
+  const [mediaState, setMediaState] = useState<InterviewMediaSessionState>(
+    EMPTY_CANDIDATE_MEDIA_STATE,
+  );
   const roomCreationRef = useRef<{
     roomClient: InterviewRoomClient;
     request: ReturnType<InterviewRoomClient["createRoom"]>;
@@ -123,9 +139,37 @@ function useCandidateInterviewRoomSession({
   useEffect(() => {
     let closed = false;
     let signalingClient: InterviewSignalingClient | null = null;
+    let mediaSession: InterviewMediaSession | null = null;
+    let unsubscribeMediaSession: (() => void) | null = null;
+    let mediaOfferStarted = false;
+    let mediaSessionVersion = 0;
+    let activeInterviewerConnectionId: string | null = null;
+    const staleInterviewerConnectionIds = new Set<string>();
+
+    const closeMediaSession = ({ publish }: { publish: boolean }) => {
+      const current = mediaSession;
+      if (!current) return;
+      mediaSessionVersion += 1;
+      unsubscribeMediaSession?.();
+      unsubscribeMediaSession = null;
+      mediaSession = null;
+      mediaOfferStarted = false;
+      const closedState = current.close();
+      if (publish && !closed) {
+        setMediaState(closedState);
+      }
+    };
+    const isCurrentMediaSession = (
+      currentMediaSession: InterviewMediaSession | null,
+      currentMediaSessionVersion: number,
+    ) =>
+      !closed &&
+      mediaSession === currentMediaSession &&
+      mediaSessionVersion === currentMediaSessionVersion;
 
     if (routeRoomId) {
       roomCreationRef.current = null;
+      setMediaState(EMPTY_CANDIDATE_MEDIA_STATE);
       setSession({
         roomId: routeRoomId,
         roomState: initialCandidateRoomState(routeRoomId),
@@ -141,6 +185,7 @@ function useCandidateInterviewRoomSession({
         interviewerOnline: false,
       },
     });
+    setMediaState(EMPTY_CANDIDATE_MEDIA_STATE);
 
     if (!roomCreationRef.current || roomCreationRef.current.roomClient !== roomClient) {
       roomCreationRef.current = { roomClient, request: roomClient.createRoom() };
@@ -164,12 +209,162 @@ function useCandidateInterviewRoomSession({
       }
 
       const room = result.value;
+      const failWithRoomContext = (errorMessage: string) => {
+        closeMediaSession({ publish: true });
+        setSession((current) => ({
+          roomId: current.roomId ?? room.roomId,
+          roomState: {
+            ...current.roomState,
+            status: "failed",
+            joinCode: current.roomState.joinCode ?? room.joinCode,
+            interviewerOnline: false,
+            expiresAt: current.roomState.expiresAt ?? room.expiresAt,
+            signalingUrl: current.roomState.signalingUrl ?? room.signalingUrl,
+            errorMessage,
+          },
+        }));
+      };
+      const sendPendingIceCandidates = () => {
+        if (!mediaSession || !signalingClient) return;
+        if (mediaSession.getState().outgoingIceCandidates.length === 0) return;
+        const candidates = mediaSession.drainOutgoingIceCandidates();
+        for (const candidate of candidates) {
+          if (!candidate?.candidate) continue;
+          const sendResult = signalingClient.sendIceCandidate({
+            candidate: candidate.candidate,
+            sdpMid: candidate.sdpMid ?? null,
+            sdpMLineIndex: candidate.sdpMLineIndex ?? null,
+          });
+          if (!sendResult.ok) {
+            failWithRoomContext(`ice candidate failed: ${sendResult.reason}`);
+            return;
+          }
+        }
+      };
+      const openMediaSession = () => {
+        if (mediaSession) return true;
+        try {
+          mediaSession = createMediaSession();
+          mediaSessionVersion += 1;
+          setMediaState(mediaSession.getState());
+          unsubscribeMediaSession = mediaSession.subscribe((next) => {
+            if (closed) return;
+            setMediaState(next);
+            if (next.outgoingIceCandidates.length > 0) {
+              sendPendingIceCandidates();
+            }
+          });
+          return true;
+        } catch (error) {
+          failWithRoomContext(candidateMediaErrorMessage(error));
+          return false;
+        }
+      };
+      const shouldApplyRemoteMediaMessage = (message: {
+        role: "candidate" | "interviewer";
+        connectionId: string;
+      }) => {
+        if (message.role !== "interviewer") return false;
+        if (staleInterviewerConnectionIds.has(message.connectionId)) return false;
+        if (
+          activeInterviewerConnectionId &&
+          activeInterviewerConnectionId !== message.connectionId
+        ) {
+          return false;
+        }
+        activeInterviewerConnectionId = message.connectionId;
+        return true;
+      };
+      const startCandidateMediaOffer = () => {
+        if (mediaOfferStarted) return;
+        if (!openMediaSession()) return;
+        const currentMediaSession = mediaSession;
+        const currentMediaSessionVersion = mediaSessionVersion;
+        mediaOfferStarted = true;
+        void (async () => {
+          try {
+            if (!currentMediaSession) {
+              throw new Error("candidate media session is not available");
+            }
+            await currentMediaSession.requestLocalMedia();
+            if (!isCurrentMediaSession(currentMediaSession, currentMediaSessionVersion)) {
+              return;
+            }
+            const offer = await currentMediaSession.createOffer();
+            if (!isCurrentMediaSession(currentMediaSession, currentMediaSessionVersion)) {
+              return;
+            }
+            if (!offer.sdp) {
+              throw new Error("candidate media offer missing sdp");
+            }
+            const sendResult = signalingClient?.sendOffer(offer.sdp);
+            if (!sendResult) {
+              throw new Error("candidate signaling client is not available");
+            }
+            if (!sendResult.ok) {
+              throw new Error(`offer failed: ${sendResult.reason}`);
+            }
+            sendPendingIceCandidates();
+          } catch (error) {
+            if (isCurrentMediaSession(currentMediaSession, currentMediaSessionVersion)) {
+              failWithRoomContext(candidateMediaErrorMessage(error));
+            }
+          }
+        })();
+      };
+      const applyRemoteAnswer = (message: {
+        role: "candidate" | "interviewer";
+        connectionId: string;
+        sdp: string;
+      }) => {
+        if (!shouldApplyRemoteMediaMessage(message)) return;
+        const currentMediaSession = mediaSession;
+        if (!currentMediaSession) return;
+        const currentMediaSessionVersion = mediaSessionVersion;
+        void (async () => {
+          try {
+            await currentMediaSession.setRemoteDescription({ type: "answer", sdp: message.sdp });
+            if (!isCurrentMediaSession(currentMediaSession, currentMediaSessionVersion)) {
+              return;
+            }
+          } catch (error) {
+            if (isCurrentMediaSession(currentMediaSession, currentMediaSessionVersion)) {
+              failWithRoomContext(candidateMediaErrorMessage(error));
+            }
+          }
+        })();
+      };
+      const applyRemoteIceCandidate = (
+        message: Extract<InboundSignalingMessage, { kind: "ice-candidate" }>,
+      ) => {
+        if (!shouldApplyRemoteMediaMessage(message)) return;
+        const currentMediaSession = mediaSession;
+        if (!currentMediaSession) return;
+        const currentMediaSessionVersion = mediaSessionVersion;
+        void (async () => {
+          try {
+            await currentMediaSession.addRemoteIceCandidate({
+              candidate: message.candidate,
+              sdpMid: message.sdpMid ?? null,
+              sdpMLineIndex: message.sdpMLineIndex ?? null,
+            });
+            if (!isCurrentMediaSession(currentMediaSession, currentMediaSessionVersion)) {
+              return;
+            }
+          } catch (error) {
+            if (isCurrentMediaSession(currentMediaSession, currentMediaSessionVersion)) {
+              failWithRoomContext(candidateMediaErrorMessage(error));
+            }
+          }
+        })();
+      };
       const updateFromMessage = (message: InboundSignalingMessage) => {
         if ("roomId" in message && message.roomId !== room.roomId) return;
 
         if (message.kind === "connected") {
           const sendResult = signalingClient?.sendJoin();
           if (sendResult && !sendResult.ok) {
+            closeMediaSession({ publish: true });
             setSession((current) => ({
               ...current,
               roomState: {
@@ -194,10 +389,14 @@ function useCandidateInterviewRoomSession({
               signalingUrl: room.signalingUrl,
             },
           });
+          if (message.role === "interviewer" && message.status === "live") {
+            startCandidateMediaOffer();
+          }
           return;
         }
 
         if (message.kind === "ended") {
+          closeMediaSession({ publish: true });
           setSession((current) => ({
             ...current,
             roomState: {
@@ -210,6 +409,7 @@ function useCandidateInterviewRoomSession({
         }
 
         if (message.kind === "error") {
+          closeMediaSession({ publish: true });
           setSession((current) => ({
             ...current,
             roomState: {
@@ -223,6 +423,11 @@ function useCandidateInterviewRoomSession({
         }
 
         if (message.kind === "leave" && message.role === "interviewer") {
+          staleInterviewerConnectionIds.add(message.connectionId);
+          if (activeInterviewerConnectionId === message.connectionId) {
+            activeInterviewerConnectionId = null;
+          }
+          closeMediaSession({ publish: true });
           setSession((current) => ({
             ...current,
             roomState: {
@@ -231,8 +436,20 @@ function useCandidateInterviewRoomSession({
               interviewerOnline: false,
             },
           }));
+          return;
+        }
+
+        if (message.kind === "answer") {
+          applyRemoteAnswer(message);
+          return;
+        }
+
+        if (message.kind === "ice-candidate") {
+          applyRemoteIceCandidate(message);
         }
       };
+
+      if (!openMediaSession()) return;
 
       setSession({
         roomId: room.roomId,
@@ -253,6 +470,7 @@ function useCandidateInterviewRoomSession({
         onMessage: updateFromMessage,
         onError: (error) => {
           if (closed) return;
+          closeMediaSession({ publish: true });
           setSession((current) => ({
             ...current,
             roomState: {
@@ -283,11 +501,12 @@ function useCandidateInterviewRoomSession({
 
     return () => {
       closed = true;
+      closeMediaSession({ publish: false });
       signalingClient?.close();
     };
-  }, [createSignalingClient, roomClient, routeRoomId]);
+  }, [createMediaSession, createSignalingClient, roomClient, routeRoomId]);
 
-  return session;
+  return { ...session, mediaState };
 }
 
 function initialCandidateRoomState(routeRoomId: string | null): CandidateInterviewRoomState {
@@ -307,6 +526,10 @@ function initialCandidateRoomState(routeRoomId: string | null): CandidateIntervi
 
 function candidateRoomCreationErrorMessage(error: unknown): string {
   return error instanceof Error ? error.message : "interview room request failed";
+}
+
+function candidateMediaErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : "candidate media setup failed";
 }
 
 function candidateStatusFromRoomStatus(status: InterviewRoomStatus): CandidateInterviewStatus {

--- a/apps/web/src/features/interview/__tests__/CandidateInterviewPage.test.tsx
+++ b/apps/web/src/features/interview/__tests__/CandidateInterviewPage.test.tsx
@@ -1,11 +1,11 @@
-import { act, render, screen } from "@testing-library/react";
+import { act, render, screen, waitFor } from "@testing-library/react";
 import { StrictMode, type ComponentProps } from "react";
 import { createMemoryRouter, RouterProvider } from "react-router-dom";
 import { describe, expect, it, vi } from "vitest";
 import { appRoutes } from "@/app/routes";
 import { ThemeProvider } from "@/shared/ui/themeProvider";
 import { TooltipProvider } from "@/shared/ui/Tooltip";
-import type { InterviewMediaSessionState } from "../interviewMediaSession";
+import type { InterviewMediaSession, InterviewMediaSessionState } from "../interviewMediaSession";
 import type { InterviewRoomClient } from "../interviewRoomClient";
 import type {
   InboundSignalingMessage,
@@ -76,6 +76,367 @@ describe("CandidateInterviewPage", () => {
 
     expect(screen.getAllByText("面试官已加入")).toHaveLength(2);
     expect(screen.getByText("面试官在线")).toBeInTheDocument();
+  });
+
+  it("starts the candidate media offer after the interviewer joins", async () => {
+    const roomClient = makeRoomClient();
+    const signaling = makeSignalingFactory();
+    const media = makeMediaSessionFactory();
+
+    renderCandidatePage({
+      initialEntry: "/interview/candidate",
+      roomClient,
+      createSignalingClient: signaling.create,
+      createMediaSession: media.create,
+    });
+    await screen.findByText("room-created");
+
+    act(() => {
+      signaling.emit({
+        kind: "connected",
+        roomId: "room-created",
+        connectionId: "candidate-connection-1",
+      });
+      signaling.emit({
+        kind: "joined",
+        roomId: "room-created",
+        role: "interviewer",
+        status: "live",
+      });
+    });
+
+    await waitFor(() => {
+      expect(media.session.requestLocalMedia).toHaveBeenCalledTimes(1);
+      expect(media.session.createOffer).toHaveBeenCalledTimes(1);
+      expect(signaling.client.sendOffer).toHaveBeenCalledWith("candidate-offer-sdp");
+    });
+    expect(screen.getByRole("button", { name: "麦克风已开启" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "摄像头已开启" })).toBeDisabled();
+
+    act(() => {
+      signaling.emit({
+        kind: "joined",
+        roomId: "room-created",
+        role: "interviewer",
+        status: "live",
+      });
+    });
+
+    expect(media.session.requestLocalMedia).toHaveBeenCalledTimes(1);
+    expect(media.session.createOffer).toHaveBeenCalledTimes(1);
+    expect(signaling.client.sendOffer).toHaveBeenCalledTimes(1);
+  });
+
+  it("bridges local ICE, remote answer, and remote ICE between media and signaling", async () => {
+    const roomClient = makeRoomClient();
+    const signaling = makeSignalingFactory();
+    const media = makeMediaSessionFactory();
+
+    renderCandidatePage({
+      initialEntry: "/interview/candidate",
+      roomClient,
+      createSignalingClient: signaling.create,
+      createMediaSession: media.create,
+    });
+    await screen.findByText("room-created");
+
+    act(() => {
+      signaling.emit({
+        kind: "connected",
+        roomId: "room-created",
+        connectionId: "candidate-connection-1",
+      });
+      signaling.emit({
+        kind: "joined",
+        roomId: "room-created",
+        role: "interviewer",
+        status: "live",
+      });
+    });
+    await waitFor(() => {
+      expect(signaling.client.sendOffer).toHaveBeenCalledWith("candidate-offer-sdp");
+    });
+
+    act(() => {
+      media.emitState({
+        outgoingIceCandidates: [
+          { candidate: "candidate:local", sdpMid: "0", sdpMLineIndex: 0 },
+        ],
+      });
+    });
+    await waitFor(() => {
+      expect(signaling.client.sendIceCandidate).toHaveBeenCalledWith({
+        candidate: "candidate:local",
+        sdpMid: "0",
+        sdpMLineIndex: 0,
+      });
+    });
+
+    act(() => {
+      signaling.emit({
+        kind: "answer",
+        roomId: "room-created",
+        role: "interviewer",
+        connectionId: "interviewer-connection-1",
+        messageId: "answer-1",
+        sentAt: 1_780_000_000_000,
+        sdp: "answer-sdp",
+      });
+      signaling.emit({
+        kind: "ice-candidate",
+        roomId: "room-created",
+        role: "interviewer",
+        connectionId: "interviewer-connection-1",
+        messageId: "ice-1",
+        sentAt: 1_780_000_000_001,
+        candidate: "candidate:remote",
+        sdpMid: "0",
+        sdpMLineIndex: 0,
+      });
+    });
+
+    await waitFor(() => {
+      expect(media.session.setRemoteDescription).toHaveBeenCalledWith({
+        type: "answer",
+        sdp: "answer-sdp",
+      });
+      expect(media.session.addRemoteIceCandidate).toHaveBeenCalledWith({
+        candidate: "candidate:remote",
+        sdpMid: "0",
+        sdpMLineIndex: 0,
+      });
+    });
+  });
+
+  it("ignores remote media messages that are not from the interviewer", async () => {
+    const roomClient = makeRoomClient();
+    const signaling = makeSignalingFactory();
+    const media = makeMediaSessionFactory();
+
+    renderCandidatePage({
+      initialEntry: "/interview/candidate",
+      roomClient,
+      createSignalingClient: signaling.create,
+      createMediaSession: media.create,
+    });
+    await screen.findByText("room-created");
+
+    act(() => {
+      signaling.emit({
+        kind: "joined",
+        roomId: "room-created",
+        role: "interviewer",
+        status: "live",
+      });
+    });
+    await waitFor(() => {
+      expect(signaling.client.sendOffer).toHaveBeenCalledTimes(1);
+    });
+
+    act(() => {
+      signaling.emit({
+        kind: "answer",
+        roomId: "room-created",
+        role: "candidate",
+        connectionId: "candidate-connection-1",
+        messageId: "candidate-answer-1",
+        sentAt: 1_780_000_000_000,
+        sdp: "candidate-answer-sdp",
+      });
+      signaling.emit({
+        kind: "ice-candidate",
+        roomId: "room-created",
+        role: "candidate",
+        connectionId: "candidate-connection-1",
+        messageId: "candidate-ice-1",
+        sentAt: 1_780_000_000_001,
+        candidate: "candidate:self",
+        sdpMid: "0",
+        sdpMLineIndex: 0,
+      });
+    });
+
+    expect(screen.queryByText("连接失败")).not.toBeInTheDocument();
+    expect(media.session.setRemoteDescription).not.toHaveBeenCalled();
+    expect(media.session.addRemoteIceCandidate).not.toHaveBeenCalled();
+  });
+
+  it("keeps the recorder workspace visible when candidate media setup fails", async () => {
+    const roomClient = makeRoomClient();
+    const signaling = makeSignalingFactory();
+    const media = makeMediaSessionFactory({
+      requestLocalMedia: vi.fn().mockRejectedValue(new Error("camera denied")),
+    });
+
+    renderCandidatePage({
+      initialEntry: "/interview/candidate",
+      roomClient,
+      createSignalingClient: signaling.create,
+      createMediaSession: media.create,
+    });
+    await screen.findByText("room-created");
+
+    act(() => {
+      signaling.emit({
+        kind: "joined",
+        roomId: "room-created",
+        role: "interviewer",
+        status: "live",
+      });
+    });
+
+    expect(await screen.findAllByText("连接失败")).toHaveLength(2);
+    expect(screen.getByText("camera denied")).toBeInTheDocument();
+    expect(screen.getByTestId("recorder-workspace")).toBeInTheDocument();
+    expect(media.session.close).toHaveBeenCalledTimes(1);
+  });
+
+  it("recreates candidate media when the interviewer rejoins after leaving", async () => {
+    const roomClient = makeRoomClient();
+    const signaling = makeSignalingFactory();
+    const firstMedia = makeMediaSessionFactory();
+    const secondMedia = makeMediaSessionFactory();
+    const createMediaSession = vi
+      .fn()
+      .mockReturnValueOnce(firstMedia.session)
+      .mockReturnValueOnce(secondMedia.session);
+
+    renderCandidatePage({
+      initialEntry: "/interview/candidate",
+      roomClient,
+      createSignalingClient: signaling.create,
+      createMediaSession,
+    });
+    await screen.findByText("room-created");
+
+    act(() => {
+      signaling.emit({
+        kind: "joined",
+        roomId: "room-created",
+        role: "interviewer",
+        status: "live",
+      });
+    });
+    await waitFor(() => {
+      expect(firstMedia.session.requestLocalMedia).toHaveBeenCalledTimes(1);
+      expect(signaling.client.sendOffer).toHaveBeenCalledTimes(1);
+    });
+
+    act(() => {
+      signaling.emit({
+        kind: "leave",
+        roomId: "room-created",
+        role: "interviewer",
+        connectionId: "interviewer-connection-1",
+        messageId: "leave-1",
+        sentAt: 1_780_000_000_000,
+      });
+    });
+    expect(firstMedia.session.close).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      signaling.emit({
+        kind: "joined",
+        roomId: "room-created",
+        role: "interviewer",
+        status: "live",
+      });
+    });
+
+    await waitFor(() => {
+      expect(createMediaSession).toHaveBeenCalledTimes(2);
+      expect(secondMedia.session.requestLocalMedia).toHaveBeenCalledTimes(1);
+      expect(signaling.client.sendOffer).toHaveBeenCalledTimes(2);
+    });
+
+    act(() => {
+      signaling.emit({
+        kind: "answer",
+        roomId: "room-created",
+        role: "interviewer",
+        connectionId: "interviewer-connection-1",
+        messageId: "old-answer-1",
+        sentAt: 1_780_000_000_001,
+        sdp: "old-answer-sdp",
+      });
+      signaling.emit({
+        kind: "ice-candidate",
+        roomId: "room-created",
+        role: "interviewer",
+        connectionId: "interviewer-connection-1",
+        messageId: "old-ice-1",
+        sentAt: 1_780_000_000_002,
+        candidate: "candidate:old",
+        sdpMid: "0",
+        sdpMLineIndex: 0,
+      });
+    });
+
+    expect(screen.queryByText("连接失败")).not.toBeInTheDocument();
+    expect(secondMedia.session.setRemoteDescription).not.toHaveBeenCalled();
+    expect(secondMedia.session.addRemoteIceCandidate).not.toHaveBeenCalled();
+  });
+
+  it("ignores late remote media messages after the interviewer leaves", async () => {
+    const roomClient = makeRoomClient();
+    const signaling = makeSignalingFactory();
+    const media = makeMediaSessionFactory();
+
+    renderCandidatePage({
+      initialEntry: "/interview/candidate",
+      roomClient,
+      createSignalingClient: signaling.create,
+      createMediaSession: media.create,
+    });
+    await screen.findByText("room-created");
+
+    act(() => {
+      signaling.emit({
+        kind: "joined",
+        roomId: "room-created",
+        role: "interviewer",
+        status: "live",
+      });
+    });
+    await waitFor(() => {
+      expect(signaling.client.sendOffer).toHaveBeenCalledTimes(1);
+    });
+
+    act(() => {
+      signaling.emit({
+        kind: "leave",
+        roomId: "room-created",
+        role: "interviewer",
+        connectionId: "interviewer-connection-1",
+        messageId: "leave-1",
+        sentAt: 1_780_000_000_000,
+      });
+      signaling.emit({
+        kind: "answer",
+        roomId: "room-created",
+        role: "interviewer",
+        connectionId: "interviewer-connection-1",
+        messageId: "answer-1",
+        sentAt: 1_780_000_000_001,
+        sdp: "late-answer-sdp",
+      });
+      signaling.emit({
+        kind: "ice-candidate",
+        roomId: "room-created",
+        role: "interviewer",
+        connectionId: "interviewer-connection-1",
+        messageId: "ice-1",
+        sentAt: 1_780_000_000_002,
+        candidate: "candidate:late",
+        sdpMid: "0",
+        sdpMLineIndex: 0,
+      });
+    });
+
+    expect(screen.queryByText("连接失败")).not.toBeInTheDocument();
+    expect(screen.getAllByText("等待面试官")).toHaveLength(2);
+    expect(media.session.setRemoteDescription).not.toHaveBeenCalled();
+    expect(media.session.addRemoteIceCandidate).not.toHaveBeenCalled();
   });
 
   it("reuses in-flight room creation during StrictMode effect replay", async () => {
@@ -225,14 +586,16 @@ describe("CandidateInterviewPage", () => {
     expect(screen.getByText("面试官离线")).toBeInTheDocument();
   });
 
-  it("clears interviewer presence when the signaling socket errors after a live join", async () => {
+  it("closes candidate media when the signaling socket closes after a live join", async () => {
     const roomClient = makeRoomClient();
     const signaling = makeSignalingFactory();
+    const media = makeMediaSessionFactory();
 
     renderCandidatePage({
       initialEntry: "/interview/candidate",
       roomClient,
       createSignalingClient: signaling.create,
+      createMediaSession: media.create,
     });
     await screen.findByText("room-created");
 
@@ -244,16 +607,21 @@ describe("CandidateInterviewPage", () => {
         status: "live",
       });
     });
-    expect(screen.getByText("面试官在线")).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByText("面试官在线")).toBeInTheDocument();
+      expect(signaling.client.sendOffer).toHaveBeenCalledTimes(1);
+    });
 
     act(() => {
       signaling.emitError({
-        code: "socket-error",
-        message: "interview signaling socket error",
+        code: "socket-closed",
+        message: "interview signaling socket closed",
       });
     });
     expect(screen.getAllByText("连接失败")).toHaveLength(2);
     expect(screen.getByText("面试官离线")).toBeInTheDocument();
+    expect(screen.getByTestId("recorder-workspace")).toBeInTheDocument();
+    expect(media.session.close).toHaveBeenCalledTimes(1);
   });
 
   it("marks the interviewer offline when an interviewer leave message arrives", async () => {
@@ -317,27 +685,32 @@ describe("CandidateInterviewPage", () => {
   it("closes the signaling client when the candidate page unmounts", async () => {
     const roomClient = makeRoomClient();
     const signaling = makeSignalingFactory();
+    const media = makeMediaSessionFactory();
 
     const view = renderCandidatePage({
       initialEntry: "/interview/candidate",
       roomClient,
       createSignalingClient: signaling.create,
+      createMediaSession: media.create,
     });
     await screen.findByText("room-created");
 
     view.unmount();
 
     expect(signaling.client.close).toHaveBeenCalledTimes(1);
+    expect(media.session.close).toHaveBeenCalledTimes(1);
   });
 
   it("keeps routed candidate rooms in read-only recording mode without a join code", () => {
     const roomClient = makeRoomClient();
     const signaling = makeSignalingFactory();
+    const media = makeMediaSessionFactory();
 
     renderCandidatePage({
       initialEntry: "/interview/candidate/room-route",
       roomClient,
       createSignalingClient: signaling.create,
+      createMediaSession: media.create,
     });
 
     expect(screen.getByText("room-route")).toBeInTheDocument();
@@ -345,6 +718,7 @@ describe("CandidateInterviewPage", () => {
     expect(screen.getByTestId("recorder-workspace")).toBeInTheDocument();
     expect(roomClient.createRoom).not.toHaveBeenCalled();
     expect(signaling.create).not.toHaveBeenCalled();
+    expect(media.create).not.toHaveBeenCalled();
   });
 
   it("renders the candidate room status and recording workspace", () => {
@@ -431,11 +805,13 @@ function renderCandidatePage({
   initialEntry,
   roomClient,
   createSignalingClient,
+  createMediaSession = makeMediaSessionFactory().create,
   strict = false,
 }: {
   initialEntry: string;
   roomClient: InterviewRoomClient;
   createSignalingClient: (options: InterviewSignalingClientOptions) => InterviewSignalingClient;
+  createMediaSession?: () => InterviewMediaSession;
   strict?: boolean;
 }) {
   const router = createMemoryRouter(
@@ -447,6 +823,7 @@ function renderCandidatePage({
             deps={{
               roomClient,
               createSignalingClient,
+              createMediaSession,
             }}
           />
         ),
@@ -514,11 +891,11 @@ function makeSignalingFactory() {
     socket: {} as InterviewSignalingClient["socket"],
     getConnectionId: vi.fn(() => "candidate-connection-1"),
     sendJoin: vi.fn(() => ({ ok: true as const, message: {} as never })),
-    sendOffer: vi.fn(),
-    sendAnswer: vi.fn(),
-    sendIceCandidate: vi.fn(),
-    sendHeartbeat: vi.fn(),
-    sendLeave: vi.fn(),
+    sendOffer: vi.fn(() => ({ ok: true as const, message: {} as never })),
+    sendAnswer: vi.fn(() => ({ ok: true as const, message: {} as never })),
+    sendIceCandidate: vi.fn(() => ({ ok: true as const, message: {} as never })),
+    sendHeartbeat: vi.fn(() => ({ ok: true as const, message: {} as never })),
+    sendLeave: vi.fn(() => ({ ok: true as const, message: {} as never })),
     close: vi.fn(),
   };
 
@@ -541,5 +918,73 @@ function makeSignalingFactory() {
       }
       onError(error);
     },
+  };
+}
+
+function makeMediaSessionFactory(patch: Partial<InterviewMediaSession> = {}) {
+  let state = makeMediaState();
+  const listeners = new Set<(next: InterviewMediaSessionState) => void>();
+  const updateState = (next: Partial<InterviewMediaSessionState>) => {
+    state = { ...state, ...next };
+    listeners.forEach((listener) => listener(state));
+    return state;
+  };
+  const localStream = {} as MediaStream;
+  const remoteStream = {} as MediaStream;
+  const session: InterviewMediaSession = {
+    getState: vi.fn(() => state),
+    requestLocalMedia: vi.fn(async () =>
+      updateState({
+        localStream,
+        microphoneEnabled: true,
+        cameraEnabled: true,
+      }),
+    ),
+    setMicrophoneEnabled: vi.fn((enabled) =>
+      updateState({
+        microphoneEnabled: enabled,
+      }),
+    ),
+    setCameraEnabled: vi.fn((enabled) =>
+      updateState({
+        cameraEnabled: enabled,
+      }),
+    ),
+    createOffer: vi.fn(async () => ({ type: "offer" as const, sdp: "candidate-offer-sdp" })),
+    createAnswer: vi.fn(async () => ({ type: "answer" as const, sdp: "candidate-answer-sdp" })),
+    setRemoteDescription: vi.fn(async () => state),
+    addRemoteIceCandidate: vi.fn(async () => state),
+    drainOutgoingIceCandidates: vi.fn(() => {
+      const candidates = state.outgoingIceCandidates;
+      updateState({ outgoingIceCandidates: [] });
+      return candidates;
+    }),
+    subscribe: vi.fn((listener) => {
+      listeners.add(listener);
+      return () => listeners.delete(listener);
+    }),
+    close: vi.fn(() =>
+      updateState({
+        localStream: null,
+        remoteStream: null,
+        microphoneEnabled: false,
+        cameraEnabled: false,
+        connectionState: "closed",
+        iceConnectionState: "closed",
+        signalingState: "closed",
+        outgoingIceCandidates: [],
+      }),
+    ),
+    ...patch,
+  };
+
+  return {
+    create: vi.fn(() => session),
+    session,
+    emitState(next: Partial<InterviewMediaSessionState>) {
+      updateState(next);
+    },
+    localStream,
+    remoteStream,
   };
 }

--- a/apps/web/src/features/interview/__tests__/interviewMediaSession.test.ts
+++ b/apps/web/src/features/interview/__tests__/interviewMediaSession.test.ts
@@ -241,6 +241,26 @@ describe("InterviewMediaSession", () => {
     });
   });
 
+  it("stops local media if the session closes while getUserMedia is pending", async () => {
+    const { audioTrack, videoTrack, localStream, peer, deps } = createFixture();
+    let resolveMedia!: (stream: MediaStream) => void;
+    deps.getUserMedia = () =>
+      new Promise<MediaStream>((resolve) => {
+        resolveMedia = resolve;
+      });
+    const session = createInterviewMediaSession({ deps });
+
+    const request = session.requestLocalMedia();
+    session.close();
+    resolveMedia(localStream as unknown as MediaStream);
+
+    await expect(request).rejects.toThrow("Interview media session is closed");
+    expect(audioTrack.stopped).toBe(true);
+    expect(videoTrack.stopped).toBe(true);
+    expect(peer.addedTracks).toEqual([]);
+    expect(session.getState().localStream).toBeNull();
+  });
+
   it("ignores late peer events after close and clears pending ICE candidates", async () => {
     const { peer, deps } = createFixture();
     const session = createInterviewMediaSession({ deps });

--- a/apps/web/src/features/interview/interviewMediaSession.ts
+++ b/apps/web/src/features/interview/interviewMediaSession.ts
@@ -128,7 +128,12 @@ export function createInterviewMediaSession(
       if (localStream) {
         throw new Error("Local media has already been requested for this interview session");
       }
-      localStream = await deps.getUserMedia(constraints);
+      const requestedStream = await deps.getUserMedia(constraints);
+      if (closed) {
+        stopStreamTracks(requestedStream);
+        throw new Error("Interview media session is closed");
+      }
+      localStream = requestedStream;
       localStream.getTracks().forEach((track) => {
         peer.addTrack(track, localStream as MediaStream);
       });


### PR DESCRIPTION
## 关联

Closes #171
Refs #120（总控 issue，不在本 PR 中关闭）

## 改动点

- 候选人页接入真实 `InterviewMediaSession`，将媒体状态传给候选人视图。
- 面试官进入 live 后，候选人端请求本地音视频、创建 offer，并通过现有 signaling client 发送 SDP。
- 衔接本地 ICE、远端 answer、远端 ICE candidate，失败时关闭媒体会话并保留录制工作区。
- 补充关闭/离开/错误/卸载清理；面试官离开后重入会重建媒体会话，晚到的旧 answer/ICE 会按 interviewer `connectionId` 被丢弃。
- 修复 `getUserMedia` pending 期间 session 被关闭时的本地轨道泄漏。

## 影响范围

- Web 候选人面试页的媒体信令接线与媒体状态 UI。
- `interviewMediaSession` 的关闭竞态处理。
- 新增/扩展候选人页和媒体会话单元测试；不改后端 signaling 协议。

## GitNexus 影响分析摘要

- 风险等级: high（detect-changes: 2 files / 12 symbols / 6 affected processes），高风险来自候选人面试主流程触达。
- 关键骨架变更: 否；`contract:local` 提示无 critical contract surface changed，GitNexus 分析为 advisory。
- GitNexus 影响面: `useCandidateInterviewRoomSession` upstream impactedCount=3 / risk=LOW，影响 `CandidateInterviewPage -> routes.tsx -> App.tsx`；`startCandidateMediaOffer` upstream impactedCount=1 / risk=LOW；`shouldApplyRemoteMediaMessage` upstream impactedCount=3 / risk=LOW。
- 备注: GitNexus CLI 对多个同名 `code-tape` worktree 的 repo 解析存在路径 hash 碰撞；本次使用只包含当前 worktree 的临时 `GITNEXUS_HOME` 复跑 detect/impact，确保分析对准 PR #173。
- 验证结果: `GITNEXUS_ANALYZE_TIMEOUT_MS=120000 npm run quality:local` 通过；push 前 hook 的 `npm run quality:local` 也通过。

## 自检

- [x] 未修改 `docs/progress.json` 或 `docs/progress.md`
- [x] 已运行 `npm run quality:local`
- [x] 不涉及 AI 字幕纠错/章节生成链路
- [x] 不涉及 AI 字幕点击链路、LLM worker、模型加载或性能
- [x] 已说明改动点和影响范围
- [x] 未改动关键骨架；已填写 GitNexus 影响分析摘要
- [ ] 已等待 repo-guard、codex 和 Copilot 评论，并完成必要审查（PR 更新后处理中）

## 验证

- `npm run quality:predev`
- `npm run agent:bootstrap`
- `npm run test:web -- src/features/interview/__tests__/CandidateInterviewPage.test.tsx --runInBand`（22 tests）
- `npm run test:web -- src/features/interview/__tests__/CandidateInterviewPage.test.tsx src/features/interview/__tests__/interviewMediaSession.test.ts src/features/interview/__tests__/interviewSignalingClient.test.ts --runInBand`（38 tests）
- `npm run lint:web`
- `npm run build -w apps/web`
- `git diff --check`
- `GITNEXUS_ANALYZE_TIMEOUT_MS=120000 npm run quality:local`
- `git commit --amend --no-edit`（precommit `quality:precommit` 通过）
- `git push --force-with-lease`（pre-push `quality:local` 通过）
