### PR TITLE
[Bug] 恢复线上 stale Transformers chunk 加载失败

### DIFF
--- a/apps/web/src/app/__tests__/staleChunkRecovery.test.ts
+++ b/apps/web/src/app/__tests__/staleChunkRecovery.test.ts
@@ -1,0 +1,88 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { installStaleChunkRecovery } from "../staleChunkRecovery";
+
+function createPreloadError(message: string): Event {
+  const event = new Event("vite:preloadError", { cancelable: true });
+  Object.defineProperty(event, "payload", {
+    value: new Error(message),
+  });
+  return event;
+}
+
+describe("installStaleChunkRecovery", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("reloads once when Vite reports a stale dynamic chunk", () => {
+    const reload = vi.fn();
+    const storage = new Map<string, string>();
+    const target = new EventTarget();
+    const getRecoveryToken = () => "entry-index-A.js";
+    installStaleChunkRecovery({
+      target,
+      storage: {
+        getItem: (key) => storage.get(key) ?? null,
+        setItem: (key, value) => storage.set(key, value),
+      },
+      reload,
+      getRecoveryToken,
+    });
+
+    const firstError = createPreloadError(
+      "Failed to fetch dynamically imported module: https://ceilf6.github.io/code-tape/assets/transformers.web-Ddnr203B.js",
+    );
+    const secondError = createPreloadError(
+      "Failed to fetch dynamically imported module: https://ceilf6.github.io/code-tape/assets/transformers.web-Ddnr203B.js",
+    );
+
+    target.dispatchEvent(firstError);
+    target.dispatchEvent(secondError);
+
+    expect(firstError.defaultPrevented).toBe(true);
+    expect(secondError.defaultPrevented).toBe(true);
+    expect(reload).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not reload for unrelated preload errors", () => {
+    const reload = vi.fn();
+    const target = new EventTarget();
+    installStaleChunkRecovery({
+      target,
+      storage: {
+        getItem: () => null,
+        setItem: vi.fn(),
+      },
+      reload,
+      getRecoveryToken: () => "entry-index-A.js",
+    });
+
+    const event = createPreloadError("Cannot read properties of undefined");
+
+    target.dispatchEvent(event);
+
+    expect(event.defaultPrevented).toBe(false);
+    expect(reload).not.toHaveBeenCalled();
+  });
+
+  it("still reloads once when session storage writes fail", () => {
+    const reload = vi.fn();
+    const target = new EventTarget();
+    installStaleChunkRecovery({
+      target,
+      storage: {
+        getItem: () => null,
+        setItem: () => {
+          throw new Error("storage blocked");
+        },
+      },
+      reload,
+      getRecoveryToken: () => "entry-index-storage-blocked.js",
+    });
+
+    target.dispatchEvent(createPreloadError("Importing a module script failed."));
+    target.dispatchEvent(createPreloadError("Importing a module script failed."));
+
+    expect(reload).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/src/app/staleChunkRecovery.ts
+++ b/apps/web/src/app/staleChunkRecovery.ts
@@ -1,0 +1,88 @@
+type StaleChunkRecoveryTarget = Pick<EventTarget, "addEventListener" | "removeEventListener">;
+
+type StaleChunkRecoveryStorage = {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+};
+
+type VitePreloadErrorEvent = Event & {
+  payload?: unknown;
+};
+
+export type StaleChunkRecoveryOptions = {
+  target?: StaleChunkRecoveryTarget;
+  storage?: StaleChunkRecoveryStorage;
+  reload?: () => void;
+  getRecoveryToken?: () => string;
+};
+
+const STALE_CHUNK_RECOVERY_KEY = "code-tape:stale-chunk-recovery";
+const RECOVERABLE_DYNAMIC_IMPORT_ERROR =
+  /Failed to fetch dynamically imported module|Importing a module script failed|error loading dynamically imported module|Load failed|NetworkError|Failed to fetch/iu;
+
+let inMemoryRecoveryToken: string | null = null;
+
+export function installStaleChunkRecovery(options: StaleChunkRecoveryOptions = {}): () => void {
+  const target = options.target ?? globalThis;
+  const reload = options.reload ?? (() => globalThis.location.reload());
+  const getRecoveryToken = options.getRecoveryToken ?? readDefaultRecoveryToken;
+  const storage = options.storage ?? readSessionStorage();
+
+  const handlePreloadError = (event: Event) => {
+    if (!isRecoverablePreloadError(event)) return;
+    event.preventDefault();
+
+    const recoveryToken = getRecoveryToken();
+    if (readRecoveryToken(storage) === recoveryToken) return;
+
+    writeRecoveryToken(storage, recoveryToken);
+    reload();
+  };
+
+  target.addEventListener("vite:preloadError", handlePreloadError);
+  return () => target.removeEventListener("vite:preloadError", handlePreloadError);
+}
+
+function isRecoverablePreloadError(event: Event): boolean {
+  const error = (event as VitePreloadErrorEvent).payload;
+  const message = error instanceof Error ? error.message : String(error);
+  return RECOVERABLE_DYNAMIC_IMPORT_ERROR.test(message);
+}
+
+function readDefaultRecoveryToken(): string {
+  if (typeof document !== "undefined") {
+    const script = document.querySelector<HTMLScriptElement>('script[type="module"][src]');
+    if (script?.src) return script.src;
+  }
+  return typeof location !== "undefined" ? location.href : "unknown-entry";
+}
+
+function readSessionStorage(): StaleChunkRecoveryStorage | undefined {
+  try {
+    return globalThis.sessionStorage;
+  } catch {
+    return undefined;
+  }
+}
+
+function readRecoveryToken(storage: StaleChunkRecoveryStorage | undefined): string | null {
+  if (!storage) return inMemoryRecoveryToken;
+  try {
+    return storage.getItem(STALE_CHUNK_RECOVERY_KEY) ?? inMemoryRecoveryToken;
+  } catch {
+    return inMemoryRecoveryToken;
+  }
+}
+
+function writeRecoveryToken(
+  storage: StaleChunkRecoveryStorage | undefined,
+  recoveryToken: string,
+): void {
+  inMemoryRecoveryToken = recoveryToken;
+  if (!storage) return;
+  try {
+    storage.setItem(STALE_CHUNK_RECOVERY_KEY, recoveryToken);
+  } catch {
+    // Session storage can be blocked; the in-memory token still prevents loops in this runtime.
+  }
+}

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -1,7 +1,10 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
 import { App } from "./app/App";
+import { installStaleChunkRecovery } from "./app/staleChunkRecovery";
 import "./styles/globals.css";
+
+installStaleChunkRecovery();
 
 const rootElement = document.getElementById("root");
 if (!rootElement) {


### PR DESCRIPTION
## Summary
- Install a Vite `vite:preloadError` recovery hook at the web entrypoint.
- Detect stale dynamic import / chunk fetch failures such as `transformers.web-Ddnr203B.js`, prevent the preload error, and reload once per entry script to avoid loops.
- Keep ASR model, ASR `language: "chinese"`, LLM model, prompt, and subtitle contracts unchanged.

Closes #175

## Tests
- RED: `npm --workspace apps/web run test -- --run src/app/__tests__/staleChunkRecovery.test.ts` failed before implementation because `../staleChunkRecovery` did not exist.
- `npm --workspace apps/web run test -- --run src/app/__tests__/staleChunkRecovery.test.ts src/features/subtitles/__tests__/transformersLoader.test.ts src/features/subtitles/__tests__/subtitleTranscriber.test.ts` -> 17 passed.
- `npm run build -w apps/web` -> passed.
- `npm run quality:local` -> passed: GitNexus contract passed; 193 script/API tests passed; 553 web tests passed; build passed; 6 Playwright e2e passed.

## GitNexus Impact
- `detect_changes --scope compare --base-ref origin/main` -> 3 files, 22 symbols, 0 affected processes, risk low.
- `context installStaleChunkRecovery` -> only incoming caller is `apps/web/src/main.tsx`; no indexed processes affected.
