### PR TITLE
#177 add candidate events data channel

### DIFF
--- a/apps/web/src/features/interview/CandidateInterviewPage.tsx
+++ b/apps/web/src/features/interview/CandidateInterviewPage.tsx
@@ -77,6 +77,7 @@ const EMPTY_CANDIDATE_MEDIA_STATE: InterviewMediaSessionState = {
   iceConnectionState: "new",
   signalingState: "stable",
   outgoingIceCandidates: [],
+  eventsDataChannelState: "not-created",
 };
 
 export function CandidateInterviewPage({ deps = {} }: CandidateInterviewPageProps = {}) {
@@ -287,6 +288,10 @@ function useCandidateInterviewRoomSession({
               throw new Error("candidate media session is not available");
             }
             await currentMediaSession.requestLocalMedia();
+            if (!isCurrentMediaSession(currentMediaSession, currentMediaSessionVersion)) {
+              return;
+            }
+            currentMediaSession.ensureEventsDataChannel();
             if (!isCurrentMediaSession(currentMediaSession, currentMediaSessionVersion)) {
               return;
             }

--- a/apps/web/src/features/interview/RemoteInterviewWorkbenchPage.tsx
+++ b/apps/web/src/features/interview/RemoteInterviewWorkbenchPage.tsx
@@ -36,6 +36,7 @@ const EMPTY_INTERVIEW_MEDIA_SESSION_STATE: InterviewMediaSessionState = {
   iceConnectionState: "new",
   signalingState: "stable",
   outgoingIceCandidates: [],
+  eventsDataChannelState: "not-created",
 };
 
 export function RemoteInterviewWorkbenchPage() {

--- a/apps/web/src/features/interview/__tests__/CandidateInterviewPage.test.tsx
+++ b/apps/web/src/features/interview/__tests__/CandidateInterviewPage.test.tsx
@@ -5,7 +5,11 @@ import { describe, expect, it, vi } from "vitest";
 import { appRoutes } from "@/app/routes";
 import { ThemeProvider } from "@/shared/ui/themeProvider";
 import { TooltipProvider } from "@/shared/ui/Tooltip";
-import type { InterviewMediaSession, InterviewMediaSessionState } from "../interviewMediaSession";
+import type {
+  InterviewEventsDataChannel,
+  InterviewMediaSession,
+  InterviewMediaSessionState,
+} from "../interviewMediaSession";
 import type { InterviewRoomClient } from "../interviewRoomClient";
 import type {
   InboundSignalingMessage,
@@ -107,9 +111,13 @@ describe("CandidateInterviewPage", () => {
 
     await waitFor(() => {
       expect(media.session.requestLocalMedia).toHaveBeenCalledTimes(1);
+      expect(media.session.ensureEventsDataChannel).toHaveBeenCalledTimes(1);
       expect(media.session.createOffer).toHaveBeenCalledTimes(1);
       expect(signaling.client.sendOffer).toHaveBeenCalledWith("candidate-offer-sdp");
     });
+    expect(
+      vi.mocked(media.session.ensureEventsDataChannel).mock.invocationCallOrder[0],
+    ).toBeLessThan(vi.mocked(media.session.createOffer).mock.invocationCallOrder[0]);
     expect(screen.getByRole("button", { name: "麦克风已开启" })).toBeDisabled();
     expect(screen.getByRole("button", { name: "摄像头已开启" })).toBeDisabled();
 
@@ -123,6 +131,7 @@ describe("CandidateInterviewPage", () => {
     });
 
     expect(media.session.requestLocalMedia).toHaveBeenCalledTimes(1);
+    expect(media.session.ensureEventsDataChannel).toHaveBeenCalledTimes(1);
     expect(media.session.createOffer).toHaveBeenCalledTimes(1);
     expect(signaling.client.sendOffer).toHaveBeenCalledTimes(1);
   });
@@ -288,6 +297,39 @@ describe("CandidateInterviewPage", () => {
     expect(await screen.findAllByText("连接失败")).toHaveLength(2);
     expect(screen.getByText("camera denied")).toBeInTheDocument();
     expect(screen.getByTestId("recorder-workspace")).toBeInTheDocument();
+    expect(media.session.close).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps the recorder workspace visible when candidate events data channel setup fails", async () => {
+    const roomClient = makeRoomClient();
+    const signaling = makeSignalingFactory();
+    const media = makeMediaSessionFactory({
+      ensureEventsDataChannel: vi.fn(() => {
+        throw new Error("events data channel failed");
+      }),
+    });
+
+    renderCandidatePage({
+      initialEntry: "/interview/candidate",
+      roomClient,
+      createSignalingClient: signaling.create,
+      createMediaSession: media.create,
+    });
+    await screen.findByText("room-created");
+
+    act(() => {
+      signaling.emit({
+        kind: "joined",
+        roomId: "room-created",
+        role: "interviewer",
+        status: "live",
+      });
+    });
+
+    expect(await screen.findAllByText("连接失败")).toHaveLength(2);
+    expect(screen.getByText("events data channel failed")).toBeInTheDocument();
+    expect(screen.getByTestId("recorder-workspace")).toBeInTheDocument();
+    expect(media.session.createOffer).not.toHaveBeenCalled();
     expect(media.session.close).toHaveBeenCalledTimes(1);
   });
 
@@ -550,6 +592,9 @@ describe("CandidateInterviewPage", () => {
         role: "interviewer",
         status: "live",
       });
+    });
+    await waitFor(() => {
+      expect(signaling.client.sendOffer).toHaveBeenCalledTimes(1);
     });
     expect(screen.getByText("面试官在线")).toBeInTheDocument();
   });
@@ -862,6 +907,7 @@ function makeMediaState(
     iceConnectionState: "new",
     signalingState: "stable",
     outgoingIceCandidates: [],
+    eventsDataChannelState: "not-created",
     ...patch,
   };
 }
@@ -931,6 +977,13 @@ function makeMediaSessionFactory(patch: Partial<InterviewMediaSession> = {}) {
   };
   const localStream = {} as MediaStream;
   const remoteStream = {} as MediaStream;
+  const eventsDataChannel: InterviewEventsDataChannel = {
+    readyState: "connecting",
+    onopen: null,
+    onclose: null,
+    send: vi.fn(),
+    close: vi.fn(),
+  };
   const session: InterviewMediaSession = {
     getState: vi.fn(() => state),
     requestLocalMedia: vi.fn(async () =>
@@ -952,6 +1005,10 @@ function makeMediaSessionFactory(patch: Partial<InterviewMediaSession> = {}) {
     ),
     createOffer: vi.fn(async () => ({ type: "offer" as const, sdp: "candidate-offer-sdp" })),
     createAnswer: vi.fn(async () => ({ type: "answer" as const, sdp: "candidate-answer-sdp" })),
+    ensureEventsDataChannel: vi.fn(() => {
+      updateState({ eventsDataChannelState: eventsDataChannel.readyState });
+      return eventsDataChannel;
+    }),
     setRemoteDescription: vi.fn(async () => state),
     addRemoteIceCandidate: vi.fn(async () => state),
     drainOutgoingIceCandidates: vi.fn(() => {

--- a/apps/web/src/features/interview/__tests__/RemoteInterviewWorkbenchPage.test.tsx
+++ b/apps/web/src/features/interview/__tests__/RemoteInterviewWorkbenchPage.test.tsx
@@ -234,6 +234,7 @@ function makeMediaState(
     iceConnectionState: "new",
     signalingState: "stable",
     outgoingIceCandidates: [],
+    eventsDataChannelState: "not-created",
     ...patch,
   };
 }

--- a/apps/web/src/features/interview/__tests__/interviewMediaSession.test.ts
+++ b/apps/web/src/features/interview/__tests__/interviewMediaSession.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   createInterviewMediaSession,
+  type InterviewEventsDataChannel,
   type InterviewMediaSessionDependencies,
   type InterviewPeerConnection,
 } from "../interviewMediaSession";
@@ -42,6 +43,26 @@ class FakeMediaStream {
   }
 }
 
+class FakeDataChannel implements InterviewEventsDataChannel {
+  readyState: RTCDataChannelState = "connecting";
+  onopen: (() => void) | null = null;
+  onclose: (() => void) | null = null;
+  closeCalls = 0;
+
+  send(): void {}
+
+  open(): void {
+    this.readyState = "open";
+    this.onopen?.();
+  }
+
+  close(): void {
+    this.closeCalls += 1;
+    this.readyState = "closed";
+    this.onclose?.();
+  }
+}
+
 class FakePeerConnection implements InterviewPeerConnection {
   localDescription: RTCSessionDescriptionInit | null = null;
   remoteDescription: RTCSessionDescriptionInit | null = null;
@@ -56,10 +77,21 @@ class FakePeerConnection implements InterviewPeerConnection {
   onsignalingstatechange: (() => void) | null = null;
   readonly addedTracks: Array<{ track: MediaStreamTrack; stream: MediaStream }> = [];
   readonly remoteCandidates: Array<RTCIceCandidateInit | null> = [];
+  readonly createdDataChannels: Array<{
+    label: string;
+    options?: RTCDataChannelInit;
+    channel: FakeDataChannel;
+  }> = [];
   closed = false;
 
   addTrack(track: MediaStreamTrack, stream: MediaStream): void {
     this.addedTracks.push({ track, stream });
+  }
+
+  createDataChannel(label: string, options?: RTCDataChannelInit): InterviewEventsDataChannel {
+    const channel = new FakeDataChannel();
+    this.createdDataChannels.push({ label, options, channel });
+    return channel;
   }
 
   async createOffer(): Promise<RTCSessionDescriptionInit> {
@@ -183,6 +215,28 @@ describe("InterviewMediaSession", () => {
     ]);
   });
 
+  it("creates a reliable ordered events data channel once and exposes its lifecycle state", () => {
+    const { peer, deps } = createFixture();
+    const session = createInterviewMediaSession({ deps });
+
+    expect(session.getState().eventsDataChannelState).toBe("not-created");
+
+    const channel = session.ensureEventsDataChannel();
+    const reused = session.ensureEventsDataChannel();
+
+    expect(reused).toBe(channel);
+    expect(peer.createdDataChannels).toHaveLength(1);
+    expect(peer.createdDataChannels[0]).toMatchObject({
+      label: "events",
+      options: { ordered: true },
+    });
+    expect(session.getState().eventsDataChannelState).toBe("connecting");
+
+    peer.createdDataChannels[0].channel.open();
+
+    expect(session.getState().eventsDataChannelState).toBe("open");
+  });
+
   it("queues local ICE candidates for the signaling layer and clears them after drain", () => {
     const { peer, deps } = createFixture();
     const session = createInterviewMediaSession({ deps });
@@ -239,6 +293,18 @@ describe("InterviewMediaSession", () => {
       microphoneEnabled: false,
       cameraEnabled: false,
     });
+  });
+
+  it("closes the events data channel when closed", () => {
+    const { peer, deps } = createFixture();
+    const session = createInterviewMediaSession({ deps });
+    session.ensureEventsDataChannel();
+
+    const closed = session.close();
+
+    expect(peer.createdDataChannels[0].channel.closeCalls).toBe(1);
+    expect(closed.eventsDataChannelState).toBe("closed");
+    expect(session.getState().eventsDataChannelState).toBe("closed");
   });
 
   it("stops local media if the session closes while getUserMedia is pending", async () => {

--- a/apps/web/src/features/interview/index.ts
+++ b/apps/web/src/features/interview/index.ts
@@ -16,6 +16,8 @@ export {
 } from "./interviewSync";
 export {
   createInterviewMediaSession,
+  type InterviewDataChannelState,
+  type InterviewEventsDataChannel,
   type InterviewIceCandidateEvent,
   type InterviewIceCandidateSignal,
   type InterviewMediaSession,

--- a/apps/web/src/features/interview/interviewMediaSession.ts
+++ b/apps/web/src/features/interview/interviewMediaSession.ts
@@ -9,6 +9,16 @@ export type InterviewTrackEvent = {
   streams: MediaStream[];
 };
 
+export type InterviewDataChannelState = "not-created" | RTCDataChannelState;
+
+export type InterviewEventsDataChannel = {
+  readonly readyState: RTCDataChannelState;
+  onopen: (() => void) | null;
+  onclose: (() => void) | null;
+  send(data: string): void;
+  close(): void;
+};
+
 export type InterviewPeerConnection = {
   readonly localDescription: RTCSessionDescriptionInit | null;
   readonly remoteDescription: RTCSessionDescriptionInit | null;
@@ -21,6 +31,7 @@ export type InterviewPeerConnection = {
   oniceconnectionstatechange: (() => void) | null;
   onsignalingstatechange: (() => void) | null;
   addTrack(track: MediaStreamTrack, stream: MediaStream): void;
+  createDataChannel(label: string, dataChannelDict?: RTCDataChannelInit): InterviewEventsDataChannel;
   createOffer(options?: RTCOfferOptions): Promise<RTCSessionDescriptionInit>;
   createAnswer(options?: RTCAnswerOptions): Promise<RTCSessionDescriptionInit>;
   setLocalDescription(description: RTCSessionDescriptionInit): Promise<void>;
@@ -50,6 +61,7 @@ export type InterviewMediaSessionState = {
   iceConnectionState: RTCIceConnectionState;
   signalingState: RTCSignalingState;
   outgoingIceCandidates: InterviewIceCandidateSignal[];
+  eventsDataChannelState: InterviewDataChannelState;
 };
 
 export type InterviewMediaSession = {
@@ -57,6 +69,7 @@ export type InterviewMediaSession = {
   requestLocalMedia(constraints?: MediaStreamConstraints): Promise<InterviewMediaSessionState>;
   setMicrophoneEnabled(enabled: boolean): InterviewMediaSessionState;
   setCameraEnabled(enabled: boolean): InterviewMediaSessionState;
+  ensureEventsDataChannel(): InterviewEventsDataChannel;
   createOffer(options?: RTCOfferOptions): Promise<RTCSessionDescriptionInit>;
   createAnswer(options?: RTCAnswerOptions): Promise<RTCSessionDescriptionInit>;
   setRemoteDescription(description: RTCSessionDescriptionInit): Promise<InterviewMediaSessionState>;
@@ -67,6 +80,8 @@ export type InterviewMediaSession = {
 };
 
 const DEFAULT_MEDIA_CONSTRAINTS: MediaStreamConstraints = { audio: true, video: true };
+const EVENTS_DATA_CHANNEL_LABEL = "events";
+const EVENTS_DATA_CHANNEL_OPTIONS: RTCDataChannelInit = { ordered: true };
 
 export function createInterviewMediaSession(
   options: InterviewMediaSessionOptions = {},
@@ -79,6 +94,7 @@ export function createInterviewMediaSession(
   let microphoneEnabled = false;
   let cameraEnabled = false;
   let outgoingIceCandidates: InterviewIceCandidateSignal[] = [];
+  let eventsDataChannel: InterviewEventsDataChannel | null = null;
   let closed = false;
 
   const snapshot = (): InterviewMediaSessionState => ({
@@ -90,6 +106,7 @@ export function createInterviewMediaSession(
     iceConnectionState: closed ? "closed" : peer.iceConnectionState,
     signalingState: closed ? "closed" : peer.signalingState,
     outgoingIceCandidates: cloneIceCandidates(outgoingIceCandidates),
+    eventsDataChannelState: closed ? "closed" : eventsDataChannel?.readyState ?? "not-created",
   });
 
   const notify = (): InterviewMediaSessionState => {
@@ -151,6 +168,22 @@ export function createInterviewMediaSession(
       cameraEnabled = hasEnabledTrack(localStream, "video");
       return notify();
     },
+    ensureEventsDataChannel() {
+      if (closed) {
+        throw new Error("Interview media session is closed");
+      }
+      if (eventsDataChannel) {
+        return eventsDataChannel;
+      }
+      eventsDataChannel = peer.createDataChannel(
+        EVENTS_DATA_CHANNEL_LABEL,
+        EVENTS_DATA_CHANNEL_OPTIONS,
+      );
+      eventsDataChannel.onopen = notify;
+      eventsDataChannel.onclose = notify;
+      notify();
+      return eventsDataChannel;
+    },
     async createOffer(offerOptions) {
       const offer = await peer.createOffer(offerOptions);
       await peer.setLocalDescription(offer);
@@ -197,10 +230,21 @@ export function createInterviewMediaSession(
       microphoneEnabled = false;
       cameraEnabled = false;
       outgoingIceCandidates = [];
+      closeEventsDataChannel(eventsDataChannel);
+      eventsDataChannel = null;
       peer.close();
       return notify();
     },
   };
+}
+
+function closeEventsDataChannel(channel: InterviewEventsDataChannel | null): void {
+  if (!channel) {
+    return;
+  }
+  channel.onopen = null;
+  channel.onclose = null;
+  channel.close();
 }
 
 function resolveDependencies(deps: InterviewMediaSessionDependencies = {}): Required<InterviewMediaSessionDependencies> {


### PR DESCRIPTION
## 关联

Refs #120（总控 issue，不在本 PR 中关闭）
Closes #177

## 改动点

- 为 `InterviewMediaSession` 增加候选人侧 `events` DataChannel 的创建、复用、生命周期状态与关闭清理。
- 候选人页在创建 WebRTC offer 前确保创建可靠有序的 `events` DataChannel，创建失败时进入连接失败状态并保留录制工作区。
- 补充 media session 与候选人页测试，覆盖通道 ordered 配置、重复 live 不重复创建、close 关闭通道、DataChannel 创建失败兜底。

## 影响范围

- 影响候选人 WebRTC 建连的 offer 前准备流程，以及 `InterviewMediaSessionState` 的类型字段。
- 面试官工作台仅补齐空 media state 的新增字段；不接入 `InterviewSyncPublisher`，不修改 signaling 协议，不发送录制事件。

## GitNexus 影响分析摘要

- 风险等级: `detect_changes` 标记为 high，因为本 PR 触达 `startCandidateMediaOffer`、`useCandidateInterviewRoomSession`、`createInterviewMediaSession`、`snapshot`/`notify` 等 WebRTC 建连主流程。
- 关键骨架变更: `npm run quality:local` 的 GitNexus contract 结果为 passed，并提示 “No critical contract surface changed; GitNexus analysis is advisory for this diff”。
- GitNexus 影响面: `gitnexus impact createInterviewMediaSession --depth 2 --include-tests` 结果为 upstream `LOW`，`impactedCount: 0`，`modules_affected: 0`，`processes_affected: 0`。
- 验证结果: `npm run quality:local` 通过；其中 web 单测 58 files / 564 tests passed，Playwright e2e 6 passed。

## 自检

- [x] 未修改 `docs/progress.json` 或 `docs/progress.md`
- [x] 已运行 `npm run quality:local`，或说明无法运行的原因
- [x] 不涉及 AI 字幕：无需记录 `npm run subtitle:postprocess:evaluate` 结果
- [x] 不涉及 AI 字幕点击链路、LLM worker、模型加载或性能：无需记录 runtime benchmark
- [x] 已说明改动点和影响范围
- [x] 如果改动关键骨架，已补充契约测试并填写 GitNexus 影响分析摘要
- [ ] 已等待 repo-guard、codex 和 Copilot 评论，并完成必要审查
