### PR TITLE
[P1+ WebRTC] 面试官接收 events DataChannel 生命周期

### DIFF
--- a/apps/web/src/features/interview/RemoteInterviewWorkbenchPage.tsx
+++ b/apps/web/src/features/interview/RemoteInterviewWorkbenchPage.tsx
@@ -209,6 +209,7 @@ function InterviewMediaPanel({ state }: { state: InterviewMediaSessionState }) {
       <dl className="mt-3 grid gap-2 text-xs">
         <Metric label="WebRTC" value={state.connectionState} />
         <Metric label="ICE" value={state.iceConnectionState} />
+        <Metric label="事件通道" value={state.eventsDataChannelState} />
       </dl>
     </section>
   );

--- a/apps/web/src/features/interview/__tests__/CandidateInterviewPage.test.tsx
+++ b/apps/web/src/features/interview/__tests__/CandidateInterviewPage.test.tsx
@@ -978,6 +978,7 @@ function makeMediaSessionFactory(patch: Partial<InterviewMediaSession> = {}) {
   const localStream = {} as MediaStream;
   const remoteStream = {} as MediaStream;
   const eventsDataChannel: InterviewEventsDataChannel = {
+    label: "events",
     readyState: "connecting",
     onopen: null,
     onclose: null,

--- a/apps/web/src/features/interview/__tests__/RemoteInterviewWorkbenchPage.test.tsx
+++ b/apps/web/src/features/interview/__tests__/RemoteInterviewWorkbenchPage.test.tsx
@@ -116,6 +116,7 @@ describe("RemoteInterviewWorkbenchPage", () => {
         cameraEnabled: false,
         connectionState: "connecting",
         iceConnectionState: "checking",
+        eventsDataChannelState: "open",
       }),
     });
 
@@ -129,6 +130,8 @@ describe("RemoteInterviewWorkbenchPage", () => {
     expect(screen.getByText("connecting")).toBeInTheDocument();
     expect(screen.getByText("ICE")).toBeInTheDocument();
     expect(screen.getByText("checking")).toBeInTheDocument();
+    expect(screen.getByText("事件通道")).toBeInTheDocument();
+    expect(screen.getByText("open")).toBeInTheDocument();
   });
 
   it("binds local and remote media streams into video elements", async () => {

--- a/apps/web/src/features/interview/__tests__/interviewMediaSession.test.ts
+++ b/apps/web/src/features/interview/__tests__/interviewMediaSession.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   createInterviewMediaSession,
+  type InterviewDataChannelEvent,
   type InterviewEventsDataChannel,
   type InterviewMediaSessionDependencies,
   type InterviewPeerConnection,
@@ -49,6 +50,8 @@ class FakeDataChannel implements InterviewEventsDataChannel {
   onclose: (() => void) | null = null;
   closeCalls = 0;
 
+  constructor(readonly label = "events") {}
+
   send(): void {}
 
   open(): void {
@@ -72,6 +75,7 @@ class FakePeerConnection implements InterviewPeerConnection {
   onicecandidate: ((event: { candidate: RTCIceCandidate | RTCIceCandidateInit | null }) => void) | null =
     null;
   ontrack: ((event: { track: MediaStreamTrack; streams: MediaStream[] }) => void) | null = null;
+  ondatachannel: ((event: InterviewDataChannelEvent) => void) | null = null;
   onconnectionstatechange: (() => void) | null = null;
   oniceconnectionstatechange: (() => void) | null = null;
   onsignalingstatechange: (() => void) | null = null;
@@ -89,7 +93,7 @@ class FakePeerConnection implements InterviewPeerConnection {
   }
 
   createDataChannel(label: string, options?: RTCDataChannelInit): InterviewEventsDataChannel {
-    const channel = new FakeDataChannel();
+    const channel = new FakeDataChannel(label);
     this.createdDataChannels.push({ label, options, channel });
     return channel;
   }
@@ -125,6 +129,12 @@ class FakePeerConnection implements InterviewPeerConnection {
 
   emitRemoteTrack(track: MediaStreamTrack, stream?: MediaStream): void {
     this.ontrack?.({ track, streams: stream ? [stream] : [] });
+  }
+
+  emitDataChannel(label: string): FakeDataChannel {
+    const channel = new FakeDataChannel(label);
+    this.ondatachannel?.({ channel });
+    return channel;
   }
 
   setConnectionState(state: RTCPeerConnectionState): void {
@@ -237,6 +247,35 @@ describe("InterviewMediaSession", () => {
     expect(session.getState().eventsDataChannelState).toBe("open");
   });
 
+  it("receives a remote events data channel and exposes its lifecycle state", () => {
+    const { peer, deps } = createFixture();
+    const session = createInterviewMediaSession({ deps });
+    const observedStates: Array<ReturnType<typeof session.getState>["eventsDataChannelState"]> = [];
+    session.subscribe((state) => {
+      observedStates.push(state.eventsDataChannelState);
+    });
+
+    const channel = peer.emitDataChannel("events");
+
+    expect(session.getState().eventsDataChannelState).toBe("connecting");
+
+    channel.open();
+    channel.close();
+
+    expect(session.getState().eventsDataChannelState).toBe("closed");
+    expect(observedStates).toEqual(["connecting", "open", "closed"]);
+  });
+
+  it("ignores remote data channels that are not the events channel", () => {
+    const { peer, deps } = createFixture();
+    const session = createInterviewMediaSession({ deps });
+
+    const channel = peer.emitDataChannel("presence");
+    channel.open();
+
+    expect(session.getState().eventsDataChannelState).toBe("not-created");
+  });
+
   it("queues local ICE candidates for the signaling layer and clears them after drain", () => {
     const { peer, deps } = createFixture();
     const session = createInterviewMediaSession({ deps });
@@ -303,6 +342,18 @@ describe("InterviewMediaSession", () => {
     const closed = session.close();
 
     expect(peer.createdDataChannels[0].channel.closeCalls).toBe(1);
+    expect(closed.eventsDataChannelState).toBe("closed");
+    expect(session.getState().eventsDataChannelState).toBe("closed");
+  });
+
+  it("closes a received remote events data channel when closed", () => {
+    const { peer, deps } = createFixture();
+    const session = createInterviewMediaSession({ deps });
+    const channel = peer.emitDataChannel("events");
+
+    const closed = session.close();
+
+    expect(channel.closeCalls).toBe(1);
     expect(closed.eventsDataChannelState).toBe("closed");
     expect(session.getState().eventsDataChannelState).toBe("closed");
   });

--- a/apps/web/src/features/interview/interviewMediaSession.ts
+++ b/apps/web/src/features/interview/interviewMediaSession.ts
@@ -12,11 +12,16 @@ export type InterviewTrackEvent = {
 export type InterviewDataChannelState = "not-created" | RTCDataChannelState;
 
 export type InterviewEventsDataChannel = {
+  readonly label: string;
   readonly readyState: RTCDataChannelState;
   onopen: (() => void) | null;
   onclose: (() => void) | null;
   send(data: string): void;
   close(): void;
+};
+
+export type InterviewDataChannelEvent = {
+  channel: InterviewEventsDataChannel;
 };
 
 export type InterviewPeerConnection = {
@@ -27,6 +32,7 @@ export type InterviewPeerConnection = {
   readonly signalingState: RTCSignalingState;
   onicecandidate: ((event: InterviewIceCandidateEvent) => void) | null;
   ontrack: ((event: InterviewTrackEvent) => void) | null;
+  ondatachannel: ((event: InterviewDataChannelEvent) => void) | null;
   onconnectionstatechange: (() => void) | null;
   oniceconnectionstatechange: (() => void) | null;
   onsignalingstatechange: (() => void) | null;
@@ -115,6 +121,14 @@ export function createInterviewMediaSession(
     return next;
   };
 
+  const attachEventsDataChannel = (channel: InterviewEventsDataChannel): InterviewEventsDataChannel => {
+    eventsDataChannel = channel;
+    eventsDataChannel.onopen = notify;
+    eventsDataChannel.onclose = notify;
+    notify();
+    return eventsDataChannel;
+  };
+
   peer.onicecandidate = (event) => {
     if (closed) {
       return;
@@ -131,6 +145,12 @@ export function createInterviewMediaSession(
       remoteStream.addTrack(event.track);
     }
     notify();
+  };
+  peer.ondatachannel = (event) => {
+    if (closed || event.channel.label !== EVENTS_DATA_CHANNEL_LABEL || eventsDataChannel) {
+      return;
+    }
+    attachEventsDataChannel(event.channel);
   };
   peer.onconnectionstatechange = notify;
   peer.oniceconnectionstatechange = notify;
@@ -175,14 +195,9 @@ export function createInterviewMediaSession(
       if (eventsDataChannel) {
         return eventsDataChannel;
       }
-      eventsDataChannel = peer.createDataChannel(
-        EVENTS_DATA_CHANNEL_LABEL,
-        EVENTS_DATA_CHANNEL_OPTIONS,
+      return attachEventsDataChannel(
+        peer.createDataChannel(EVENTS_DATA_CHANNEL_LABEL, EVENTS_DATA_CHANNEL_OPTIONS),
       );
-      eventsDataChannel.onopen = notify;
-      eventsDataChannel.onclose = notify;
-      notify();
-      return eventsDataChannel;
     },
     async createOffer(offerOptions) {
       const offer = await peer.createOffer(offerOptions);
@@ -221,6 +236,7 @@ export function createInterviewMediaSession(
       closed = true;
       peer.onicecandidate = null;
       peer.ontrack = null;
+      peer.ondatachannel = null;
       peer.onconnectionstatechange = null;
       peer.oniceconnectionstatechange = null;
       peer.onsignalingstatechange = null;
@@ -244,7 +260,9 @@ function closeEventsDataChannel(channel: InterviewEventsDataChannel | null): voi
   }
   channel.onopen = null;
   channel.onclose = null;
-  channel.close();
+  if (channel.readyState !== "closed") {
+    channel.close();
+  }
 }
 
 function resolveDependencies(deps: InterviewMediaSessionDependencies = {}): Required<InterviewMediaSessionDependencies> {


### PR DESCRIPTION
## 关联

Refs #120（WebRTC 总控 issue，不在本 PR 中关闭）
Closes #181

## 改动点

- `InterviewMediaSession` 监听远端 `ondatachannel`，只接收 `label === "events"` 的可靠事件通道，并复用现有 `eventsDataChannelState` 暴露生命周期。
- 复用同一个 attach/close 流程处理候选人本地创建和面试官远端接收，session 关闭时清理 `ondatachannel` 并关闭已接收通道。
- 面试官工作台音视频面板展示 `事件通道` 状态，便于后续接入实时事件流前观察通道生命周期。
- 补充 TDD 测试：远端 events 通道接收、非 events 通道忽略、关闭 session 时关闭远端通道，以及面试官侧栏展示事件通道状态。

## 影响范围

- WebRTC 面试媒体会话核心：`apps/web/src/features/interview/interviewMediaSession.ts`
- 面试官只读工作台侧栏状态展示：`apps/web/src/features/interview/RemoteInterviewWorkbenchPage.tsx`
- 相关单元测试与候选人页测试 fake 类型补齐。
- 不改信令协议，不发送/解析 `InterviewRealtimeMessage`，不接入 publisher、jitter buffer 或快照重同步。

## GitNexus 影响分析摘要

- 风险等级: medium（`detect_changes --scope compare --base-ref origin/main`，5 files / 5 symbols / 3 flows）
- 关键骨架变更: 否；`contract:local` 提示 no critical contract surface changed，GitNexus 为 advisory。
- GitNexus 影响面: `createInterviewMediaSession` upstream impactedCount 0 / risk LOW；`InterviewMediaPanel` upstream impactedCount 2 / risk LOW，仅影响 `RemoteInterviewWorkbenchView`/页面链路。
- 验证结果: targeted interview tests 44 passed；`npm run quality:precommit` passed；`npm run quality:local` passed，本地 push hook 再次运行 `quality:local` passed（含 Playwright 6 passed）。

## 自检

- [x] 未修改 `docs/progress.json` 或 `docs/progress.md`
- [x] 已运行 `npm run quality:local`，或说明无法运行的原因
- [x] 涉及 AI 字幕时，已记录一次 `npm run subtitle:postprocess:evaluate` 的“纠错并生成章节”效果验证结果，包含 `representativeOutputSource`、`overallEvaluationDurationMs`，并区分输出校验耗时与真实端到端耗时（N/A，不涉及 AI 字幕）
- [x] 涉及 AI 字幕点击链路、LLM worker、模型加载或性能时，已记录一次 `npm run subtitle:postprocess:runtime-benchmark` 结果，包含 `postprocessClickToResultReadyDurationMs`、`postProcessTimeoutBudgetMs` 和 `playbackProbeResponsiveDuringPostprocess`（N/A，不涉及 AI 字幕）
- [x] 已说明改动点和影响范围
- [x] 如果改动关键骨架，已补充契约测试并填写 GitNexus 影响分析摘要（N/A，未改关键骨架；已补 GitNexus 摘要）
- [ ] 已等待 repo-guard、codex 和 Copilot 评论，并完成必要审查
