### PR TITLE
[Bug] 修复生成字幕 Transformers stale chunk 恢复

### DIFF
--- a/apps/web/src/features/subtitles/__tests__/subtitlePostProcessorWorkerClient.test.ts
+++ b/apps/web/src/features/subtitles/__tests__/subtitlePostProcessorWorkerClient.test.ts
@@ -122,6 +122,58 @@ describe("createWorkerBackedHuggingFaceSubtitlePostProcessor", () => {
     expect(JSON.stringify(onMetric.mock.calls[0]?.[0])).not.toContain("use state hook");
   });
 
+  it("forwards stale Transformers chunk errors from the worker to Vite preload recovery", async () => {
+    const worker = createMockWorker();
+    const dispatchEvent = vi.spyOn(globalThis, "dispatchEvent");
+    const postProcessor = createWorkerBackedHuggingFaceSubtitlePostProcessor({
+      workerFactory: () => worker as unknown as Worker,
+    });
+
+    const promise = postProcessor.process({ track: makeTrack() });
+    await flushPromises();
+    const request = worker.postMessage.mock.calls[0]?.[0] as { id: string };
+    const message =
+      "当前浏览器无法加载本地字幕 LLM 模型（wasm/q8）。原始错误：Failed to fetch dynamically imported module: https://ceilf6.github.io/code-tape/assets/transformers.web-Ddnr203B.js";
+
+    worker.dispatch({
+      id: request.id,
+      type: "error",
+      error: { name: "Error", message },
+      metrics: { workerRequestDurationMs: 20 },
+    });
+
+    await expect(promise).rejects.toThrow("Failed to fetch dynamically imported module");
+    expect(dispatchEvent).toHaveBeenCalledTimes(1);
+    const event = dispatchEvent.mock.calls[0]?.[0];
+    expect(event?.type).toBe("vite:preloadError");
+    expect(event?.cancelable).toBe(true);
+    expect((event as Event & { payload?: unknown }).payload).toMatchObject({ message });
+  });
+
+  it("does not forward plain worker fetch failures to stale chunk recovery", async () => {
+    const worker = createMockWorker();
+    const dispatchEvent = vi.spyOn(globalThis, "dispatchEvent");
+    const postProcessor = createWorkerBackedHuggingFaceSubtitlePostProcessor({
+      workerFactory: () => worker as unknown as Worker,
+    });
+
+    const promise = postProcessor.process({ track: makeTrack() });
+    await flushPromises();
+    const request = worker.postMessage.mock.calls[0]?.[0] as { id: string };
+    const message =
+      "当前浏览器无法加载本地字幕 LLM 模型（wasm/q8）。原始错误：Failed to fetch";
+
+    worker.dispatch({
+      id: request.id,
+      type: "error",
+      error: { name: "TypeError", message },
+      metrics: { workerRequestDurationMs: 20 },
+    });
+
+    await expect(promise).rejects.toThrow("Failed to fetch");
+    expect(dispatchEvent).not.toHaveBeenCalled();
+  });
+
   it("terminates in-flight worker inference when the request is aborted", async () => {
     const worker = createMockWorker();
     const onMetric = vi.fn();

--- a/apps/web/src/features/subtitles/__tests__/transformersLoader.test.ts
+++ b/apps/web/src/features/subtitles/__tests__/transformersLoader.test.ts
@@ -3,6 +3,7 @@ import {
   configureQuietBrowserCache,
   loadTransformersModule,
   loadTransformersPipeline,
+  requestStaleTransformersImportRecovery,
   type TransformersEnvironment,
   type TransformersModule,
 } from "../transformersLoader";
@@ -37,12 +38,14 @@ describe("transformersLoader", () => {
     const importer = vi
       .fn<() => Promise<TransformersModule>>()
       .mockRejectedValue(new SyntaxError("Unexpected token"));
+    const dispatchEvent = vi.spyOn(globalThis, "dispatchEvent");
 
     await expect(loadTransformersModule({ importer, retryDelayMs: 0 })).rejects.toThrow(
       "Unexpected token",
     );
 
     expect(importer).toHaveBeenCalledTimes(1);
+    expect(dispatchEvent).not.toHaveBeenCalled();
   });
 
   it("stops retrying after the configured import attempts", async () => {
@@ -56,6 +59,33 @@ describe("transformersLoader", () => {
 
     expect(importer).toHaveBeenCalledTimes(2);
     expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+
+  it("dispatches a Vite preload error when stale Transformers chunk loading is exhausted", async () => {
+    const error = new TypeError(
+      "Failed to fetch dynamically imported module: https://ceilf6.github.io/code-tape/assets/transformers.web-Ddnr203B.js",
+    );
+    const importer = vi.fn<() => Promise<TransformersModule>>().mockRejectedValue(error);
+    const dispatchEvent = vi.spyOn(globalThis, "dispatchEvent");
+
+    await expect(
+      loadTransformersModule({ importer, attempts: 2, retryDelayMs: 0 }),
+    ).rejects.toBe(error);
+
+    expect(dispatchEvent).toHaveBeenCalledTimes(1);
+    const event = dispatchEvent.mock.calls[0]?.[0];
+    expect(event?.type).toBe("vite:preloadError");
+    expect(event?.cancelable).toBe(true);
+    expect((event as Event & { payload?: unknown }).payload).toBe(error);
+  });
+
+  it("does not request stale chunk recovery for a plain fetch failure", () => {
+    const dispatchEvent = vi.spyOn(globalThis, "dispatchEvent");
+
+    const requested = requestStaleTransformersImportRecovery(new TypeError("Failed to fetch"));
+
+    expect(requested).toBe(false);
+    expect(dispatchEvent).not.toHaveBeenCalled();
   });
 
   it("loads a pipeline after a recovered import and applies the quiet browser cache", async () => {

--- a/apps/web/src/features/subtitles/subtitlePostProcessorWorkerClient.ts
+++ b/apps/web/src/features/subtitles/subtitlePostProcessorWorkerClient.ts
@@ -1,4 +1,5 @@
 import { DEFAULT_POSTPROCESSOR_MODEL } from "./subtitlePostProcessorConfig";
+import { requestStaleTransformersImportRecovery } from "./transformersLoader";
 import type {
   SubtitleCorrectionResult,
   SubtitlePostProcessor,
@@ -209,7 +210,9 @@ export function createWorkerBackedHuggingFaceSubtitlePostProcessor(
       pending.resolve(response.result, response.metrics);
       return;
     }
-    pending.reject(deserializeWorkerError(response.error), response.metrics);
+    const error = deserializeWorkerError(response.error);
+    requestStaleTransformersImportRecovery(error);
+    pending.reject(error, response.metrics);
   }
 
   function handleWorkerError(event: Event | ErrorEvent) {

--- a/apps/web/src/features/subtitles/transformersLoader.ts
+++ b/apps/web/src/features/subtitles/transformersLoader.ts
@@ -25,6 +25,7 @@ export type TransformersModuleLoaderOptions = {
 
 const DEFAULT_IMPORT_ATTEMPTS = 3;
 const DEFAULT_RETRY_DELAY_MS = 250;
+const VITE_PRELOAD_ERROR_EVENT = "vite:preloadError";
 
 export async function loadTransformersModule(
   options: TransformersModuleLoaderOptions = {},
@@ -35,7 +36,9 @@ export async function loadTransformersModule(
     try {
       return await importer();
     } catch (error) {
-      if (attempt >= attempts || !isRecoverableTransformersImportError(error)) {
+      const recoverable = isRecoverableTransformersImportError(error);
+      if (attempt >= attempts || !recoverable) {
+        if (recoverable) requestStaleTransformersImportRecovery(error);
         throw error;
       }
       options.onRetry?.(error, attempt);
@@ -84,11 +87,31 @@ export function configureQuietBrowserCache(env: TransformersEnvironment | undefi
   };
 }
 
-function isRecoverableTransformersImportError(error: unknown): boolean {
+export function requestStaleTransformersImportRecovery(error: unknown): boolean {
+  if (!isStaleTransformersChunkImportError(error)) return false;
+  dispatchStaleChunkRecoveryEvent(error);
+  return true;
+}
+
+export function isRecoverableTransformersImportError(error: unknown): boolean {
   const message = error instanceof Error ? error.message : String(error);
   return /Failed to fetch dynamically imported module|Importing a module script failed|error loading dynamically imported module|Load failed|NetworkError|Failed to fetch/iu.test(
     message,
   );
+}
+
+export function isStaleTransformersChunkImportError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return /Failed to fetch dynamically imported module|Importing a module script failed|error loading dynamically imported module|ChunkLoadError|Loading chunk [\w-]+ failed/iu.test(
+    message,
+  );
+}
+
+function dispatchStaleChunkRecoveryEvent(error: unknown): void {
+  if (typeof Event === "undefined" || typeof globalThis.dispatchEvent !== "function") return;
+  const event = new Event(VITE_PRELOAD_ERROR_EVENT, { cancelable: true });
+  Object.defineProperty(event, "payload", { value: error });
+  globalThis.dispatchEvent(event);
 }
 
 async function defaultTransformersImporter(): Promise<TransformersModule> {


### PR DESCRIPTION
## 关联

Refs #2（总控 issue，不在本 PR 中关闭）
Closes #184

## 改动点

- 在 `loadTransformersModule` 的可恢复动态 import 错误重试耗尽后，派发 `vite:preloadError` 事件并附带原始 error payload。
- 补充 Transformers loader 单测：stale chunk import 失败会触发恢复事件，非 chunk 错误不会误触发。
- 保持 ASR 配置不变，`subtitleTranscriber` 仍验证 `language: "chinese"`。

## 影响范围

- 影响 `@huggingface/transformers` 共享 loader；覆盖 ASR “生成字幕”和本地 LLM “纠错并生成章节”共用的动态 chunk 加载路径。
- 不修改 ASR 模型、LLM 模型、字幕后处理 prompt、worker 协议或 UI。

## GitNexus 影响分析摘要

- 风险等级: LOW
- 关键骨架变更: 否；GitNexus contract 标记为 advisory，无 critical contract surface changed。
- GitNexus 影响面: `loadTransformersModule` 上游影响 5 个节点，直接调用方为 `loadTransformersPipeline`；受影响流程为 `subtitleTranscriber.ts` 的 `transcribe` 和 `subtitlePostProcessor.ts` 的 `process`，模块范围集中在 Subtitles。
- 验证结果: 已运行 `detect_changes`、`context loadTransformersModule`、`impact loadTransformersModule --direction upstream --include-tests`；focused tests、`quality:precommit`、`quality:local` 均通过。

## 自检

- [x] 未修改 `docs/progress.json` 或 `docs/progress.md`
- [x] 已运行 `npm run quality:local`，或说明无法运行的原因
- [x] 涉及 AI 字幕时，已记录一次 `npm run subtitle:postprocess:evaluate` 的“纠错并生成章节”效果验证结果，包含 `representativeOutputSource`、`overallEvaluationDurationMs`，并区分输出校验耗时与真实端到端耗时
  - `representativeOutputSource`: `postprocessor-runner`
  - `overallEvaluationDurationMs`: `1.6678`
  - 输出校验耗时: `averageFixtureValidationDurationMs=0.1858`, `maxFixtureValidationDurationMs=0.935`; 该命令是 fixture/runner 校验，不代表真实端到端模型推理耗时。
- [x] 涉及 AI 字幕点击链路、LLM worker、模型加载或性能时，已记录一次 `npm run subtitle:postprocess:runtime-benchmark` 结果，包含 `postprocessClickToResultReadyDurationMs`、`postProcessTimeoutBudgetMs` 和 `playbackProbeResponsiveDuringPostprocess`
  - `postprocessClickToResultReadyDurationMs`: `30.973`
  - `postProcessTimeoutBudgetMs`: `60000`
  - `playbackProbeResponsiveDuringPostprocess`: `true`
- [x] 已说明改动点和影响范围
- [x] 如果改动关键骨架，已补充契约测试并填写 GitNexus 影响分析摘要
- [ ] 已等待 repo-guard、codex 和 Copilot 评论，并完成必要审查