### PR TITLE
[P1+ WebRTC] 接入候选人录制事件实时发布

### DIFF
--- a/apps/web/src/features/interview/CandidateInterviewPage.tsx
+++ b/apps/web/src/features/interview/CandidateInterviewPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState, type ReactNode } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import { useParams } from "react-router-dom";
 import {
   CircleDot,
@@ -12,12 +12,15 @@ import {
   VideoOff,
 } from "lucide-react";
 import { RecorderPage } from "@/features/recorder/RecorderPage";
+import type { EventBus } from "@/shared/recording-schema";
 import { Toggle, Tooltip } from "@/shared/ui";
 import {
   createInterviewMediaSession,
+  type InterviewEventsDataChannel,
   type InterviewMediaSession,
   type InterviewMediaSessionState,
 } from "./interviewMediaSession";
+import { createInterviewSyncPublisher } from "./interviewSync";
 import {
   createInterviewRoomClient,
   type InterviewRoomClient,
@@ -68,6 +71,14 @@ export type CandidateInterviewPageProps = {
   };
 };
 
+type RecorderEventBusSubscription = Pick<EventBus, "peek" | "subscribe">;
+
+type CandidateRealtimePublisherContext = {
+  channel: InterviewEventsDataChannel;
+  roomId: string;
+  sessionId: string;
+};
+
 const EMPTY_CANDIDATE_MEDIA_STATE: InterviewMediaSessionState = {
   localStream: null,
   remoteStream: null,
@@ -100,7 +111,7 @@ export function CandidateInterviewPage({ deps = {} }: CandidateInterviewPageProp
       roomId={session.roomId}
       roomState={session.roomState}
       mediaState={session.mediaState}
-      recordingWorkspace={<RecorderPage />}
+      recordingWorkspace={<RecorderPage onEventBusReady={session.onEventBusReady} />}
     />
   );
 }
@@ -121,6 +132,7 @@ function useCandidateInterviewRoomSession({
   roomId: string | null;
   roomState: CandidateInterviewRoomState;
   mediaState: InterviewMediaSessionState;
+  onEventBusReady: (bus: RecorderEventBusSubscription) => (() => void) | void;
 } {
   const [session, setSession] = useState<{
     roomId: string | null;
@@ -136,6 +148,60 @@ function useCandidateInterviewRoomSession({
     roomClient: InterviewRoomClient;
     request: ReturnType<InterviewRoomClient["createRoom"]>;
   } | null>(null);
+  const recorderEventBusRef = useRef<RecorderEventBusSubscription | null>(null);
+  const realtimePublisherContextRef = useRef<CandidateRealtimePublisherContext | null>(null);
+  const unsubscribeRealtimePublisherRef = useRef<(() => void) | null>(null);
+  const subscribedRealtimePublisherContextRef = useRef<CandidateRealtimePublisherContext | null>(null);
+  const subscribedRecorderEventBusRef = useRef<RecorderEventBusSubscription | null>(null);
+  const publishedRealtimeEventIdsRef = useRef<Set<string>>(new Set());
+  const stopRealtimePublisher = useCallback(() => {
+    unsubscribeRealtimePublisherRef.current?.();
+    unsubscribeRealtimePublisherRef.current = null;
+    subscribedRealtimePublisherContextRef.current = null;
+    subscribedRecorderEventBusRef.current = null;
+  }, []);
+  const refreshRealtimePublisher = useCallback(() => {
+    const bus = recorderEventBusRef.current;
+    const context = realtimePublisherContextRef.current;
+    if (!bus || !context || context.channel.readyState !== "open") {
+      stopRealtimePublisher();
+      return;
+    }
+    if (
+      subscribedRecorderEventBusRef.current === bus &&
+      subscribedRealtimePublisherContextRef.current === context
+    ) {
+      return;
+    }
+    stopRealtimePublisher();
+    unsubscribeRealtimePublisherRef.current = createInterviewSyncPublisher({
+      channel: context.channel,
+      roomId: context.roomId,
+      sessionId: context.sessionId,
+    }).subscribeTo(bus, {
+      includeBacklog: true,
+      shouldPublishEvent: (event) => !publishedRealtimeEventIdsRef.current.has(event.id),
+      onPublishResult: (event, result) => {
+        if (result.ok) {
+          publishedRealtimeEventIdsRef.current.add(event.id);
+        }
+      },
+    });
+    subscribedRecorderEventBusRef.current = bus;
+    subscribedRealtimePublisherContextRef.current = context;
+  }, [stopRealtimePublisher]);
+  const onEventBusReady = useCallback(
+    (bus: RecorderEventBusSubscription) => {
+      recorderEventBusRef.current = bus;
+      refreshRealtimePublisher();
+      return () => {
+        if (recorderEventBusRef.current !== bus) return;
+        recorderEventBusRef.current = null;
+        stopRealtimePublisher();
+      };
+    },
+    [refreshRealtimePublisher, stopRealtimePublisher],
+  );
 
   useEffect(() => {
     let closed = false;
@@ -144,10 +210,18 @@ function useCandidateInterviewRoomSession({
     let unsubscribeMediaSession: (() => void) | null = null;
     let mediaOfferStarted = false;
     let mediaSessionVersion = 0;
+    let lastEventsDataChannelState: InterviewMediaSessionState["eventsDataChannelState"] =
+      "not-created";
     let activeInterviewerConnectionId: string | null = null;
     const staleInterviewerConnectionIds = new Set<string>();
+    realtimePublisherContextRef.current = null;
+    publishedRealtimeEventIdsRef.current = new Set();
+    stopRealtimePublisher();
 
     const closeMediaSession = ({ publish }: { publish: boolean }) => {
+      realtimePublisherContextRef.current = null;
+      publishedRealtimeEventIdsRef.current = new Set();
+      stopRealtimePublisher();
       const current = mediaSession;
       if (!current) return;
       mediaSessionVersion += 1;
@@ -247,12 +321,27 @@ function useCandidateInterviewRoomSession({
         try {
           mediaSession = createMediaSession();
           mediaSessionVersion += 1;
-          setMediaState(mediaSession.getState());
+          const initialMediaState = mediaSession.getState();
+          lastEventsDataChannelState = initialMediaState.eventsDataChannelState;
+          setMediaState(initialMediaState);
           unsubscribeMediaSession = mediaSession.subscribe((next) => {
             if (closed) return;
             setMediaState(next);
             if (next.outgoingIceCandidates.length > 0) {
               sendPendingIceCandidates();
+            }
+            const previousEventsDataChannelState = lastEventsDataChannelState;
+            lastEventsDataChannelState = next.eventsDataChannelState;
+            if (
+              next.eventsDataChannelState === "open" &&
+              previousEventsDataChannelState !== "open"
+            ) {
+              refreshRealtimePublisher();
+            } else if (
+              next.eventsDataChannelState !== "open" &&
+              previousEventsDataChannelState === "open"
+            ) {
+              stopRealtimePublisher();
             }
           });
           return true;
@@ -291,10 +380,16 @@ function useCandidateInterviewRoomSession({
             if (!isCurrentMediaSession(currentMediaSession, currentMediaSessionVersion)) {
               return;
             }
-            currentMediaSession.ensureEventsDataChannel();
+            const eventsDataChannel = currentMediaSession.ensureEventsDataChannel();
             if (!isCurrentMediaSession(currentMediaSession, currentMediaSessionVersion)) {
               return;
             }
+            realtimePublisherContextRef.current = {
+              channel: eventsDataChannel,
+              roomId: room.roomId,
+              sessionId: signalingClient?.getConnectionId() ?? room.roomId,
+            };
+            refreshRealtimePublisher();
             const offer = await currentMediaSession.createOffer();
             if (!isCurrentMediaSession(currentMediaSession, currentMediaSessionVersion)) {
               return;
@@ -509,9 +604,16 @@ function useCandidateInterviewRoomSession({
       closeMediaSession({ publish: false });
       signalingClient?.close();
     };
-  }, [createMediaSession, createSignalingClient, roomClient, routeRoomId]);
+  }, [
+    createMediaSession,
+    createSignalingClient,
+    refreshRealtimePublisher,
+    roomClient,
+    routeRoomId,
+    stopRealtimePublisher,
+  ]);
 
-  return { ...session, mediaState };
+  return { ...session, mediaState, onEventBusReady };
 }
 
 function initialCandidateRoomState(routeRoomId: string | null): CandidateInterviewRoomState {

--- a/apps/web/src/features/interview/__tests__/CandidateInterviewPage.test.tsx
+++ b/apps/web/src/features/interview/__tests__/CandidateInterviewPage.test.tsx
@@ -1,8 +1,9 @@
 import { act, render, screen, waitFor } from "@testing-library/react";
 import { StrictMode, type ComponentProps } from "react";
 import { createMemoryRouter, RouterProvider } from "react-router-dom";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { appRoutes } from "@/app/routes";
+import type { EventBus, RecordingEvent } from "@/shared/recording-schema";
 import { ThemeProvider } from "@/shared/ui/themeProvider";
 import { TooltipProvider } from "@/shared/ui/Tooltip";
 import type {
@@ -18,13 +19,63 @@ import type {
 } from "../interviewSignalingClient";
 import { CandidateInterviewPage, CandidateInterviewView } from "../CandidateInterviewPage";
 
-vi.mock("@/features/recorder/RecorderPage", () => ({
-  RecorderPage() {
-    return <div data-testid="recorder-workspace">Recorder workspace</div>;
-  },
-}));
+const recorderPageMock = vi.hoisted(() => {
+  const listeners = new Set<(event: RecordingEvent) => void>();
+  const history: RecordingEvent[] = [];
+  const unsubscribe = vi.fn();
+  const bus: Pick<EventBus, "peek" | "subscribe"> = {
+    peek: vi.fn(() => history.slice()),
+    subscribe: vi.fn((listener) => {
+      listeners.add(listener);
+      return () => {
+        unsubscribe();
+        listeners.delete(listener);
+      };
+    }),
+  };
+
+  return {
+    bus,
+    unsubscribe,
+    emit(event: RecordingEvent) {
+      history.push(event);
+      listeners.forEach((listener) => listener(event));
+    },
+    reset() {
+      listeners.clear();
+      history.length = 0;
+      unsubscribe.mockClear();
+      vi.mocked(bus.peek).mockClear();
+      vi.mocked(bus.subscribe).mockClear();
+    },
+    resetHistory() {
+      history.length = 0;
+    },
+  };
+});
+
+vi.mock("@/features/recorder/RecorderPage", async () => {
+  const React = (await vi.importActual("react")) as {
+    useEffect(effect: () => void | (() => void), deps: unknown[]): void;
+  };
+
+  return {
+    RecorderPage({
+      onEventBusReady,
+    }: {
+      onEventBusReady?: (bus: Pick<EventBus, "peek" | "subscribe">) => void | (() => void);
+    }) {
+      React.useEffect(() => onEventBusReady?.(recorderPageMock.bus), [onEventBusReady]);
+      return <div data-testid="recorder-workspace">Recorder workspace</div>;
+    },
+  };
+});
 
 describe("CandidateInterviewPage", () => {
+  beforeEach(() => {
+    recorderPageMock.reset();
+  });
+
   it("creates a room and connects candidate signaling from the candidate entry route", async () => {
     const roomClient = makeRoomClient({
       createRoom: vi.fn().mockResolvedValue({
@@ -134,6 +185,451 @@ describe("CandidateInterviewPage", () => {
     expect(media.session.ensureEventsDataChannel).toHaveBeenCalledTimes(1);
     expect(media.session.createOffer).toHaveBeenCalledTimes(1);
     expect(signaling.client.sendOffer).toHaveBeenCalledTimes(1);
+  });
+
+  it("publishes recorder EventBus events to the candidate events DataChannel", async () => {
+    const roomClient = makeRoomClient();
+    const signaling = makeSignalingFactory();
+    const media = makeMediaSessionFactory(
+      {},
+      {
+        eventsDataChannelState: "open",
+      },
+    );
+    const event = contentEvent(7, "const answer = 42;");
+
+    renderCandidatePage({
+      initialEntry: "/interview/candidate",
+      roomClient,
+      createSignalingClient: signaling.create,
+      createMediaSession: media.create,
+    });
+    await screen.findByText("room-created");
+
+    act(() => {
+      signaling.emit({
+        kind: "joined",
+        roomId: "room-created",
+        role: "interviewer",
+        status: "live",
+      });
+    });
+    await waitFor(() => {
+      expect(signaling.client.sendOffer).toHaveBeenCalledTimes(1);
+    });
+
+    act(() => {
+      recorderPageMock.emit(event);
+    });
+
+    await waitFor(() => {
+      expect(media.eventsDataChannel.send).toHaveBeenCalledTimes(1);
+    });
+    expect(JSON.parse(vi.mocked(media.eventsDataChannel.send).mock.calls[0][0])).toEqual({
+      kind: "recording-event",
+      roomId: "room-created",
+      sessionId: "candidate-connection-1",
+      messageId: expect.any(String),
+      sentAt: expect.any(Number),
+      stateVersion: 0,
+      contentHash: "hash-7",
+      event,
+    });
+  });
+
+  it("waits for the candidate events DataChannel to open before subscribing and backfills queued events", async () => {
+    const roomClient = makeRoomClient();
+    const signaling = makeSignalingFactory();
+    const media = makeMediaSessionFactory(
+      {},
+      {
+        eventsDataChannelState: "connecting",
+      },
+    );
+    const queuedEvent = contentEvent(1, "const queued = true;");
+    const liveEvent = contentEvent(2, "const live = true;");
+
+    renderCandidatePage({
+      initialEntry: "/interview/candidate",
+      roomClient,
+      createSignalingClient: signaling.create,
+      createMediaSession: media.create,
+    });
+    await screen.findByText("room-created");
+
+    act(() => {
+      signaling.emit({
+        kind: "joined",
+        roomId: "room-created",
+        role: "interviewer",
+        status: "live",
+      });
+    });
+    await waitFor(() => {
+      expect(signaling.client.sendOffer).toHaveBeenCalledTimes(1);
+    });
+
+    expect(recorderPageMock.bus.subscribe).not.toHaveBeenCalled();
+    act(() => {
+      recorderPageMock.emit(queuedEvent);
+    });
+    expect(media.eventsDataChannel.send).not.toHaveBeenCalled();
+
+    act(() => {
+      media.setEventsDataChannelState("open");
+    });
+
+    await waitFor(() => {
+      expect(media.eventsDataChannel.send).toHaveBeenCalledTimes(1);
+    });
+    expect(JSON.parse(vi.mocked(media.eventsDataChannel.send).mock.calls[0][0]).event).toEqual(
+      queuedEvent,
+    );
+
+    act(() => {
+      recorderPageMock.emit(liveEvent);
+    });
+
+    await waitFor(() => {
+      expect(media.eventsDataChannel.send).toHaveBeenCalledTimes(2);
+    });
+    expect(JSON.parse(vi.mocked(media.eventsDataChannel.send).mock.calls[1][0]).event).toEqual(
+      liveEvent,
+    );
+  });
+
+  it("publishes already-recorded EventBus events when the interviewer joins late", async () => {
+    const roomClient = makeRoomClient();
+    const signaling = makeSignalingFactory();
+    const media = makeMediaSessionFactory(
+      {},
+      {
+        eventsDataChannelState: "open",
+      },
+    );
+    const firstEvent = contentEvent(1, "const beforeJoin = 1;");
+    const secondEvent = contentEvent(2, "const beforeJoin = 2;");
+
+    renderCandidatePage({
+      initialEntry: "/interview/candidate",
+      roomClient,
+      createSignalingClient: signaling.create,
+      createMediaSession: media.create,
+    });
+    await screen.findByText("room-created");
+
+    act(() => {
+      recorderPageMock.emit(firstEvent);
+      recorderPageMock.emit(secondEvent);
+      signaling.emit({
+        kind: "joined",
+        roomId: "room-created",
+        role: "interviewer",
+        status: "live",
+      });
+    });
+
+    await waitFor(() => {
+      expect(signaling.client.sendOffer).toHaveBeenCalledTimes(1);
+      expect(media.eventsDataChannel.send).toHaveBeenCalledTimes(2);
+    });
+    expect(vi.mocked(media.eventsDataChannel.send).mock.calls.map(([data]) => JSON.parse(data).event)).toEqual([
+      firstEvent,
+      secondEvent,
+    ]);
+  });
+
+  it("does not replay already-sent EventBus events after the events DataChannel reopens", async () => {
+    const roomClient = makeRoomClient();
+    const signaling = makeSignalingFactory();
+    const media = makeMediaSessionFactory(
+      {},
+      {
+        eventsDataChannelState: "open",
+      },
+    );
+    const firstEvent = contentEvent(1, "const first = true;");
+    const secondEvent = contentEvent(2, "const duringClose = true;");
+    const thirdEvent = contentEvent(3, "const afterReopen = true;");
+
+    renderCandidatePage({
+      initialEntry: "/interview/candidate",
+      roomClient,
+      createSignalingClient: signaling.create,
+      createMediaSession: media.create,
+    });
+    await screen.findByText("room-created");
+
+    act(() => {
+      signaling.emit({
+        kind: "joined",
+        roomId: "room-created",
+        role: "interviewer",
+        status: "live",
+      });
+    });
+    await waitFor(() => {
+      expect(signaling.client.sendOffer).toHaveBeenCalledTimes(1);
+    });
+
+    act(() => {
+      recorderPageMock.emit(firstEvent);
+    });
+    await waitFor(() => {
+      expect(media.eventsDataChannel.send).toHaveBeenCalledTimes(1);
+    });
+
+    act(() => {
+      media.setEventsDataChannelState("closed");
+      recorderPageMock.emit(secondEvent);
+    });
+    expect(media.eventsDataChannel.send).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      media.setEventsDataChannelState("open");
+    });
+    await waitFor(() => {
+      expect(media.eventsDataChannel.send).toHaveBeenCalledTimes(2);
+    });
+
+    act(() => {
+      recorderPageMock.emit(thirdEvent);
+    });
+    await waitFor(() => {
+      expect(media.eventsDataChannel.send).toHaveBeenCalledTimes(3);
+    });
+
+    expect(vi.mocked(media.eventsDataChannel.send).mock.calls.map(([data]) => JSON.parse(data).event)).toEqual([
+      firstEvent,
+      secondEvent,
+      thirdEvent,
+    ]);
+  });
+
+  it("publishes a new recorder session after the EventBus resets and reuses seq numbers", async () => {
+    const roomClient = makeRoomClient();
+    const signaling = makeSignalingFactory();
+    const media = makeMediaSessionFactory(
+      {},
+      {
+        eventsDataChannelState: "open",
+      },
+    );
+    const firstSessionEvent = contentEvent(1, "const firstSession = true;", "event-first-session");
+    const resetSessionEvent = contentEvent(1, "const resetSession = true;", "event-reset-session");
+
+    renderCandidatePage({
+      initialEntry: "/interview/candidate",
+      roomClient,
+      createSignalingClient: signaling.create,
+      createMediaSession: media.create,
+    });
+    await screen.findByText("room-created");
+
+    act(() => {
+      signaling.emit({
+        kind: "joined",
+        roomId: "room-created",
+        role: "interviewer",
+        status: "live",
+      });
+    });
+    await waitFor(() => {
+      expect(signaling.client.sendOffer).toHaveBeenCalledTimes(1);
+    });
+
+    act(() => {
+      recorderPageMock.emit(firstSessionEvent);
+    });
+    await waitFor(() => {
+      expect(media.eventsDataChannel.send).toHaveBeenCalledTimes(1);
+    });
+
+    act(() => {
+      recorderPageMock.resetHistory();
+      recorderPageMock.emit(resetSessionEvent);
+    });
+    await waitFor(() => {
+      expect(media.eventsDataChannel.send).toHaveBeenCalledTimes(2);
+    });
+
+    expect(vi.mocked(media.eventsDataChannel.send).mock.calls.map(([data]) => JSON.parse(data).event)).toEqual([
+      firstSessionEvent,
+      resetSessionEvent,
+    ]);
+  });
+
+  it("stops publishing recorder events when the interviewer leaves", async () => {
+    const roomClient = makeRoomClient();
+    const signaling = makeSignalingFactory();
+    const media = makeMediaSessionFactory(
+      {},
+      {
+        eventsDataChannelState: "open",
+      },
+    );
+
+    renderCandidatePage({
+      initialEntry: "/interview/candidate",
+      roomClient,
+      createSignalingClient: signaling.create,
+      createMediaSession: media.create,
+    });
+    await screen.findByText("room-created");
+
+    act(() => {
+      signaling.emit({
+        kind: "joined",
+        roomId: "room-created",
+        role: "interviewer",
+        status: "live",
+      });
+    });
+    await waitFor(() => {
+      expect(signaling.client.sendOffer).toHaveBeenCalledTimes(1);
+    });
+
+    act(() => {
+      recorderPageMock.emit(contentEvent(1));
+    });
+    await waitFor(() => {
+      expect(media.eventsDataChannel.send).toHaveBeenCalledTimes(1);
+    });
+
+    act(() => {
+      signaling.emit({
+        kind: "leave",
+        roomId: "room-created",
+        role: "interviewer",
+        connectionId: "interviewer-connection-1",
+        messageId: "leave-1",
+        sentAt: 1_780_000_000_000,
+      });
+      recorderPageMock.emit(contentEvent(2));
+    });
+
+    expect(recorderPageMock.unsubscribe).toHaveBeenCalledTimes(1);
+    expect(media.eventsDataChannel.send).toHaveBeenCalledTimes(1);
+  });
+
+  it("replays recorded backlog for a new interviewer after the previous interviewer leaves", async () => {
+    const roomClient = makeRoomClient();
+    const signaling = makeSignalingFactory();
+    const firstMedia = makeMediaSessionFactory(
+      {},
+      {
+        eventsDataChannelState: "open",
+      },
+    );
+    const secondMedia = makeMediaSessionFactory(
+      {},
+      {
+        eventsDataChannelState: "open",
+      },
+    );
+    const createMediaSession = vi
+      .fn<() => InterviewMediaSession>()
+      .mockReturnValueOnce(firstMedia.session)
+      .mockReturnValueOnce(secondMedia.session);
+    const firstEvent = contentEvent(1, "const firstInterviewer = true;");
+    const secondEvent = contentEvent(2, "const nextInterviewer = true;");
+
+    renderCandidatePage({
+      initialEntry: "/interview/candidate",
+      roomClient,
+      createSignalingClient: signaling.create,
+      createMediaSession,
+    });
+    await screen.findByText("room-created");
+
+    act(() => {
+      signaling.emit({
+        kind: "joined",
+        roomId: "room-created",
+        role: "interviewer",
+        status: "live",
+      });
+    });
+    await waitFor(() => {
+      expect(signaling.client.sendOffer).toHaveBeenCalledTimes(1);
+    });
+
+    act(() => {
+      recorderPageMock.emit(firstEvent);
+    });
+    await waitFor(() => {
+      expect(firstMedia.eventsDataChannel.send).toHaveBeenCalledTimes(1);
+    });
+
+    act(() => {
+      signaling.emit({
+        kind: "leave",
+        roomId: "room-created",
+        role: "interviewer",
+        connectionId: "interviewer-connection-1",
+        messageId: "leave-1",
+        sentAt: 1_780_000_000_000,
+      });
+      recorderPageMock.emit(secondEvent);
+    });
+    expect(firstMedia.eventsDataChannel.send).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      signaling.emit({
+        kind: "joined",
+        roomId: "room-created",
+        role: "interviewer",
+        status: "live",
+      });
+    });
+
+    await waitFor(() => {
+      expect(createMediaSession).toHaveBeenCalledTimes(2);
+      expect(signaling.client.sendOffer).toHaveBeenCalledTimes(2);
+      expect(secondMedia.eventsDataChannel.send).toHaveBeenCalledTimes(2);
+    });
+    expect(
+      vi.mocked(secondMedia.eventsDataChannel.send).mock.calls.map(([data]) => JSON.parse(data).event),
+    ).toEqual([firstEvent, secondEvent]);
+  });
+
+  it("stops publishing recorder events when the candidate page unmounts", async () => {
+    const roomClient = makeRoomClient();
+    const signaling = makeSignalingFactory();
+    const media = makeMediaSessionFactory(
+      {},
+      {
+        eventsDataChannelState: "open",
+      },
+    );
+
+    const view = renderCandidatePage({
+      initialEntry: "/interview/candidate",
+      roomClient,
+      createSignalingClient: signaling.create,
+      createMediaSession: media.create,
+    });
+    await screen.findByText("room-created");
+
+    act(() => {
+      signaling.emit({
+        kind: "joined",
+        roomId: "room-created",
+        role: "interviewer",
+        status: "live",
+      });
+    });
+    await waitFor(() => {
+      expect(signaling.client.sendOffer).toHaveBeenCalledTimes(1);
+    });
+
+    view.unmount();
+    act(() => {
+      recorderPageMock.emit(contentEvent(1));
+    });
+
+    expect(recorderPageMock.unsubscribe).toHaveBeenCalledTimes(1);
+    expect(media.eventsDataChannel.send).not.toHaveBeenCalled();
   });
 
   it("bridges local ICE, remote answer, and remote ICE between media and signaling", async () => {
@@ -967,7 +1463,10 @@ function makeSignalingFactory() {
   };
 }
 
-function makeMediaSessionFactory(patch: Partial<InterviewMediaSession> = {}) {
+function makeMediaSessionFactory(
+  patch: Partial<InterviewMediaSession> = {},
+  options: { eventsDataChannelState?: InterviewEventsDataChannel["readyState"] } = {},
+) {
   let state = makeMediaState();
   const listeners = new Set<(next: InterviewMediaSessionState) => void>();
   const updateState = (next: Partial<InterviewMediaSessionState>) => {
@@ -979,7 +1478,7 @@ function makeMediaSessionFactory(patch: Partial<InterviewMediaSession> = {}) {
   const remoteStream = {} as MediaStream;
   const eventsDataChannel: InterviewEventsDataChannel = {
     label: "events",
-    readyState: "connecting",
+    readyState: options.eventsDataChannelState ?? "connecting",
     onopen: null,
     onclose: null,
     send: vi.fn(),
@@ -1039,10 +1538,40 @@ function makeMediaSessionFactory(patch: Partial<InterviewMediaSession> = {}) {
   return {
     create: vi.fn(() => session),
     session,
+    eventsDataChannel,
+    setEventsDataChannelState(next: InterviewEventsDataChannel["readyState"]) {
+      Object.defineProperty(eventsDataChannel, "readyState", {
+        configurable: true,
+        value: next,
+      });
+      updateState({ eventsDataChannelState: next });
+    },
     emitState(next: Partial<InterviewMediaSessionState>) {
       updateState(next);
     },
     localStream,
     remoteStream,
+  };
+}
+
+function contentEvent(seq: number, code = `code-${seq}`, id = `event-${seq}`): RecordingEvent {
+  return {
+    id,
+    seq,
+    timestampMs: seq * 100,
+    wallTime: "2026-05-29T17:00:00.000Z",
+    source: "editor",
+    track: "main",
+    type: "content-change",
+    payload: {
+      fileId: "main",
+      version: seq,
+      code,
+      contentHash: `hash-${seq}`,
+      language: "typescript",
+      changeReason: "input",
+      changeCount: 1,
+      flushedBy: "debounce",
+    },
   };
 }

--- a/apps/web/src/features/interview/__tests__/interviewSync.test.ts
+++ b/apps/web/src/features/interview/__tests__/interviewSync.test.ts
@@ -38,14 +38,20 @@ function createFakeChannel(initialState: InterviewRealtimeDataChannel["readyStat
   return { channel, sent };
 }
 
-function createFakeEventBus(): Pick<EventBus, "subscribe"> & { emit(event: RecordingEvent): void } {
+function createFakeEventBus(
+  history: RecordingEvent[] = [],
+): Pick<EventBus, "peek" | "subscribe"> & { emit(event: RecordingEvent): void } {
   const listeners = new Set<(event: RecordingEvent) => void>();
   return {
+    peek() {
+      return history.slice();
+    },
     subscribe(listener) {
       listeners.add(listener);
       return () => listeners.delete(listener);
     },
     emit(event) {
+      history.push(event);
       listeners.forEach((listener) => listener(event));
     },
   };
@@ -82,6 +88,28 @@ describe("InterviewSyncPublisher", () => {
       contentHash: "hash-1",
       event,
     });
+  });
+
+  it("only replays existing EventBus events when backlog publishing is requested", () => {
+    const { channel, sent } = createFakeChannel();
+    const event = contentEvent(1, "const beforeSubscribe = true;");
+    const bus = createFakeEventBus([event]);
+    const publisher = createInterviewSyncPublisher({
+      channel,
+      roomId: "room-1",
+      sessionId: "session-1",
+    });
+
+    const unsubscribeWithoutBacklog = publisher.subscribeTo(bus);
+    unsubscribeWithoutBacklog();
+
+    expect(sent).toEqual([]);
+
+    const unsubscribeWithBacklog = publisher.subscribeTo(bus, { includeBacklog: true });
+    unsubscribeWithBacklog();
+
+    expect(sent).toHaveLength(1);
+    expect(JSON.parse(sent[0]).event).toEqual(event);
   });
 
   it("returns an explicit failure when the DataChannel is not open", () => {

--- a/apps/web/src/features/interview/interviewSync.ts
+++ b/apps/web/src/features/interview/interviewSync.ts
@@ -68,7 +68,16 @@ export type InterviewSyncPublisherOptions = {
 
 export type InterviewSyncPublisher = {
   publishRecordingEvent(event: RecordingEvent): InterviewPublishResult;
-  subscribeTo(bus: Pick<EventBus, "subscribe">): () => void;
+  subscribeTo(
+    bus: Pick<EventBus, "subscribe"> & Partial<Pick<EventBus, "peek">>,
+    options?: InterviewSyncSubscribeOptions,
+  ): () => void;
+};
+
+export type InterviewSyncSubscribeOptions = {
+  includeBacklog?: boolean;
+  shouldPublishEvent?: (event: RecordingEvent) => boolean;
+  onPublishResult?: (event: RecordingEvent, result: InterviewPublishResult) => void;
 };
 
 export function createInterviewSyncPublisher(
@@ -104,10 +113,18 @@ export function createInterviewSyncPublisher(
 
   return {
     publishRecordingEvent,
-    subscribeTo(bus) {
-      return bus.subscribe((event) => {
-        publishRecordingEvent(event);
-      });
+    subscribeTo(bus, subscribeOptions = {}) {
+      const publishFromSubscription = (event: RecordingEvent) => {
+        if (subscribeOptions.shouldPublishEvent?.(event) === false) return;
+        const result = publishRecordingEvent(event);
+        subscribeOptions.onPublishResult?.(event, result);
+      };
+
+      if (subscribeOptions.includeBacklog) {
+        bus.peek?.().forEach(publishFromSubscription);
+      }
+
+      return bus.subscribe(publishFromSubscription);
     },
   };
 }

--- a/apps/web/src/features/recorder/RecorderPage.tsx
+++ b/apps/web/src/features/recorder/RecorderPage.tsx
@@ -27,6 +27,7 @@ import { IconButton, useTheme } from "@/shared/ui";
 import type {
   CameraPositionPayload,
   DeviceInfo,
+  EventBus,
   MediaCapability,
   MediaDevicesController,
   OpenStreamResult,
@@ -83,7 +84,11 @@ type RecorderRuntimeState = {
  * RecorderPage — wires the recording core (clock + bus + producers + builder
  * + repository + media + runtime) and renders the workshop layout.
  */
-export function RecorderPage() {
+export type RecorderPageProps = {
+  onEventBusReady?: (bus: Pick<EventBus, "peek" | "subscribe">) => (() => void) | void;
+};
+
+export function RecorderPage({ onEventBusReady }: RecorderPageProps = {}) {
   const navigate = useNavigate();
   const theme = useTheme();
   const editorRef = useRef<CodeEditorHandle | null>(null);
@@ -223,6 +228,10 @@ export function RecorderPage() {
   const [mediaPermissionNotice, setMediaPermissionNotice] = useState<string | null>(null);
   const [mediaPermissionRequesting, setMediaPermissionRequesting] = useState(false);
   const [runtimeState, setRuntimeState] = useState<RecorderRuntimeState>(INITIAL_RUNTIME_STATE);
+
+  useEffect(() => {
+    return onEventBusReady?.(stack.bus) ?? undefined;
+  }, [onEventBusReady, stack.bus]);
 
   const loadDevices = useCallback((options: { force?: boolean } = {}) => {
     if (deviceLoadPromiseRef.current && !options.force) return deviceLoadPromiseRef.current;

--- a/apps/web/src/features/recorder/__tests__/RecorderPage.test.tsx
+++ b/apps/web/src/features/recorder/__tests__/RecorderPage.test.tsx
@@ -11,6 +11,7 @@ import type {
 import type { CodeEditorHandle, CodeEditorProps } from "@/features/editor/CodeEditor";
 import type { CameraPreviewProps } from "@/features/media/CameraPreview";
 import type {
+  EventBus,
   MediaDevicesController,
   OpenStreamResult,
   RecordingRepository,
@@ -377,6 +378,24 @@ describe("RecorderPage", () => {
     await act(async () => {
       await new Promise((resolve) => setTimeout(resolve, 60));
     });
+  });
+
+  it("exposes the recording EventBus to an optional realtime subscriber and cleans it up", async () => {
+    const { RecorderPage } = await import("../RecorderPage");
+    const cleanupSubscriber = vi.fn();
+    const onEventBusReady = vi.fn(
+      (_bus: Pick<EventBus, "peek" | "subscribe">) => cleanupSubscriber,
+    );
+
+    const { unmount } = render(<RecorderPage onEventBusReady={onEventBusReady} />);
+
+    await waitFor(() => expect(onEventBusReady).toHaveBeenCalledTimes(1));
+    expect(onEventBusReady.mock.calls[0][0].peek).toBeTypeOf("function");
+    expect(onEventBusReady.mock.calls[0][0].subscribe).toBeTypeOf("function");
+
+    unmount();
+
+    expect(cleanupSubscriber).toHaveBeenCalledTimes(1);
   });
 
   it("runs with the current editor language after producer-driven language changes", async () => {


### PR DESCRIPTION
## 关联

Refs #120（总控 issue，不在本 PR 中关闭）
Closes #183

## 改动点

- 为 `RecorderPage` 增加可选 `onEventBusReady` 扩展点，向实时面试页暴露 `peek` + `subscribe` 的录制 EventBus 读取能力。
- 候选人进入 WebRTC 会话并建立 events DataChannel 后，使用 `createInterviewSyncPublisher` 将录制 EventBus 事件封装为实时消息发送给面试官端。
- 仅在 events DataChannel 进入 `open` 后订阅实时发布；连接未打开期间录制的事件会通过显式 `includeBacklog` 回填，避免 seq 缺口。
- 候选人页记录已成功发送的事件 seq，DataChannel 抖动重订阅时只补未发送事件，避免重复发送已发布历史事件。
- 在面试官离开、媒体会话关闭、DataChannel 非 open、页面卸载或录制页清理时解绑实时发布订阅，避免离线后继续发送事件。
- 补充候选人页、同步发布器和录制页测试，覆盖事件发送、DataChannel open 后订阅回填、面试官晚加入 backlog、DataChannel reopen 不重复重放、离开解绑、卸载解绑和扩展点清理。

## 影响范围

- 候选人面试页的录制工作区会在 events DataChannel 存活期间发布编辑器/录制事件。
- 普通录制页默认行为不变；新增 props 为可选扩展点。
- `InterviewSyncPublisher.subscribeTo` 的 backlog 发布改为显式选项，默认订阅只转发 live events，避免共享 publisher 出现隐式全量重放语义。
- 面试官端消费与重放应用仍沿用既有 `interviewSync` 消息/缓冲协议，后续 issue 继续补齐远端渲染与抖动恢复闭环。

## GitNexus 影响分析摘要

- 风险等级: `createInterviewSyncPublisher` HIGH；`CandidateInterviewPage` LOW；`RecorderPage` LOW。
- 关键骨架变更: 无；`npm run contract:local` 报告 no critical contract surface changed，GitNexus analysis advisory。
- GitNexus 影响面: `git diff origin/main...HEAD` 为 6 个 Web 前端文件；`CandidateInterviewPage` upstream impactedCount=3/risk LOW，`RecorderPage` upstream impactedCount=3/risk LOW，`createInterviewSyncPublisher` upstream impactedCount=6/risk HIGH，直接影响 Interview 模块中的 `refreshRealtimePublisher`、`onEventBusReady`、`openMediaSession`、`startCandidateMediaOffer`、`useCandidateInterviewRoomSession`、`updateFromMessage`。
- 针对性验证: `npm run test -w apps/web -- src/features/interview/__tests__/CandidateInterviewPage.test.tsx src/features/interview/__tests__/interviewSync.test.ts src/features/recorder/__tests__/RecorderPage.test.tsx`，3 files / 71 tests passed。
- 本地完整验证: `npm run quality:local` 通过，包含 GitNexus contract passed、root 105 passed、schema 1 passed、api 193 passed、web 58 files / 581 tests passed、Playwright e2e 6 passed。
- Review 修复: 已处理 Repo Guard 指出的 DataChannel open → closed → open 后 `peek()` 全量重放风险；新增回归测试断言 reopen 后不重复发送已成功发送事件，只补关闭期间未发送事件；已处理 Codex 指出的跨面试官会话去重风险，媒体会话关闭时重置已发送事件集合，保证新面试官加入后收到完整已录制 backlog；已处理 Codex 最新指出的 EventBus reset 后 seq 复用风险，发送侧改为按 RecordingEvent.id 去重并补充 reset 后 seq=1 仍发送的新回归测试。

## 自检

- [x] 未修改 `docs/progress.json` 或 `docs/progress.md`
- [x] 已运行 `npm run quality:local`，或说明无法运行的原因
- [x] 涉及 AI 字幕时，已记录一次 `npm run subtitle:postprocess:evaluate` 的“纠错并生成章节”效果验证结果，包含 `representativeOutputSource`、`overallEvaluationDurationMs`，并区分输出校验耗时与真实端到端耗时（不涉及）
- [x] 涉及 AI 字幕点击链路、LLM worker、模型加载或性能时，已记录一次 `npm run subtitle:postprocess:runtime-benchmark` 结果，包含 `postprocessClickToResultReadyDurationMs`、`postProcessTimeoutBudgetMs` 和 `playbackProbeResponsiveDuringPostprocess`（不涉及）
- [x] 已说明改动点和影响范围
- [x] 如果改动关键骨架，已补充契约测试并填写 GitNexus 影响分析摘要（不涉及关键骨架）
- [ ] 已等待 repo-guard、codex 和 Copilot 评论，并完成必要审查

