### PR TITLE
[P1+ WebRTC] 面试官 DataChannel 接收与只读工作台接线

### DIFF
--- a/apps/web/src/features/interview/RemoteInterviewWorkbenchPage.tsx
+++ b/apps/web/src/features/interview/RemoteInterviewWorkbenchPage.tsx
@@ -14,7 +14,13 @@ import {
 } from "lucide-react";
 import { CodeEditor } from "@/features/editor/CodeEditor";
 import { Toggle, Tooltip } from "@/shared/ui";
-import type { InterviewMediaSessionState } from "./interviewMediaSession";
+import {
+  createInterviewMediaSession,
+  type InterviewEventsDataChannel,
+  type InterviewMediaSession,
+  type InterviewMediaSessionState,
+} from "./interviewMediaSession";
+import { createInterviewRealtimeReceiver } from "./interviewRealtimeReceiver";
 import { INITIAL_REMOTE_INTERVIEW_STABLE_STATE } from "./remoteInterviewInitialState";
 import {
   createRemoteInterviewWorkbench,
@@ -25,6 +31,12 @@ export type RemoteInterviewWorkbenchViewProps = {
   roomId: string;
   workbenchState: RemoteInterviewWorkbenchState;
   mediaState: InterviewMediaSessionState;
+};
+
+export type RemoteInterviewWorkbenchPageProps = {
+  deps?: {
+    createMediaSession?: () => InterviewMediaSession;
+  };
 };
 
 const EMPTY_INTERVIEW_MEDIA_SESSION_STATE: InterviewMediaSessionState = {
@@ -39,19 +51,64 @@ const EMPTY_INTERVIEW_MEDIA_SESSION_STATE: InterviewMediaSessionState = {
   eventsDataChannelState: "not-created",
 };
 
-export function RemoteInterviewWorkbenchPage() {
+export function RemoteInterviewWorkbenchPage({
+  deps = {},
+}: RemoteInterviewWorkbenchPageProps = {}) {
   const { roomId = "unknown" } = useParams();
+  const createMediaSession = deps.createMediaSession ?? createInterviewMediaSession;
   const workbench = useMemo(
     () => createRemoteInterviewWorkbench({ initialState: INITIAL_REMOTE_INTERVIEW_STABLE_STATE }),
     [],
   );
+  const receiver = useMemo(
+    () => createInterviewRealtimeReceiver({ roomId, workbench }),
+    [roomId, workbench],
+  );
   const [workbenchState, setWorkbenchState] = useState(() => workbench.getState());
-  const [mediaState] = useState<InterviewMediaSessionState>(() => ({
-    ...EMPTY_INTERVIEW_MEDIA_SESSION_STATE,
-    outgoingIceCandidates: [],
-  }));
+  const [mediaSession, setMediaSession] = useState<InterviewMediaSession | null>(null);
+  const [mediaState, setMediaState] = useState<InterviewMediaSessionState>(
+    emptyInterviewMediaSessionState,
+  );
 
   useEffect(() => workbench.subscribe(setWorkbenchState), [workbench]);
+  useEffect(() => {
+    const nextMediaSession = safeCreateMediaSession(createMediaSession);
+    setMediaSession(nextMediaSession);
+    setMediaState(nextMediaSession?.getState() ?? emptyInterviewMediaSessionState());
+
+    return () => {
+      nextMediaSession?.close();
+    };
+  }, [createMediaSession]);
+  useEffect(() => {
+    if (!mediaSession) {
+      return undefined;
+    }
+
+    let attachedChannel: InterviewEventsDataChannel | null = null;
+    let detachReceiver: (() => void) | null = null;
+    const refreshReceiver = () => {
+      const nextChannel = mediaSession.getEventsDataChannel();
+      if (nextChannel === attachedChannel) {
+        return;
+      }
+      detachReceiver?.();
+      attachedChannel = nextChannel;
+      detachReceiver = nextChannel ? receiver.attach(nextChannel) : null;
+    };
+
+    setMediaState(mediaSession.getState());
+    refreshReceiver();
+    const unsubscribe = mediaSession.subscribe((next) => {
+      setMediaState(next);
+      refreshReceiver();
+    });
+
+    return () => {
+      unsubscribe();
+      detachReceiver?.();
+    };
+  }, [mediaSession, receiver]);
 
   return (
     <RemoteInterviewWorkbenchView
@@ -60,6 +117,23 @@ export function RemoteInterviewWorkbenchPage() {
       mediaState={mediaState}
     />
   );
+}
+
+function safeCreateMediaSession(
+  createMediaSession: () => InterviewMediaSession,
+): InterviewMediaSession | null {
+  try {
+    return createMediaSession();
+  } catch {
+    return null;
+  }
+}
+
+function emptyInterviewMediaSessionState(): InterviewMediaSessionState {
+  return {
+    ...EMPTY_INTERVIEW_MEDIA_SESSION_STATE,
+    outgoingIceCandidates: [],
+  };
 }
 
 export function RemoteInterviewWorkbenchView({

--- a/apps/web/src/features/interview/RemoteInterviewWorkbenchPage.tsx
+++ b/apps/web/src/features/interview/RemoteInterviewWorkbenchPage.tsx
@@ -88,7 +88,7 @@ export function RemoteInterviewWorkbenchPage({
     let attachedChannel: InterviewEventsDataChannel | null = null;
     let detachReceiver: (() => void) | null = null;
     const refreshReceiver = () => {
-      const nextChannel = mediaSession.getEventsDataChannel();
+      const nextChannel = receivableEventsDataChannel(mediaSession.getEventsDataChannel());
       if (nextChannel === attachedChannel) {
         return;
       }
@@ -127,6 +127,15 @@ function safeCreateMediaSession(
   } catch {
     return null;
   }
+}
+
+function receivableEventsDataChannel(
+  channel: InterviewEventsDataChannel | null,
+): InterviewEventsDataChannel | null {
+  if (!channel || channel.readyState === "closed" || channel.readyState === "closing") {
+    return null;
+  }
+  return channel;
 }
 
 function emptyInterviewMediaSessionState(): InterviewMediaSessionState {

--- a/apps/web/src/features/interview/RemoteInterviewWorkbenchPage.tsx
+++ b/apps/web/src/features/interview/RemoteInterviewWorkbenchPage.tsx
@@ -39,6 +39,11 @@ export type RemoteInterviewWorkbenchPageProps = {
   };
 };
 
+type RemoteInterviewWorkbenchRoomProps = {
+  roomId: string;
+  deps: NonNullable<RemoteInterviewWorkbenchPageProps["deps"]>;
+};
+
 const EMPTY_INTERVIEW_MEDIA_SESSION_STATE: InterviewMediaSessionState = {
   localStream: null,
   remoteStream: null,
@@ -55,6 +60,11 @@ export function RemoteInterviewWorkbenchPage({
   deps = {},
 }: RemoteInterviewWorkbenchPageProps = {}) {
   const { roomId = "unknown" } = useParams();
+
+  return <RemoteInterviewWorkbenchRoom key={roomId} roomId={roomId} deps={deps} />;
+}
+
+function RemoteInterviewWorkbenchRoom({ roomId, deps }: RemoteInterviewWorkbenchRoomProps) {
   const createMediaSession = deps.createMediaSession ?? createInterviewMediaSession;
   const workbench = useMemo(
     () => createRemoteInterviewWorkbench({ initialState: INITIAL_REMOTE_INTERVIEW_STABLE_STATE }),

--- a/apps/web/src/features/interview/__tests__/CandidateInterviewPage.test.tsx
+++ b/apps/web/src/features/interview/__tests__/CandidateInterviewPage.test.tsx
@@ -1481,11 +1481,13 @@ function makeMediaSessionFactory(
     readyState: options.eventsDataChannelState ?? "connecting",
     onopen: null,
     onclose: null,
+    onmessage: null,
     send: vi.fn(),
     close: vi.fn(),
   };
   const session: InterviewMediaSession = {
     getState: vi.fn(() => state),
+    getEventsDataChannel: vi.fn(() => eventsDataChannel),
     requestLocalMedia: vi.fn(async () =>
       updateState({
         localStream,

--- a/apps/web/src/features/interview/__tests__/RemoteInterviewWorkbenchPage.test.tsx
+++ b/apps/web/src/features/interview/__tests__/RemoteInterviewWorkbenchPage.test.tsx
@@ -1,14 +1,21 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { act, render, screen, waitFor } from "@testing-library/react";
 import type { ComponentProps } from "react";
 import { createMemoryRouter, RouterProvider } from "react-router-dom";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { CodeEditorProps } from "@/features/editor/CodeEditor";
-import type { ReplayStableState } from "@/shared/recording-schema";
+import type { RecordingEvent, ReplayStableState } from "@/shared/recording-schema";
 import { ThemeProvider } from "@/shared/ui/themeProvider";
 import { TooltipProvider } from "@/shared/ui/Tooltip";
 import { appRoutes } from "@/app/routes";
-import type { InterviewMediaSessionState } from "../interviewMediaSession";
-import { RemoteInterviewWorkbenchView } from "../RemoteInterviewWorkbenchPage";
+import type {
+  InterviewEventsDataChannel,
+  InterviewMediaSession,
+  InterviewMediaSessionState,
+} from "../interviewMediaSession";
+import {
+  RemoteInterviewWorkbenchPage,
+  RemoteInterviewWorkbenchView,
+} from "../RemoteInterviewWorkbenchPage";
 import type { RemoteInterviewWorkbenchState } from "../remoteInterviewWorkbench";
 
 const codeEditorMock = vi.hoisted(() => ({
@@ -194,6 +201,87 @@ describe("RemoteInterviewWorkbenchPage", () => {
     expect(screen.getByRole("heading", { name: "面试官工作台" })).toBeInTheDocument();
     expect(screen.getByText("room-route")).toBeInTheDocument();
   });
+
+  it("applies recording-event messages from the events DataChannel to the read-only workbench", async () => {
+    const media = createFakeMediaSession();
+    const router = createMemoryRouter(
+      [
+        {
+          path: "/interview/interviewer/:roomId",
+          element: (
+            <RemoteInterviewWorkbenchPage
+              deps={{ createMediaSession: () => media.session }}
+            />
+          ),
+        },
+      ],
+      {
+        initialEntries: ["/interview/interviewer/room-live"],
+      },
+    );
+
+    render(
+      <ThemeProvider>
+        <TooltipProvider>
+          <RouterProvider router={router} />
+        </TooltipProvider>
+      </ThemeProvider>,
+    );
+
+    let channel!: TestEventsDataChannel;
+    act(() => {
+      channel = media.attachEventsDataChannel();
+    });
+
+    act(() => {
+      channel.emit(JSON.stringify(recordingMessage(contentEvent(1, "const fromCandidate = true;"))));
+    });
+
+    await waitFor(() => {
+      expect(latestCodeEditorProps().value).toBe("const fromCandidate = true;");
+    });
+    expect(latestCodeEditorProps().readOnly).toBe(true);
+    expect(screen.getAllByText("实时同步")).toHaveLength(2);
+    expect(screen.getByText("seq 1")).toBeInTheDocument();
+    expect(screen.getByText("seq 2")).toBeInTheDocument();
+  });
+
+  it("detaches the DataChannel receiver when the interviewer workbench unmounts", () => {
+    const media = createFakeMediaSession();
+    const router = createMemoryRouter(
+      [
+        {
+          path: "/interview/interviewer/:roomId",
+          element: (
+            <RemoteInterviewWorkbenchPage
+              deps={{ createMediaSession: () => media.session }}
+            />
+          ),
+        },
+      ],
+      {
+        initialEntries: ["/interview/interviewer/room-live"],
+      },
+    );
+
+    const { unmount } = render(
+      <ThemeProvider>
+        <TooltipProvider>
+          <RouterProvider router={router} />
+        </TooltipProvider>
+      </ThemeProvider>,
+    );
+    let channel!: TestEventsDataChannel;
+    act(() => {
+      channel = media.attachEventsDataChannel();
+    });
+
+    expect(channel.onmessage).not.toBeNull();
+    unmount();
+
+    expect(channel.onmessage).toBeNull();
+    expect(media.session.close).toHaveBeenCalledTimes(1);
+  });
 });
 
 function latestCodeEditorProps(): CodeEditorProps {
@@ -275,6 +363,97 @@ function makeStableState(
       previewHtml: null,
       errorMessage: null,
       ...patch.runtime,
+    },
+  };
+}
+
+type TestEventsDataChannel = InterviewEventsDataChannel & {
+  onmessage: ((event: { data: unknown }) => void) | null;
+  emit(data: unknown): void;
+};
+
+function createFakeMediaSession(): {
+  session: InterviewMediaSession;
+  attachEventsDataChannel(): TestEventsDataChannel;
+} {
+  let state = makeMediaState();
+  let channel: TestEventsDataChannel | null = null;
+  const listeners = new Set<(next: InterviewMediaSessionState) => void>();
+  const notify = () => listeners.forEach((listener) => listener({ ...state }));
+  const session = {
+    getState: () => ({ ...state }),
+    getEventsDataChannel: () => channel,
+    requestLocalMedia: vi.fn(),
+    setMicrophoneEnabled: vi.fn(),
+    setCameraEnabled: vi.fn(),
+    ensureEventsDataChannel: vi.fn(),
+    createOffer: vi.fn(),
+    createAnswer: vi.fn(),
+    setRemoteDescription: vi.fn(),
+    addRemoteIceCandidate: vi.fn(),
+    drainOutgoingIceCandidates: vi.fn(() => []),
+    subscribe(listener: (next: InterviewMediaSessionState) => void) {
+      listeners.add(listener);
+      return () => listeners.delete(listener);
+    },
+    close: vi.fn(),
+  } as unknown as InterviewMediaSession;
+
+  return {
+    session,
+    attachEventsDataChannel() {
+      channel = createFakeEventsChannel();
+      state = { ...state, eventsDataChannelState: "open" };
+      notify();
+      return channel;
+    },
+  };
+}
+
+function createFakeEventsChannel(): TestEventsDataChannel {
+  return {
+    label: "events",
+    readyState: "open",
+    onopen: null,
+    onclose: null,
+    onmessage: null,
+    send: vi.fn(),
+    close: vi.fn(),
+    emit(data) {
+      this.onmessage?.({ data });
+    },
+  };
+}
+
+function recordingMessage(event: RecordingEvent) {
+  return {
+    kind: "recording-event" as const,
+    roomId: "room-live",
+    sessionId: "session-1",
+    messageId: `message-${event.seq}`,
+    sentAt: 1_000 + event.seq,
+    stateVersion: event.seq,
+    event,
+  };
+}
+
+function contentEvent(seq: number, code: string): RecordingEvent {
+  return {
+    id: `event-${seq}`,
+    seq,
+    timestampMs: seq * 100,
+    source: "editor",
+    track: "main",
+    type: "content-change",
+    payload: {
+      fileId: "main",
+      version: seq,
+      code,
+      contentHash: `hash-${seq}`,
+      language: "typescript",
+      changeReason: "input",
+      changeCount: 1,
+      flushedBy: "debounce",
     },
   };
 }

--- a/apps/web/src/features/interview/__tests__/RemoteInterviewWorkbenchPage.test.tsx
+++ b/apps/web/src/features/interview/__tests__/RemoteInterviewWorkbenchPage.test.tsx
@@ -322,6 +322,75 @@ describe("RemoteInterviewWorkbenchPage", () => {
     expect(channel.onmessage).toBeNull();
     expect(latestCodeEditorProps().value).toBe("");
   });
+
+  it("resets room-scoped workbench and media session when the route room changes", async () => {
+    const firstMedia = createFakeMediaSession();
+    const secondMedia = createFakeMediaSession();
+    const createMediaSession = vi
+      .fn<() => InterviewMediaSession>()
+      .mockReturnValueOnce(firstMedia.session)
+      .mockReturnValueOnce(secondMedia.session);
+    const router = createMemoryRouter(
+      [
+        {
+          path: "/interview/interviewer/:roomId",
+          element: (
+            <RemoteInterviewWorkbenchPage
+              deps={{ createMediaSession }}
+            />
+          ),
+        },
+      ],
+      {
+        initialEntries: ["/interview/interviewer/room-a"],
+      },
+    );
+
+    render(
+      <ThemeProvider>
+        <TooltipProvider>
+          <RouterProvider router={router} />
+        </TooltipProvider>
+      </ThemeProvider>,
+    );
+    let firstChannel!: TestEventsDataChannel;
+    act(() => {
+      firstChannel = firstMedia.attachEventsDataChannel();
+      firstChannel.emit(
+        JSON.stringify(recordingMessage(contentEvent(1, "const roomA = true;"), "room-a")),
+      );
+    });
+    await waitFor(() => {
+      expect(latestCodeEditorProps().value).toBe("const roomA = true;");
+    });
+
+    await act(async () => {
+      await router.navigate("/interview/interviewer/room-b");
+    });
+
+    expect(firstMedia.session.close).toHaveBeenCalledTimes(1);
+    expect(firstChannel.onmessage).toBeNull();
+    expect(screen.getByText("room-b")).toBeInTheDocument();
+    expect(latestCodeEditorProps().value).toBe("");
+
+    act(() => {
+      firstChannel.emit(
+        JSON.stringify(recordingMessage(contentEvent(2, "const stale = true;"), "room-a")),
+      );
+    });
+    expect(latestCodeEditorProps().value).toBe("");
+
+    act(() => {
+      const secondChannel = secondMedia.attachEventsDataChannel();
+      secondChannel.emit(
+        JSON.stringify(recordingMessage(contentEvent(1, "const roomB = true;"), "room-b")),
+      );
+    });
+    await waitFor(() => {
+      expect(latestCodeEditorProps().value).toBe("const roomB = true;");
+    });
+    expect(createMediaSession).toHaveBeenCalledTimes(2);
+  });
 });
 
 function latestCodeEditorProps(): CodeEditorProps {
@@ -480,10 +549,10 @@ function createFakeEventsChannel(): TestEventsDataChannel {
   };
 }
 
-function recordingMessage(event: RecordingEvent) {
+function recordingMessage(event: RecordingEvent, roomId = "room-live") {
   return {
     kind: "recording-event" as const,
-    roomId: "room-live",
+    roomId,
     sessionId: "session-1",
     messageId: `message-${event.seq}`,
     sentAt: 1_000 + event.seq,

--- a/apps/web/src/features/interview/__tests__/RemoteInterviewWorkbenchPage.test.tsx
+++ b/apps/web/src/features/interview/__tests__/RemoteInterviewWorkbenchPage.test.tsx
@@ -282,6 +282,46 @@ describe("RemoteInterviewWorkbenchPage", () => {
     expect(channel.onmessage).toBeNull();
     expect(media.session.close).toHaveBeenCalledTimes(1);
   });
+
+  it("detaches the DataChannel receiver when the events channel closes", () => {
+    const media = createFakeMediaSession();
+    const router = createMemoryRouter(
+      [
+        {
+          path: "/interview/interviewer/:roomId",
+          element: (
+            <RemoteInterviewWorkbenchPage
+              deps={{ createMediaSession: () => media.session }}
+            />
+          ),
+        },
+      ],
+      {
+        initialEntries: ["/interview/interviewer/room-live"],
+      },
+    );
+
+    render(
+      <ThemeProvider>
+        <TooltipProvider>
+          <RouterProvider router={router} />
+        </TooltipProvider>
+      </ThemeProvider>,
+    );
+    let channel!: TestEventsDataChannel;
+    act(() => {
+      channel = media.attachEventsDataChannel();
+    });
+
+    expect(channel.onmessage).not.toBeNull();
+    act(() => {
+      media.closeEventsDataChannel();
+    });
+    channel.emit(JSON.stringify(recordingMessage(contentEvent(1, "const ignored = true;"))));
+
+    expect(channel.onmessage).toBeNull();
+    expect(latestCodeEditorProps().value).toBe("");
+  });
 });
 
 function latestCodeEditorProps(): CodeEditorProps {
@@ -368,13 +408,16 @@ function makeStableState(
 }
 
 type TestEventsDataChannel = InterviewEventsDataChannel & {
+  readyState: RTCDataChannelState;
   onmessage: ((event: { data: unknown }) => void) | null;
+  closeFromRemote(): void;
   emit(data: unknown): void;
 };
 
 function createFakeMediaSession(): {
   session: InterviewMediaSession;
   attachEventsDataChannel(): TestEventsDataChannel;
+  closeEventsDataChannel(): void;
 } {
   let state = makeMediaState();
   let channel: TestEventsDataChannel | null = null;
@@ -407,6 +450,14 @@ function createFakeMediaSession(): {
       notify();
       return channel;
     },
+    closeEventsDataChannel() {
+      if (!channel) {
+        return;
+      }
+      channel.closeFromRemote();
+      state = { ...state, eventsDataChannelState: "closed" };
+      notify();
+    },
   };
 }
 
@@ -419,6 +470,10 @@ function createFakeEventsChannel(): TestEventsDataChannel {
     onmessage: null,
     send: vi.fn(),
     close: vi.fn(),
+    closeFromRemote() {
+      this.readyState = "closed";
+      this.onclose?.();
+    },
     emit(data) {
       this.onmessage?.({ data });
     },

--- a/apps/web/src/features/interview/__tests__/interviewMediaSession.test.ts
+++ b/apps/web/src/features/interview/__tests__/interviewMediaSession.test.ts
@@ -48,6 +48,7 @@ class FakeDataChannel implements InterviewEventsDataChannel {
   readyState: RTCDataChannelState = "connecting";
   onopen: (() => void) | null = null;
   onclose: (() => void) | null = null;
+  onmessage: ((event: { data: unknown }) => void) | null = null;
   closeCalls = 0;
 
   constructor(readonly label = "events") {}
@@ -258,6 +259,7 @@ describe("InterviewMediaSession", () => {
     const channel = peer.emitDataChannel("events");
 
     expect(session.getState().eventsDataChannelState).toBe("connecting");
+    expect(session.getEventsDataChannel()).toBe(channel);
 
     channel.open();
     channel.close();
@@ -338,10 +340,12 @@ describe("InterviewMediaSession", () => {
     const { peer, deps } = createFixture();
     const session = createInterviewMediaSession({ deps });
     session.ensureEventsDataChannel();
+    peer.createdDataChannels[0].channel.onmessage = () => {};
 
     const closed = session.close();
 
     expect(peer.createdDataChannels[0].channel.closeCalls).toBe(1);
+    expect(peer.createdDataChannels[0].channel.onmessage).toBeNull();
     expect(closed.eventsDataChannelState).toBe("closed");
     expect(session.getState().eventsDataChannelState).toBe("closed");
   });
@@ -350,10 +354,12 @@ describe("InterviewMediaSession", () => {
     const { peer, deps } = createFixture();
     const session = createInterviewMediaSession({ deps });
     const channel = peer.emitDataChannel("events");
+    channel.onmessage = () => {};
 
     const closed = session.close();
 
     expect(channel.closeCalls).toBe(1);
+    expect(channel.onmessage).toBeNull();
     expect(closed.eventsDataChannelState).toBe("closed");
     expect(session.getState().eventsDataChannelState).toBe("closed");
   });

--- a/apps/web/src/features/interview/__tests__/interviewRealtimeReceiver.test.ts
+++ b/apps/web/src/features/interview/__tests__/interviewRealtimeReceiver.test.ts
@@ -62,10 +62,24 @@ describe("InterviewRealtimeReceiver", () => {
     expect(channel.onmessage).toBeNull();
     expect(workbench.getState().stableState.editor.code).toBe("");
   });
+
+  it("detaches when the DataChannel closes so late messages are ignored", () => {
+    const workbench = createRemoteInterviewWorkbench({ initialState: initialState() });
+    const channel = createFakeEventsChannel();
+
+    createInterviewRealtimeReceiver({ roomId: "room-1", workbench }).attach(channel);
+    channel.closeFromRemote();
+    channel.emit(JSON.stringify(messageFor(contentEvent(1, "const ignored = true;"))));
+
+    expect(channel.onmessage).toBeNull();
+    expect(workbench.getState().stableState.editor.code).toBe("");
+  });
 });
 
 type TestEventsDataChannel = InterviewEventsDataChannel & {
+  readyState: RTCDataChannelState;
   onmessage: ((event: { data: unknown }) => void) | null;
+  closeFromRemote(): void;
   emit(data: unknown): void;
 };
 
@@ -78,6 +92,10 @@ function createFakeEventsChannel(): TestEventsDataChannel {
     onmessage: null,
     send: vi.fn(),
     close: vi.fn(),
+    closeFromRemote() {
+      this.readyState = "closed";
+      this.onclose?.();
+    },
     emit(data) {
       this.onmessage?.({ data });
     },

--- a/apps/web/src/features/interview/__tests__/interviewRealtimeReceiver.test.ts
+++ b/apps/web/src/features/interview/__tests__/interviewRealtimeReceiver.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it, vi } from "vitest";
+import type { RecordingEvent, ReplayStableState } from "@/shared/recording-schema";
+import type { InterviewEventsDataChannel } from "../interviewMediaSession";
+import { createInterviewRealtimeReceiver } from "../interviewRealtimeReceiver";
+import { createRemoteInterviewWorkbench } from "../remoteInterviewWorkbench";
+
+describe("InterviewRealtimeReceiver", () => {
+  it("applies valid recording-event messages to the remote workbench", () => {
+    const workbench = createRemoteInterviewWorkbench({ initialState: initialState() });
+    const channel = createFakeEventsChannel();
+
+    createInterviewRealtimeReceiver({ roomId: "room-1", workbench }).attach(channel);
+    channel.emit(JSON.stringify(messageFor(contentEvent(1, "const live = true;"))));
+
+    const state = workbench.getState();
+    expect(state.stableState.editor.code).toBe("const live = true;");
+    expect(state.lastAppliedSeq).toBe(1);
+    expect(state.expectedSeq).toBe(2);
+    expect(state.syncStatus).toBe("live");
+  });
+
+  it("keeps candidate seq order while ignoring invalid or cross-room messages", () => {
+    const workbench = createRemoteInterviewWorkbench({ initialState: initialState() });
+    const channel = createFakeEventsChannel();
+    const ignoredReasons: string[] = [];
+
+    createInterviewRealtimeReceiver({
+      roomId: "room-1",
+      workbench,
+      onMessageResult: (result) => {
+        if (!result.ok) {
+          ignoredReasons.push(result.reason);
+        }
+      },
+    }).attach(channel);
+
+    channel.emit(JSON.stringify(messageFor(contentEvent(2, "const second = true;"))));
+    channel.emit("{not-json");
+    channel.emit(JSON.stringify({ ...messageFor(contentEvent(1, "wrong room")), roomId: "room-2" }));
+
+    expect(workbench.getState().stableState.editor.code).toBe("");
+    expect(workbench.getState().snapshotRequestNeeded).toEqual({
+      reason: "gap-detected",
+      expectedSeq: 1,
+      lastAppliedSeq: 0,
+    });
+
+    channel.emit(JSON.stringify(messageFor(contentEvent(1, "const first = true;"))));
+
+    expect(workbench.getState().stableState.editor.code).toBe("const second = true;");
+    expect(ignoredReasons).toEqual(["invalid-json", "room-mismatch"]);
+  });
+
+  it("detaches the message handler so closed or unmounted views stop applying events", () => {
+    const workbench = createRemoteInterviewWorkbench({ initialState: initialState() });
+    const channel = createFakeEventsChannel();
+    const detach = createInterviewRealtimeReceiver({ roomId: "room-1", workbench }).attach(channel);
+
+    detach();
+    channel.emit(JSON.stringify(messageFor(contentEvent(1, "const ignored = true;"))));
+
+    expect(channel.onmessage).toBeNull();
+    expect(workbench.getState().stableState.editor.code).toBe("");
+  });
+});
+
+type TestEventsDataChannel = InterviewEventsDataChannel & {
+  onmessage: ((event: { data: unknown }) => void) | null;
+  emit(data: unknown): void;
+};
+
+function createFakeEventsChannel(): TestEventsDataChannel {
+  return {
+    label: "events",
+    readyState: "open",
+    onopen: null,
+    onclose: null,
+    onmessage: null,
+    send: vi.fn(),
+    close: vi.fn(),
+    emit(data) {
+      this.onmessage?.({ data });
+    },
+  };
+}
+
+function messageFor(event: RecordingEvent) {
+  return {
+    kind: "recording-event" as const,
+    roomId: "room-1",
+    sessionId: "session-1",
+    messageId: `message-${event.seq}`,
+    sentAt: 1_000 + event.seq,
+    stateVersion: event.seq,
+    event,
+  };
+}
+
+function contentEvent(seq: number, code: string): RecordingEvent {
+  return {
+    id: `event-${seq}`,
+    seq,
+    timestampMs: seq * 100,
+    source: "editor",
+    track: "main",
+    type: "content-change",
+    payload: {
+      fileId: "main",
+      version: seq,
+      code,
+      contentHash: `hash-${seq}`,
+      language: "typescript",
+      changeReason: "input",
+      changeCount: 1,
+      flushedBy: "debounce",
+    },
+  };
+}
+
+function initialState(): ReplayStableState {
+  return {
+    editor: {
+      code: "",
+      language: "typescript",
+      cursor: null,
+      selection: null,
+      scrollTop: 0,
+      scrollLeft: 0,
+      fontSize: 14,
+      theme: "dark",
+    },
+    pointer: null,
+    media: {
+      microphoneEnabled: false,
+      cameraEnabled: false,
+      cameraPosition: { x: 0, y: 0 },
+    },
+    runtime: {
+      status: "idle",
+      stdout: [],
+      stderr: [],
+      previewHtml: null,
+      errorMessage: null,
+    },
+  };
+}

--- a/apps/web/src/features/interview/__tests__/interviewRealtimeReceiver.test.ts
+++ b/apps/web/src/features/interview/__tests__/interviewRealtimeReceiver.test.ts
@@ -89,6 +89,64 @@ describe("InterviewRealtimeReceiver", () => {
     expect(ignoredReasons).toEqual(["invalid-message", "invalid-message"]);
   });
 
+  it("applies state-snapshot messages and replays buffered later events", () => {
+    const workbench = createRemoteInterviewWorkbench({ initialState: initialState() });
+    const channel = createFakeEventsChannel();
+
+    createInterviewRealtimeReceiver({ roomId: "room-1", workbench }).attach(channel);
+    channel.emit(JSON.stringify(messageFor(contentEvent(3, "const replayed = true;"))));
+    channel.emit(
+      JSON.stringify(
+        snapshotMessage(2, {
+          ...initialState(),
+          editor: {
+            ...initialState().editor,
+            code: "const recovered = true;",
+          },
+        }),
+      ),
+    );
+
+    const state = workbench.getState();
+    expect(state.stableState.editor.code).toBe("const replayed = true;");
+    expect(state.lastAppliedSeq).toBe(3);
+    expect(state.expectedSeq).toBe(4);
+    expect(state.syncStatus).toBe("live");
+    expect(state.snapshotRequestNeeded).toBeNull();
+  });
+
+  it("ignores malformed state-snapshot messages", () => {
+    const workbench = createRemoteInterviewWorkbench({ initialState: initialState() });
+    const channel = createFakeEventsChannel();
+    const ignoredReasons: string[] = [];
+
+    createInterviewRealtimeReceiver({
+      roomId: "room-1",
+      workbench,
+      onMessageResult: (result) => {
+        if (!result.ok) {
+          ignoredReasons.push(result.reason);
+        }
+      },
+    }).attach(channel);
+    channel.emit(
+      JSON.stringify({
+        ...snapshotMessage(1, initialState()),
+        state: {
+          ...initialState(),
+          editor: {
+            ...initialState().editor,
+            code: 42,
+          },
+        },
+      }),
+    );
+
+    expect(workbench.getState().stableState.editor.code).toBe("");
+    expect(workbench.getState().lastAppliedSeq).toBe(0);
+    expect(ignoredReasons).toEqual(["invalid-message"]);
+  });
+
   it("detaches the message handler so closed or unmounted views stop applying events", () => {
     const workbench = createRemoteInterviewWorkbench({ initialState: initialState() });
     const channel = createFakeEventsChannel();
@@ -149,6 +207,20 @@ function messageFor(event: RecordingEvent) {
     sentAt: 1_000 + event.seq,
     stateVersion: event.seq,
     event,
+  };
+}
+
+function snapshotMessage(snapshotSeq: number, state: ReplayStableState) {
+  return {
+    kind: "state-snapshot" as const,
+    roomId: "room-1",
+    sessionId: "session-1",
+    messageId: `snapshot-${snapshotSeq}`,
+    sentAt: 2_000 + snapshotSeq,
+    snapshotSeq,
+    snapshotTimeMs: snapshotSeq * 100,
+    stateVersion: snapshotSeq,
+    state,
   };
 }
 

--- a/apps/web/src/features/interview/__tests__/interviewRealtimeReceiver.test.ts
+++ b/apps/web/src/features/interview/__tests__/interviewRealtimeReceiver.test.ts
@@ -51,6 +51,44 @@ describe("InterviewRealtimeReceiver", () => {
     expect(ignoredReasons).toEqual(["invalid-json", "room-mismatch"]);
   });
 
+  it("ignores malformed payloads and non-integer event sequence numbers", () => {
+    const workbench = createRemoteInterviewWorkbench({ initialState: initialState() });
+    const channel = createFakeEventsChannel();
+    const ignoredReasons: string[] = [];
+
+    createInterviewRealtimeReceiver({
+      roomId: "room-1",
+      workbench,
+      onMessageResult: (result) => {
+        if (!result.ok) {
+          ignoredReasons.push(result.reason);
+        }
+      },
+    }).attach(channel);
+
+    channel.emit(
+      JSON.stringify(
+        messageFor({
+          ...contentEvent(1, "const invalidPayload = true;"),
+          payload: {},
+        } as RecordingEvent),
+      ),
+    );
+    channel.emit(
+      JSON.stringify(
+        messageFor({
+          ...contentEvent(1.5, "const fractionalSeq = true;"),
+          id: "event-fractional",
+          seq: 1.5,
+        } as RecordingEvent),
+      ),
+    );
+
+    expect(workbench.getState().stableState.editor.code).toBe("");
+    expect(workbench.getState().lastAppliedSeq).toBe(0);
+    expect(ignoredReasons).toEqual(["invalid-message", "invalid-message"]);
+  });
+
   it("detaches the message handler so closed or unmounted views stop applying events", () => {
     const workbench = createRemoteInterviewWorkbench({ initialState: initialState() });
     const channel = createFakeEventsChannel();

--- a/apps/web/src/features/interview/__tests__/interviewSync.test.ts
+++ b/apps/web/src/features/interview/__tests__/interviewSync.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import type { EventBus, RecordingEvent } from "@/shared/recording-schema";
+import type { EventBus, RecordingEvent, ReplayStableState } from "@/shared/recording-schema";
 import {
   createInterviewSyncPublisher,
   createRemoteTimelineBuffer,
@@ -208,6 +208,36 @@ describe("RemoteTimelineBuffer", () => {
       lastAppliedSeq: 1,
     });
   });
+
+  it("accepts snapshots to skip gaps and replay buffered later events", () => {
+    const buffer = createRemoteTimelineBuffer({ initialExpectedSeq: 2 });
+
+    buffer.pushRecordingEvent(messageFor(contentEvent(3)));
+    const result = buffer.pushSnapshot(snapshotMessage(2));
+
+    expect(result.snapshotAccepted).toBe(true);
+    expect(result.appliedEvents.map((event) => event.seq)).toEqual([3]);
+    expect(result.lastAppliedSeq).toBe(3);
+    expect(result.expectedSeq).toBe(4);
+    expect(result.snapshotRequestNeeded).toBeNull();
+  });
+
+  it("ignores stale snapshots without clearing the pending gap", () => {
+    const buffer = createRemoteTimelineBuffer();
+
+    buffer.pushRecordingEvent(messageFor(contentEvent(1)));
+    buffer.pushRecordingEvent(messageFor(contentEvent(3)));
+    const result = buffer.pushSnapshot(snapshotMessage(0));
+
+    expect(result.snapshotAccepted).toBe(false);
+    expect(result.appliedEvents).toEqual([]);
+    expect(result.lastAppliedSeq).toBe(1);
+    expect(result.snapshotRequestNeeded).toEqual({
+      reason: "gap-detected",
+      expectedSeq: 2,
+      lastAppliedSeq: 1,
+    });
+  });
 });
 
 function messageFor(event: RecordingEvent) {
@@ -219,5 +249,19 @@ function messageFor(event: RecordingEvent) {
     sentAt: event.timestampMs,
     stateVersion: 1,
     event,
+  };
+}
+
+function snapshotMessage(snapshotSeq: number) {
+  return {
+    kind: "state-snapshot" as const,
+    roomId: "room-1",
+    sessionId: "session-1",
+    messageId: `snapshot-${snapshotSeq}`,
+    sentAt: snapshotSeq * 100,
+    snapshotSeq,
+    snapshotTimeMs: snapshotSeq * 100,
+    stateVersion: snapshotSeq,
+    state: {} as ReplayStableState,
   };
 }

--- a/apps/web/src/features/interview/__tests__/remoteInterviewWorkbench.test.ts
+++ b/apps/web/src/features/interview/__tests__/remoteInterviewWorkbench.test.ts
@@ -104,6 +104,26 @@ function messageFor(event: RecordingEvent) {
   };
 }
 
+function snapshotMessage(snapshotSeq: number, code: string) {
+  return {
+    kind: "state-snapshot" as const,
+    roomId: "room-1",
+    sessionId: "session-1",
+    messageId: `snapshot-${snapshotSeq}`,
+    sentAt: snapshotSeq * 100,
+    snapshotSeq,
+    snapshotTimeMs: snapshotSeq * 100,
+    stateVersion: snapshotSeq,
+    state: {
+      ...initialState(),
+      editor: {
+        ...initialState().editor,
+        code,
+      },
+    },
+  };
+}
+
 describe("RemoteInterviewWorkbench", () => {
   it("applies out-of-order remote events through the replay reducer in candidate seq order", () => {
     const workbench = createRemoteInterviewWorkbench({ initialState: initialState() });
@@ -140,6 +160,22 @@ describe("RemoteInterviewWorkbench", () => {
       expectedSeq: 2,
       lastAppliedSeq: 1,
     });
+  });
+
+  it("uses snapshots to recover gaps and replay buffered later events", () => {
+    const workbench = createRemoteInterviewWorkbench({
+      initialState: initialState(),
+      initialExpectedSeq: 2,
+    });
+
+    workbench.pushRecordingEvent(messageFor(contentEvent(3, "const afterSnapshot = true;")));
+    const state = workbench.pushSnapshot(snapshotMessage(2, "const fromSnapshot = true;"));
+
+    expect(state.stableState.editor.code).toBe("const afterSnapshot = true;");
+    expect(state.lastAppliedSeq).toBe(3);
+    expect(state.expectedSeq).toBe(4);
+    expect(state.syncStatus).toBe("live");
+    expect(state.snapshotRequestNeeded).toBeNull();
   });
 
   it("ignores duplicate and old events without rolling back stable state", () => {

--- a/apps/web/src/features/interview/index.ts
+++ b/apps/web/src/features/interview/index.ts
@@ -16,6 +16,7 @@ export {
 } from "./interviewSync";
 export {
   createInterviewMediaSession,
+  type InterviewDataChannelMessageEvent,
   type InterviewDataChannelState,
   type InterviewEventsDataChannel,
   type InterviewIceCandidateEvent,
@@ -27,6 +28,13 @@ export {
   type InterviewPeerConnection,
   type InterviewTrackEvent,
 } from "./interviewMediaSession";
+export {
+  createInterviewRealtimeReceiver,
+  type InterviewRealtimeReceiver,
+  type InterviewRealtimeReceiverIgnoredReason,
+  type InterviewRealtimeReceiverOptions,
+  type InterviewRealtimeReceiverResult,
+} from "./interviewRealtimeReceiver";
 export {
   CandidateInterviewPage,
   CandidateInterviewView,
@@ -70,6 +78,7 @@ export {
 export {
   RemoteInterviewWorkbenchPage,
   RemoteInterviewWorkbenchView,
+  type RemoteInterviewWorkbenchPageProps,
   type RemoteInterviewWorkbenchViewProps,
 } from "./RemoteInterviewWorkbenchPage";
 export { INITIAL_REMOTE_INTERVIEW_STABLE_STATE } from "./remoteInterviewInitialState";

--- a/apps/web/src/features/interview/index.ts
+++ b/apps/web/src/features/interview/index.ts
@@ -12,6 +12,7 @@ export {
   type InterviewSyncPublisher,
   type RemoteTimelineBuffer,
   type RemoteTimelineBufferResult,
+  type RemoteTimelineBufferSnapshotResult,
   type SnapshotRequestNeed,
 } from "./interviewSync";
 export {

--- a/apps/web/src/features/interview/interviewMediaSession.ts
+++ b/apps/web/src/features/interview/interviewMediaSession.ts
@@ -11,11 +11,16 @@ export type InterviewTrackEvent = {
 
 export type InterviewDataChannelState = "not-created" | RTCDataChannelState;
 
+export type InterviewDataChannelMessageEvent = {
+  data: unknown;
+};
+
 export type InterviewEventsDataChannel = {
   readonly label: string;
   readonly readyState: RTCDataChannelState;
   onopen: (() => void) | null;
   onclose: (() => void) | null;
+  onmessage: ((event: InterviewDataChannelMessageEvent) => void) | null;
   send(data: string): void;
   close(): void;
 };
@@ -72,6 +77,7 @@ export type InterviewMediaSessionState = {
 
 export type InterviewMediaSession = {
   getState(): InterviewMediaSessionState;
+  getEventsDataChannel(): InterviewEventsDataChannel | null;
   requestLocalMedia(constraints?: MediaStreamConstraints): Promise<InterviewMediaSessionState>;
   setMicrophoneEnabled(enabled: boolean): InterviewMediaSessionState;
   setCameraEnabled(enabled: boolean): InterviewMediaSessionState;
@@ -158,6 +164,9 @@ export function createInterviewMediaSession(
 
   return {
     getState: snapshot,
+    getEventsDataChannel() {
+      return eventsDataChannel;
+    },
     async requestLocalMedia(constraints = options.mediaConstraints ?? DEFAULT_MEDIA_CONSTRAINTS) {
       if (closed) {
         throw new Error("Interview media session is closed");
@@ -260,6 +269,7 @@ function closeEventsDataChannel(channel: InterviewEventsDataChannel | null): voi
   }
   channel.onopen = null;
   channel.onclose = null;
+  channel.onmessage = null;
   if (channel.readyState !== "closed") {
     channel.close();
   }

--- a/apps/web/src/features/interview/interviewRealtimeReceiver.ts
+++ b/apps/web/src/features/interview/interviewRealtimeReceiver.ts
@@ -83,19 +83,40 @@ export function createInterviewRealtimeReceiver(
 
   return {
     attach(channel) {
+      if (isClosedEventsDataChannel(channel)) {
+        return () => {};
+      }
       const previousHandler = channel.onmessage;
-      const handler = (event: { data: unknown }) => {
+      const previousCloseHandler = channel.onclose;
+      function handler(event: { data: unknown }) {
+        if (isClosedEventsDataChannel(channel)) {
+          detach();
+          return;
+        }
         handleData(event.data);
-      };
-      channel.onmessage = handler;
-      return () => {
+      }
+      function closeHandler() {
+        detach();
+        previousCloseHandler?.();
+      }
+      function detach() {
         if (channel.onmessage === handler) {
           channel.onmessage = previousHandler;
         }
-      };
+        if (channel.onclose === closeHandler) {
+          channel.onclose = previousCloseHandler;
+        }
+      }
+      channel.onmessage = handler;
+      channel.onclose = closeHandler;
+      return detach;
     },
     handleData,
   };
+}
+
+function isClosedEventsDataChannel(channel: InterviewEventsDataChannel): boolean {
+  return channel.readyState === "closed" || channel.readyState === "closing";
 }
 
 function isInterviewRecordingEventMessage(

--- a/apps/web/src/features/interview/interviewRealtimeReceiver.ts
+++ b/apps/web/src/features/interview/interviewRealtimeReceiver.ts
@@ -1,4 +1,8 @@
-import type { RecordingEvent } from "@/shared/recording-schema";
+import {
+  RECORDING_SCHEMA_VERSION,
+  validateRecordingPackageV1,
+  type RecordingEvent,
+} from "@/shared/recording-schema";
 import type { InterviewEventsDataChannel } from "./interviewMediaSession";
 import type { InterviewRecordingEventMessage } from "./interviewSync";
 import type { RemoteInterviewWorkbench } from "./remoteInterviewWorkbench";
@@ -46,6 +50,38 @@ const RECORDING_EVENT_TYPES = new Set<RecordingEvent["type"]>([
   "run-error",
   "chapter-marker",
 ]);
+
+const RECORDING_EVENT_VALIDATION_PACKAGE = {
+  schemaVersion: RECORDING_SCHEMA_VERSION,
+  manifest: {
+    packageId: "interview-realtime-message",
+    schemaVersion: RECORDING_SCHEMA_VERSION,
+    status: "complete",
+    createdAt: "2026-01-01T00:00:00.000Z",
+    completedAt: "2026-01-01T00:00:00.000Z",
+    checksums: { eventsSha256: "realtime", snapshotsSha256: "realtime" },
+  },
+  meta: {
+    id: "interview-realtime-message",
+    title: "Interview realtime message",
+    createdAt: "2026-01-01T00:00:00.000Z",
+    durationMs: 0,
+    appVersion: "0.0.0",
+    ownerId: null,
+    creatorInfo: null,
+    initialLanguage: "typescript",
+    initialFontSize: 14,
+    initialTheme: "dark",
+    mediaCapability: {
+      audio: "available",
+      camera: "available",
+      selectedAudioDeviceId: null,
+      selectedCameraDeviceId: null,
+    },
+  },
+  snapshots: [],
+  media: null,
+} as const;
 
 export function createInterviewRealtimeReceiver(
   options: InterviewRealtimeReceiverOptions,
@@ -140,14 +176,22 @@ function isRecordingEvent(value: unknown): value is RecordingEvent {
   }
   return (
     typeof value.id === "string" &&
-    isFiniteNumber(value.seq) &&
+    isPositiveInteger(value.seq) &&
     isFiniteNumber(value.timestampMs) &&
     typeof value.source === "string" &&
     typeof value.track === "string" &&
     typeof value.type === "string" &&
     RECORDING_EVENT_TYPES.has(value.type as RecordingEvent["type"]) &&
-    isPlainObject(value.payload)
+    isPlainObject(value.payload) &&
+    hasValidRecordingEventPayload(value as RecordingEvent)
   );
+}
+
+function hasValidRecordingEventPayload(event: RecordingEvent): boolean {
+  return validateRecordingPackageV1({
+    ...RECORDING_EVENT_VALIDATION_PACKAGE,
+    events: [event],
+  }).ok;
 }
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {
@@ -156,4 +200,8 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
 
 function isFiniteNumber(value: unknown): value is number {
   return typeof value === "number" && Number.isFinite(value);
+}
+
+function isPositiveInteger(value: unknown): value is number {
+  return typeof value === "number" && Number.isInteger(value) && value > 0;
 }

--- a/apps/web/src/features/interview/interviewRealtimeReceiver.ts
+++ b/apps/web/src/features/interview/interviewRealtimeReceiver.ts
@@ -1,0 +1,138 @@
+import type { RecordingEvent } from "@/shared/recording-schema";
+import type { InterviewEventsDataChannel } from "./interviewMediaSession";
+import type { InterviewRecordingEventMessage } from "./interviewSync";
+import type { RemoteInterviewWorkbench } from "./remoteInterviewWorkbench";
+
+export type InterviewRealtimeReceiverIgnoredReason =
+  | "non-string-data"
+  | "invalid-json"
+  | "unsupported-kind"
+  | "invalid-message"
+  | "room-mismatch";
+
+export type InterviewRealtimeReceiverResult =
+  | { ok: true; message: InterviewRecordingEventMessage }
+  | { ok: false; reason: InterviewRealtimeReceiverIgnoredReason };
+
+export type InterviewRealtimeReceiverOptions = {
+  roomId: string;
+  workbench: RemoteInterviewWorkbench;
+  onMessageResult?: (result: InterviewRealtimeReceiverResult) => void;
+};
+
+export type InterviewRealtimeReceiver = {
+  attach(channel: InterviewEventsDataChannel): () => void;
+  handleData(data: unknown): InterviewRealtimeReceiverResult;
+};
+
+const RECORDING_EVENT_TYPES = new Set<RecordingEvent["type"]>([
+  "record-start",
+  "record-pause",
+  "record-resume",
+  "resume-baseline",
+  "record-stop",
+  "content-change",
+  "language-change",
+  "selection-change",
+  "editor-scroll",
+  "mouse-move",
+  "mouse-click",
+  "shortcut",
+  "media-toggle",
+  "media-warning",
+  "camera-position",
+  "run-start",
+  "run-output",
+  "run-error",
+  "chapter-marker",
+]);
+
+export function createInterviewRealtimeReceiver(
+  options: InterviewRealtimeReceiverOptions,
+): InterviewRealtimeReceiver {
+  const notify = (result: InterviewRealtimeReceiverResult): InterviewRealtimeReceiverResult => {
+    options.onMessageResult?.(result);
+    return result;
+  };
+
+  const handleData = (data: unknown): InterviewRealtimeReceiverResult => {
+    if (typeof data !== "string") {
+      return notify({ ok: false, reason: "non-string-data" });
+    }
+
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(data);
+    } catch {
+      return notify({ ok: false, reason: "invalid-json" });
+    }
+
+    if (!isPlainObject(parsed) || parsed.kind !== "recording-event") {
+      return notify({ ok: false, reason: "unsupported-kind" });
+    }
+    if (parsed.roomId !== options.roomId) {
+      return notify({ ok: false, reason: "room-mismatch" });
+    }
+    if (!isInterviewRecordingEventMessage(parsed)) {
+      return notify({ ok: false, reason: "invalid-message" });
+    }
+
+    options.workbench.pushRecordingEvent(parsed);
+    return notify({ ok: true, message: parsed });
+  };
+
+  return {
+    attach(channel) {
+      const previousHandler = channel.onmessage;
+      const handler = (event: { data: unknown }) => {
+        handleData(event.data);
+      };
+      channel.onmessage = handler;
+      return () => {
+        if (channel.onmessage === handler) {
+          channel.onmessage = previousHandler;
+        }
+      };
+    },
+    handleData,
+  };
+}
+
+function isInterviewRecordingEventMessage(
+  value: Record<string, unknown>,
+): value is InterviewRecordingEventMessage {
+  return (
+    value.kind === "recording-event" &&
+    typeof value.roomId === "string" &&
+    typeof value.sessionId === "string" &&
+    typeof value.messageId === "string" &&
+    isFiniteNumber(value.sentAt) &&
+    isFiniteNumber(value.stateVersion) &&
+    (value.contentHash === undefined || typeof value.contentHash === "string") &&
+    isRecordingEvent(value.event)
+  );
+}
+
+function isRecordingEvent(value: unknown): value is RecordingEvent {
+  if (!isPlainObject(value)) {
+    return false;
+  }
+  return (
+    typeof value.id === "string" &&
+    isFiniteNumber(value.seq) &&
+    isFiniteNumber(value.timestampMs) &&
+    typeof value.source === "string" &&
+    typeof value.track === "string" &&
+    typeof value.type === "string" &&
+    RECORDING_EVENT_TYPES.has(value.type as RecordingEvent["type"]) &&
+    isPlainObject(value.payload)
+  );
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isFiniteNumber(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value);
+}

--- a/apps/web/src/features/interview/interviewRealtimeReceiver.ts
+++ b/apps/web/src/features/interview/interviewRealtimeReceiver.ts
@@ -2,9 +2,10 @@ import {
   RECORDING_SCHEMA_VERSION,
   validateRecordingPackageV1,
   type RecordingEvent,
+  type ReplayStableState,
 } from "@/shared/recording-schema";
 import type { InterviewEventsDataChannel } from "./interviewMediaSession";
-import type { InterviewRecordingEventMessage } from "./interviewSync";
+import type { InterviewRecordingEventMessage, InterviewSnapshotMessage } from "./interviewSync";
 import type { RemoteInterviewWorkbench } from "./remoteInterviewWorkbench";
 
 export type InterviewRealtimeReceiverIgnoredReason =
@@ -15,7 +16,7 @@ export type InterviewRealtimeReceiverIgnoredReason =
   | "room-mismatch";
 
 export type InterviewRealtimeReceiverResult =
-  | { ok: true; message: InterviewRecordingEventMessage }
+  | { ok: true; message: InterviewRecordingEventMessage | InterviewSnapshotMessage }
   | { ok: false; reason: InterviewRealtimeReceiverIgnoredReason };
 
 export type InterviewRealtimeReceiverOptions = {
@@ -103,16 +104,27 @@ export function createInterviewRealtimeReceiver(
       return notify({ ok: false, reason: "invalid-json" });
     }
 
-    if (!isPlainObject(parsed) || parsed.kind !== "recording-event") {
+    if (
+      !isPlainObject(parsed) ||
+      (parsed.kind !== "recording-event" && parsed.kind !== "state-snapshot")
+    ) {
       return notify({ ok: false, reason: "unsupported-kind" });
     }
     if (parsed.roomId !== options.roomId) {
       return notify({ ok: false, reason: "room-mismatch" });
     }
+
+    if (parsed.kind === "state-snapshot") {
+      if (!isInterviewSnapshotMessage(parsed)) {
+        return notify({ ok: false, reason: "invalid-message" });
+      }
+      options.workbench.pushSnapshot(parsed);
+      return notify({ ok: true, message: parsed });
+    }
+
     if (!isInterviewRecordingEventMessage(parsed)) {
       return notify({ ok: false, reason: "invalid-message" });
     }
-
     options.workbench.pushRecordingEvent(parsed);
     return notify({ ok: true, message: parsed });
   };
@@ -187,6 +199,20 @@ function isRecordingEvent(value: unknown): value is RecordingEvent {
   );
 }
 
+function isInterviewSnapshotMessage(value: Record<string, unknown>): value is InterviewSnapshotMessage {
+  return (
+    value.kind === "state-snapshot" &&
+    typeof value.roomId === "string" &&
+    typeof value.sessionId === "string" &&
+    typeof value.messageId === "string" &&
+    isFiniteNumber(value.sentAt) &&
+    isNonNegativeInteger(value.snapshotSeq) &&
+    isFiniteNumber(value.snapshotTimeMs) &&
+    isFiniteNumber(value.stateVersion) &&
+    isReplayStableState(value.state)
+  );
+}
+
 function hasValidRecordingEventPayload(event: RecordingEvent): boolean {
   return validateRecordingPackageV1({
     ...RECORDING_EVENT_VALIDATION_PACKAGE,
@@ -204,4 +230,111 @@ function isFiniteNumber(value: unknown): value is number {
 
 function isPositiveInteger(value: unknown): value is number {
   return typeof value === "number" && Number.isInteger(value) && value > 0;
+}
+
+function isNonNegativeInteger(value: unknown): value is number {
+  return typeof value === "number" && Number.isInteger(value) && value >= 0;
+}
+
+function isReplayStableState(value: unknown): value is ReplayStableState {
+  if (!isPlainObject(value)) {
+    return false;
+  }
+
+  const { editor, pointer, media, runtime } = value;
+  return (
+    isEditorState(editor) &&
+    isPointerState(pointer) &&
+    isMediaState(media) &&
+    isRuntimeState(runtime)
+  );
+}
+
+function isEditorState(value: unknown): value is ReplayStableState["editor"] {
+  if (!isPlainObject(value)) {
+    return false;
+  }
+  return (
+    typeof value.code === "string" &&
+    isRecordingLanguage(value.language) &&
+    isCursor(value.cursor) &&
+    isSelection(value.selection) &&
+    isFiniteNumber(value.scrollTop) &&
+    isFiniteNumber(value.scrollLeft) &&
+    isFiniteNumber(value.fontSize) &&
+    isRecordingTheme(value.theme)
+  );
+}
+
+function isPointerState(value: unknown): value is ReplayStableState["pointer"] {
+  if (value === null) {
+    return true;
+  }
+  return (
+    isPlainObject(value) &&
+    isFiniteNumber(value.x) &&
+    isFiniteNumber(value.y) &&
+    typeof value.visible === "boolean"
+  );
+}
+
+function isMediaState(value: unknown): value is ReplayStableState["media"] {
+  if (!isPlainObject(value) || !isPlainObject(value.cameraPosition)) {
+    return false;
+  }
+  return (
+    typeof value.microphoneEnabled === "boolean" &&
+    typeof value.cameraEnabled === "boolean" &&
+    isFiniteNumber(value.cameraPosition.x) &&
+    isFiniteNumber(value.cameraPosition.y)
+  );
+}
+
+function isRuntimeState(value: unknown): value is ReplayStableState["runtime"] {
+  if (!isPlainObject(value)) {
+    return false;
+  }
+  return (
+    isRuntimeStatus(value.status) &&
+    isStringArray(value.stdout) &&
+    isStringArray(value.stderr) &&
+    (value.previewHtml === null || typeof value.previewHtml === "string") &&
+    (value.errorMessage === null || typeof value.errorMessage === "string")
+  );
+}
+
+function isCursor(value: unknown): value is ReplayStableState["editor"]["cursor"] {
+  if (value === null) {
+    return true;
+  }
+  return isPlainObject(value) && isFiniteNumber(value.lineNumber) && isFiniteNumber(value.column);
+}
+
+function isSelection(value: unknown): value is ReplayStableState["editor"]["selection"] {
+  if (value === null) {
+    return true;
+  }
+  return (
+    isPlainObject(value) &&
+    isFiniteNumber(value.startLineNumber) &&
+    isFiniteNumber(value.startColumn) &&
+    isFiniteNumber(value.endLineNumber) &&
+    isFiniteNumber(value.endColumn)
+  );
+}
+
+function isRecordingLanguage(value: unknown): value is ReplayStableState["editor"]["language"] {
+  return value === "javascript" || value === "typescript" || value === "python";
+}
+
+function isRecordingTheme(value: unknown): value is ReplayStableState["editor"]["theme"] {
+  return value === "light" || value === "dark";
+}
+
+function isRuntimeStatus(value: unknown): value is ReplayStableState["runtime"]["status"] {
+  return value === "idle" || value === "running" || value === "success" || value === "error";
+}
+
+function isStringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every((item) => typeof item === "string");
 }

--- a/apps/web/src/features/interview/interviewSync.ts
+++ b/apps/web/src/features/interview/interviewSync.ts
@@ -142,12 +142,17 @@ export type RemoteTimelineBufferResult = {
   snapshotRequestNeeded: SnapshotRequestNeed | null;
 };
 
+export type RemoteTimelineBufferSnapshotResult = RemoteTimelineBufferResult & {
+  snapshotAccepted: boolean;
+};
+
 export type RemoteTimelineBufferOptions = {
   initialExpectedSeq?: number;
 };
 
 export type RemoteTimelineBuffer = {
   pushRecordingEvent(message: InterviewRecordingEventMessage): RemoteTimelineBufferResult;
+  pushSnapshot(message: InterviewSnapshotMessage): RemoteTimelineBufferSnapshotResult;
   state(): Omit<RemoteTimelineBufferResult, "appliedEvents">;
 };
 
@@ -169,6 +174,21 @@ export function createRemoteTimelineBuffer(
     snapshotRequestNeeded: currentSnapshotNeed(),
   });
 
+  const drainContiguousEvents = (): RecordingEvent[] => {
+    const appliedEvents: RecordingEvent[] = [];
+    while (bufferedEvents.has(expectedSeq)) {
+      const next = bufferedEvents.get(expectedSeq);
+      if (!next) {
+        break;
+      }
+      bufferedEvents.delete(expectedSeq);
+      appliedEvents.push(next);
+      lastAppliedSeq = next.seq;
+      expectedSeq = next.seq + 1;
+    }
+    return appliedEvents;
+  };
+
   return {
     pushRecordingEvent(message) {
       const { event } = message;
@@ -179,19 +199,25 @@ export function createRemoteTimelineBuffer(
         bufferedEvents.set(event.seq, event);
       }
 
-      const appliedEvents: RecordingEvent[] = [];
-      while (bufferedEvents.has(expectedSeq)) {
-        const next = bufferedEvents.get(expectedSeq);
-        if (!next) {
-          break;
-        }
-        bufferedEvents.delete(expectedSeq);
-        appliedEvents.push(next);
-        lastAppliedSeq = next.seq;
-        expectedSeq = next.seq + 1;
-      }
+      const appliedEvents = drainContiguousEvents();
 
       return { appliedEvents, ...currentState() };
+    },
+    pushSnapshot(message) {
+      if (message.snapshotSeq < lastAppliedSeq) {
+        return { snapshotAccepted: false, appliedEvents: [], ...currentState() };
+      }
+
+      for (const seq of bufferedEvents.keys()) {
+        if (seq <= message.snapshotSeq) {
+          bufferedEvents.delete(seq);
+        }
+      }
+      lastAppliedSeq = message.snapshotSeq;
+      expectedSeq = message.snapshotSeq + 1;
+
+      const appliedEvents = drainContiguousEvents();
+      return { snapshotAccepted: true, appliedEvents, ...currentState() };
     },
     state: currentState,
   };

--- a/apps/web/src/features/interview/remoteInterviewWorkbench.ts
+++ b/apps/web/src/features/interview/remoteInterviewWorkbench.ts
@@ -6,6 +6,7 @@ import {
 import {
   createRemoteTimelineBuffer,
   type InterviewRecordingEventMessage,
+  type InterviewSnapshotMessage,
   type SnapshotRequestNeed,
 } from "./interviewSync";
 
@@ -27,6 +28,7 @@ export type RemoteInterviewWorkbenchOptions = {
 export type RemoteInterviewWorkbench = {
   getState(): RemoteInterviewWorkbenchState;
   pushRecordingEvent(message: InterviewRecordingEventMessage): RemoteInterviewWorkbenchState;
+  pushSnapshot(message: InterviewSnapshotMessage): RemoteInterviewWorkbenchState;
   subscribe(listener: (state: RemoteInterviewWorkbenchState) => void): () => void;
 };
 
@@ -58,6 +60,14 @@ export function createRemoteInterviewWorkbench(
     getState: snapshot,
     pushRecordingEvent(message) {
       const result = buffer.pushRecordingEvent(message);
+      stableState = result.appliedEvents.reduce(replayReducer, stableState);
+      return notify();
+    },
+    pushSnapshot(message) {
+      const result = buffer.pushSnapshot(message);
+      if (result.snapshotAccepted) {
+        stableState = cloneReplayStableState(message.state);
+      }
       stableState = result.appliedEvents.reduce(replayReducer, stableState);
       return notify();
     },


### PR DESCRIPTION
## 关联

Closes #189
Refs #120（总控 issue，不在本 PR 中关闭）

## 改动点

- 新增 `createInterviewRealtimeReceiver`，在面试官端解析 `events` DataChannel 收到的实时 JSON 消息，并推入 `RemoteInterviewWorkbench`。
- 将 `RemoteInterviewWorkbenchPage` 改为按 room 创建/关闭 `InterviewMediaSession`，并随 DataChannel 生命周期绑定/解绑接收端；路由 roomId 变化会重置只读工作台和媒体会话。
- 扩展 `InterviewEventsDataChannel` 的 `onmessage` 和 `getEventsDataChannel()` 能力，关闭通道时清理 message handler。
- 根据 repo-guard/Codex 反馈补齐 DataChannel close 后的防 stale apply、跨房间清理、payload schema 校验、正整数 seq 校验。
- 根据 Codex snapshot 反馈补齐 `state-snapshot` 接收：面试官在 gap 后可用 snapshotSeq 替换稳定状态，并重放已缓冲的后续事件； malformed snapshot 会被忽略。
- 补充接收端、只读工作台集成、DataChannel close、room 切换、snapshot 恢复、媒体会话清理、候选人 fake session 兼容测试。

## 影响范围

- 面试官只读工作台现在能从候选人实时事件恢复代码状态，仍保持只读。
- 无效 JSON、未知 kind、跨房间消息、结构不合法消息、非正整数或非整数 seq 事件、结构不合法 snapshot 会被忽略，不更新工作台状态。
- 页面卸载、room 切换、媒体会话关闭或 events DataChannel 自身 close 后会解绑 message handler，降低泄漏和 stale apply 风险。
- `RemoteTimelineBuffer` 新增 snapshot 恢复语义：接受 `snapshotSeq >= lastAppliedSeq` 的 snapshot，丢弃已被 snapshot 覆盖的 buffered events，再按 seq 重放 `snapshotSeq` 之后的连续事件。
- 非目标：不实现 ACK、背压、周期性 snapshot 发送、hash mismatch 自动请求、完整抖动恢复、面试结束保存回放，也不在本 PR 新增面试官侧信令 join/offer-answer/ICE 完整接线；后者作为下一步单独 issue 处理。

## GitNexus 影响分析摘要

- 风险等级: critical（`npx gitnexus detect_changes --repo code-tape-issue-189 --scope compare --base-ref origin/main`）
- 关键骨架变更: `npm run quality:predev`、precommit hook、pre-push `quality:local` 的 GitNexus contract 均判定 `No critical contract surface changed`，本 diff 为 advisory。
- GitNexus 影响面: 12 files / 67 symbols / 20 affected execution flows；主要涉及 `RemoteInterviewWorkbenchPage` room 级生命周期、`Handler -> receiver validation helpers`、snapshot shape validation、`RemoteTimelineBuffer` gap/snapshot 恢复、`RemoteInterviewWorkbench` replay reducer 应用链路、`CreateInterviewMediaSession -> CloneIceCandidates`。
- 符号影响: `createInterviewRealtimeReceiver` LOW，`createRemoteTimelineBuffer` LOW，`createRemoteInterviewWorkbench` LOW。
- 风险压降: 针对 DataChannel close、room 切换、payload/schema/seq 校验、snapshot 恢复与 malformed snapshot、媒体会话状态订阅和候选人 fake session 兼容均补充回归测试。

## 验证

- `npm run quality:predev`：通过，GitNexus contract passed。
- RED: 新增 `state-snapshot` receiver 测试先失败，失败点为 snapshot 被忽略后 editor code 仍为空。
- `npm run test -w apps/web -- src/features/interview/__tests__/interviewRealtimeReceiver.test.ts src/features/interview/__tests__/interviewSync.test.ts src/features/interview/__tests__/remoteInterviewWorkbench.test.ts`：3 files / 23 tests passed。
- `npm run test -w apps/web -- src/features/interview/__tests__/interviewRealtimeReceiver.test.ts src/features/interview/__tests__/RemoteInterviewWorkbenchPage.test.tsx src/features/interview/__tests__/interviewMediaSession.test.ts src/features/interview/__tests__/CandidateInterviewPage.test.tsx src/features/interview/__tests__/interviewSync.test.ts src/features/interview/__tests__/remoteInterviewWorkbench.test.ts`：6 files / 79 tests passed。
- `npm run lint:web`：通过。
- `npm run build -w apps/web`：通过，仅保留既有 chunk-size warning。
- `git diff --check`：通过。
- `npx gitnexus analyze --force --index-only --name code-tape-issue-189 .`：通过。
- `npx gitnexus detect_changes --repo code-tape-issue-189 --scope compare --base-ref origin/main`：critical / 12 files / 67 symbols / 20 flows，见上方摘要。
- `npm run quality:precommit` / commit hook `quality:precommit`：通过；root tests 114/114、schema 1/1、API 193/193、web 59 files / 598 tests、build passed。
- pre-push `npm run quality:local`：通过；root tests 114/114、schema 1/1、API 193/193、web 59 files / 598 tests、build passed、Playwright e2e 6/6。

## 自检

- [x] 未修改 `docs/progress.json` 或 `docs/progress.md`
- [x] 已运行 `npm run quality:local`，或说明无法运行的原因
- [x] 不涉及 AI 字幕；无需 `npm run subtitle:postprocess:evaluate`
- [x] 不涉及 AI 字幕点击链路、LLM worker、模型加载或性能；无需 `npm run subtitle:postprocess:runtime-benchmark`
- [x] 已说明改动点和影响范围
- [x] 如果改动关键骨架，已补充契约测试并填写 GitNexus 影响分析摘要
- [x] 已等待 repo-guard、codex 和 Copilot 评论，并完成必要审查

