### PR TITLE
fix: recover stale transformers chunk for subtitles

### DIFF
--- a/apps/web/src/app/__tests__/staleChunkRecovery.test.ts
+++ b/apps/web/src/app/__tests__/staleChunkRecovery.test.ts
@@ -85,4 +85,31 @@ describe("installStaleChunkRecovery", () => {
 
     expect(reload).toHaveBeenCalledTimes(1);
   });
+
+  it("clears code-tape asset caches before reloading", async () => {
+    const reload = vi.fn();
+    const deletedCaches: string[] = [];
+    const target = new EventTarget();
+    installStaleChunkRecovery({
+      target,
+      storage: {
+        getItem: () => null,
+        setItem: vi.fn(),
+      },
+      reload,
+      getRecoveryToken: () => "entry-index-C.js",
+      cacheStorage: {
+        keys: async () => ["code-tape-assets-v1", "transformers-cache", "unrelated-cache"],
+        delete: async (name) => {
+          deletedCaches.push(name);
+          return true;
+        },
+      },
+    });
+
+    target.dispatchEvent(createPreloadError("Failed to fetch dynamically imported module"));
+
+    await vi.waitFor(() => expect(reload).toHaveBeenCalledTimes(1));
+    expect(deletedCaches).toEqual(["code-tape-assets-v1"]);
+  });
 });

--- a/apps/web/src/app/staleChunkRecovery.ts
+++ b/apps/web/src/app/staleChunkRecovery.ts
@@ -5,6 +5,11 @@ type StaleChunkRecoveryStorage = {
   setItem(key: string, value: string): void;
 };
 
+type StaleChunkRecoveryCacheStorage = {
+  keys(): Promise<string[]>;
+  delete(name: string): Promise<boolean>;
+};
+
 type VitePreloadErrorEvent = Event & {
   payload?: unknown;
 };
@@ -14,6 +19,7 @@ export type StaleChunkRecoveryOptions = {
   storage?: StaleChunkRecoveryStorage;
   reload?: () => void;
   getRecoveryToken?: () => string;
+  cacheStorage?: StaleChunkRecoveryCacheStorage;
 };
 
 const STALE_CHUNK_RECOVERY_KEY = "code-tape:stale-chunk-recovery";
@@ -36,7 +42,12 @@ export function installStaleChunkRecovery(options: StaleChunkRecoveryOptions = {
     if (readRecoveryToken(storage) === recoveryToken) return;
 
     writeRecoveryToken(storage, recoveryToken);
-    reload();
+    const cacheStorage = options.cacheStorage ?? readCacheStorage();
+    if (!cacheStorage) {
+      reload();
+      return;
+    }
+    void clearStaleChunkCaches(cacheStorage).finally(reload);
   };
 
   target.addEventListener("vite:preloadError", handlePreloadError);
@@ -63,6 +74,38 @@ function readSessionStorage(): StaleChunkRecoveryStorage | undefined {
   } catch {
     return undefined;
   }
+}
+
+function readCacheStorage(): StaleChunkRecoveryCacheStorage | undefined {
+  try {
+    return globalThis.caches;
+  } catch {
+    return undefined;
+  }
+}
+
+async function clearStaleChunkCaches(cacheStorage: StaleChunkRecoveryCacheStorage): Promise<void> {
+  let cacheNames: string[];
+  try {
+    cacheNames = await cacheStorage.keys();
+  } catch {
+    return;
+  }
+  await Promise.all(
+    cacheNames
+      .filter(isCodeTapeAssetCache)
+      .map(async (cacheName) => {
+        try {
+          await cacheStorage.delete(cacheName);
+        } catch {
+          // Cache cleanup is best-effort; reloading is still the recovery path.
+        }
+      }),
+  );
+}
+
+function isCodeTapeAssetCache(cacheName: string): boolean {
+  return /code-tape|vite|workbox|assets|precache/iu.test(cacheName);
 }
 
 function readRecoveryToken(storage: StaleChunkRecoveryStorage | undefined): string | null {

--- a/apps/web/src/features/subtitles/SubtitlePanel.tsx
+++ b/apps/web/src/features/subtitles/SubtitlePanel.tsx
@@ -6,6 +6,7 @@ import { resolveSubtitlePostProcessorModel } from "./subtitlePostProcessorConfig
 import { createWorkerBackedHuggingFaceSubtitlePostProcessor } from "./subtitlePostProcessorWorkerClient";
 import { createSubtitleStore } from "./subtitleStore";
 import { createHuggingFaceSubtitleTranscriber } from "./subtitleTranscriber";
+import { requestStaleTransformersImportRecovery } from "./transformersLoader";
 import type {
   SubtitleChapter,
   SubtitleCorrectionWarning,
@@ -242,6 +243,7 @@ export function SubtitlePanel({
       setStatus("ready");
     } catch (err) {
       if (abortController.signal.aborted || requestVersionRef.current !== requestVersion) return;
+      if (requestStaleTransformersImportRecovery(err)) return;
       setError(formatSubtitleError(err));
       setStatus("error");
     } finally {
@@ -296,6 +298,7 @@ export function SubtitlePanel({
         return;
       }
       if (abortController.signal.aborted || requestVersionRef.current !== requestVersion) return;
+      if (requestStaleTransformersImportRecovery(err)) return;
       setError(formatSubtitleError(err));
       setStatus("error");
     } finally {

--- a/apps/web/src/features/subtitles/__tests__/SubtitlePanel.test.tsx
+++ b/apps/web/src/features/subtitles/__tests__/SubtitlePanel.test.tsx
@@ -1,5 +1,6 @@
 import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { installStaleChunkRecovery } from "../../../app/staleChunkRecovery";
 import { SubtitlePanel } from "../SubtitlePanel";
 import type {
   SubtitleChapter,
@@ -110,6 +111,49 @@ describe("SubtitlePanel", () => {
         source: "huggingface-local",
       }),
     );
+  });
+
+  it("recovers from stale Transformers chunks during subtitle generation without showing the raw import error", async () => {
+    const store = createMemorySubtitleStore();
+    const reload = vi.fn();
+    const cleanupRecovery = installStaleChunkRecovery({
+      reload,
+      storage: {
+        getItem: () => null,
+        setItem: vi.fn(),
+      },
+      getRecoveryToken: () => "entry-index-B.js",
+    });
+    const staleChunkError = new TypeError(
+      "Failed to fetch dynamically imported module: https://ceilf6.github.io/code-tape/assets/transformers.web-Ddnr203B.js",
+    );
+    const transcriber: SubtitleTranscriber = {
+      transcribe: vi.fn(async () => {
+        throw staleChunkError;
+      }),
+    };
+
+    render(
+      <SubtitlePanel
+        recordingId="recording-1"
+        mediaBlob={new Blob(["webm"], { type: "video/webm" })}
+        hasAudio
+        durationMs={3_000}
+        currentTimeMs={0}
+        onSeek={vi.fn()}
+        store={store}
+        transcriber={transcriber}
+      />,
+    );
+
+    const generateButton = screen.getByRole("button", { name: "生成字幕" });
+    await waitFor(() => expect(generateButton).not.toBeDisabled());
+
+    fireEvent.click(generateButton);
+
+    await waitFor(() => expect(reload).toHaveBeenCalledTimes(1));
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+    cleanupRecovery();
   });
 
   it("runs local LLM post-processing to correct subtitles and render seekable chapters", async () => {

--- a/apps/web/src/features/subtitles/__tests__/transformersLoader.test.ts
+++ b/apps/web/src/features/subtitles/__tests__/transformersLoader.test.ts
@@ -88,6 +88,19 @@ describe("transformersLoader", () => {
     expect(dispatchEvent).not.toHaveBeenCalled();
   });
 
+  it("reports whether a stale chunk recovery request was handled", () => {
+    const error = new TypeError("Failed to fetch dynamically imported module");
+    expect(requestStaleTransformersImportRecovery(error)).toBe(false);
+
+    const handlePreloadError = (event: Event) => event.preventDefault();
+    globalThis.addEventListener("vite:preloadError", handlePreloadError);
+    try {
+      expect(requestStaleTransformersImportRecovery(error)).toBe(true);
+    } finally {
+      globalThis.removeEventListener("vite:preloadError", handlePreloadError);
+    }
+  });
+
   it("loads a pipeline after a recovered import and applies the quiet browser cache", async () => {
     const loadedPipeline = vi.fn();
     const pipelineFactory = vi.fn(async () => loadedPipeline);

--- a/apps/web/src/features/subtitles/transformersLoader.ts
+++ b/apps/web/src/features/subtitles/transformersLoader.ts
@@ -89,8 +89,7 @@ export function configureQuietBrowserCache(env: TransformersEnvironment | undefi
 
 export function requestStaleTransformersImportRecovery(error: unknown): boolean {
   if (!isStaleTransformersChunkImportError(error)) return false;
-  dispatchStaleChunkRecoveryEvent(error);
-  return true;
+  return dispatchStaleChunkRecoveryEvent(error);
 }
 
 export function isRecoverableTransformersImportError(error: unknown): boolean {
@@ -107,11 +106,14 @@ export function isStaleTransformersChunkImportError(error: unknown): boolean {
   );
 }
 
-function dispatchStaleChunkRecoveryEvent(error: unknown): void {
-  if (typeof Event === "undefined" || typeof globalThis.dispatchEvent !== "function") return;
+function dispatchStaleChunkRecoveryEvent(error: unknown): boolean {
+  if (typeof Event === "undefined" || typeof globalThis.dispatchEvent !== "function") {
+    return false;
+  }
   const event = new Event(VITE_PRELOAD_ERROR_EVENT, { cancelable: true });
   Object.defineProperty(event, "payload", { value: error });
   globalThis.dispatchEvent(event);
+  return event.defaultPrevented;
 }
 
 async function defaultTransformersImporter(): Promise<TransformersModule> {


### PR DESCRIPTION
## 关联

Refs #2（总控 issue，不在本 PR 中关闭）
Closes #190

## 改动点

- 在 `transformersLoader` 的 stale dynamic import 失败路径里，等待 `vite:preloadError` 恢复事件被页面处理，避免 ASR/LLM 调用方直接展示旧 chunk 原始错误。
- 在 `staleChunkRecovery` 恢复前 best-effort 清理 code-tape/Vite/Workbox/assets/precache 相关 CacheStorage，降低旧 HTML、modulepreload 或旧 `transformers.web-*.js` 继续命中的概率。
- 在 `SubtitlePanel` 的生成字幕和纠错章节入口统一吞掉已处理的 stale chunk 恢复错误，让页面恢复路径接管。
- 补充 ASR/LLM 共用 loader、页面恢复和字幕面板回归测试，确保旧 transformers chunk 会触发恢复，普通模型下载/网络错误不会误触发刷新循环。

## 影响范围

- 影响 AI 字幕的两个入口：`生成字幕` ASR 和 `纠错并生成章节` LLM，因为它们共用 `@huggingface/transformers` 动态 chunk 加载器。
- 不改变 ASR 语言参数；`subtitleTranscriber` 的 language 仍由现有链路保持 `chinese`。
- 线上旧页面请求已被新部署替换的 `assets/transformers.web-*.js` 时，会先清相关缓存并刷新恢复，而不是把 `Failed to fetch dynamically imported module` 作为最终业务错误展示。

## GitNexus 影响分析摘要

- 风险等级: high（`requestStaleTransformersImportRecovery` 同时影响 ASR `transcribe`、LLM `process` 和 worker `handleWorkerMessage`）
- 关键骨架变更: 否；`npm run contract:local` 报告 “No critical contract surface changed; GitNexus analysis is advisory for this diff.”
- GitNexus 影响面: `Transcribe -> IsStaleTransformersChunkImportError`、`Transcribe -> DispatchStaleChunkRecoveryEvent`、`HandleWorkerMessage -> IsStaleTransformersChunkImportError`、`HandleWorkerMessage -> DispatchStaleChunkRecoveryEvent`，以及 `SubtitlePanel` 的生成/后处理入口。
- 验证结果: 见下方自检命令，覆盖 stale chunk recovery、ASR/LLM loader 回归、字幕后处理评估和点击链路 benchmark。

## 自检

- [x] 未修改 `docs/progress.json` 或 `docs/progress.md`
- [x] 已运行 `npm run quality:local`，或说明无法运行的原因
- [x] 涉及 AI 字幕时，已记录一次 `npm run subtitle:postprocess:evaluate` 的“纠错并生成章节”效果验证结果，包含 `representativeOutputSource`、`overallEvaluationDurationMs`，并区分输出校验耗时与真实端到端耗时
  - `representativeOutputSource`: `postprocessor-runner`
  - `overallEvaluationDurationMs`: `1.6901`
  - 该命令是 fixture/runner 输出校验耗时，不代表浏览器真实端到端模型加载和推理耗时。
- [x] 涉及 AI 字幕点击链路、LLM worker、模型加载或性能时，已记录一次 `npm run subtitle:postprocess:runtime-benchmark` 结果，包含 `postprocessClickToResultReadyDurationMs`、`postProcessTimeoutBudgetMs` 和 `playbackProbeResponsiveDuringPostprocess`
  - `postprocessClickToResultReadyDurationMs`: `31.08`
  - `postProcessTimeoutBudgetMs`: `60000`
  - `playbackProbeResponsiveDuringPostprocess`: `true`
  - 该 benchmark 是 jsdom mock postprocessor，用于验证点击链路不阻塞播放探针，不代表真实本地 LLM 首次加载耗时。
- [x] 已说明改动点和影响范围
- [x] 如果改动关键骨架，已补充契约测试并填写 GitNexus 影响分析摘要
- [x] 已等待 repo-guard、codex 和 Copilot 评论，并完成必要审查
  - repo-guard 最新评论：批准，无 blocking findings。
  - Codex：PR 评论、review 与行级 thread 中未发现 Codex 可执行意见。
  - Copilot：旧 commit review 返回工具自身错误；已重新请求 review，未产生新的行级或可执行意见。

## 验证

- `npm run quality:precommit`：通过；脚本测试 114/114、API 测试 193/193、Web 测试 584/584，build 通过。
- `npm run subtitle:postprocess:evaluate`：通过；representative pass rate 1，failures 为空。
- `npm run subtitle:postprocess:runtime-benchmark`：通过；点击链路 benchmark 31.08ms，播放探针保持响应。
- `npx gitnexus detect_changes --scope compare --base-ref origin/main --repo <worktree>`：风险 high，影响面集中在共用 subtitle transformers loader 和 SubtitlePanel 入口。
- `npx gitnexus context requestStaleTransformersImportRecovery --repo <worktree>` 与 `npx gitnexus impact requestStaleTransformersImportRecovery --repo <worktree>`：确认直接调用方为 `loadTransformersModule` 和 `handleWorkerMessage`，上游影响 ASR `transcribe` 与 LLM postprocessor。
- `npm run e2e -w apps/web`：一次单独重跑 6/6 通过。
- `git push -u origin fix/issue-190-transformers-stale-chunk` 触发的 `npm run quality:local`：第二次完整通过，包括 e2e 6/6；第一次 push hook 中 e2e 第 6 个用例遇到一次 `ERR_CONNECTION_REFUSED`，单独重跑和第二次完整质量门均通过，未复现。

