### PR TITLE
修复纠错并生成章节 worker stale chunk 恢复

### DIFF
--- a/apps/web/src/features/subtitles/__tests__/SubtitlePanel.test.tsx
+++ b/apps/web/src/features/subtitles/__tests__/SubtitlePanel.test.tsx
@@ -122,7 +122,7 @@ describe("SubtitlePanel", () => {
         getItem: () => null,
         setItem: vi.fn(),
       },
-      getRecoveryToken: () => "entry-index-B.js",
+      getRecoveryToken: () => "entry-index-C.js",
     });
     const staleChunkError = new TypeError(
       "Failed to fetch dynamically imported module: https://ceilf6.github.io/code-tape/assets/transformers.web-Ddnr203B.js",
@@ -314,6 +314,64 @@ describe("SubtitlePanel", () => {
 
     await waitFor(() => expect(screen.getByRole("alert")).toHaveTextContent("LLM JSON parse failed"));
     expect(screen.getByText("use state hook")).toBeInTheDocument();
+  });
+
+  it("recovers from stale Transformers chunks during local LLM post-processing without showing the raw import error", async () => {
+    const originalTrack: SubtitleTrack = {
+      recordingId: "recording-1",
+      generatedAt: "2026-05-28T00:00:00.000Z",
+      model: "onnx-community/whisper-tiny",
+      source: "huggingface-local",
+      segments: [{ id: "subtitle-1", startMs: 0, endMs: 1_000, text: "use state hook" }],
+    };
+    const store = createMemorySubtitleStore();
+    await store.saveWithChapters(originalTrack, []);
+    const reload = vi.fn();
+    const cleanupRecovery = installStaleChunkRecovery({
+      reload,
+      storage: {
+        getItem: () => null,
+        setItem: vi.fn(),
+      },
+      getRecoveryToken: () => "entry-index-B.js",
+    });
+    const staleChunkError = new TypeError(
+      "Failed to fetch dynamically imported module: https://ceilf6.github.io/code-tape/assets/transformers.web-Ddnr203B.js",
+    );
+    const postProcessor: SubtitlePostProcessor = {
+      process: vi.fn(async () => {
+        throw staleChunkError;
+      }),
+    };
+
+    render(
+      <SubtitlePanel
+        recordingId="recording-1"
+        mediaBlob={new Blob(["webm"], { type: "video/webm" })}
+        hasAudio
+        durationMs={1_000}
+        currentTimeMs={0}
+        onSeek={vi.fn()}
+        store={store}
+        transcriber={{
+          transcribe: vi.fn(async () => ({
+            model: "onnx-community/whisper-tiny",
+            source: "huggingface-local" as const,
+            segments: [],
+          })),
+        }}
+        postProcessor={postProcessor}
+      />,
+    );
+
+    await waitFor(() => expect(screen.getByText("use state hook")).toBeInTheDocument());
+
+    fireEvent.click(screen.getByRole("button", { name: "纠错并生成章节" }));
+
+    await waitFor(() => expect(reload).toHaveBeenCalledTimes(1));
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+    expect(screen.getByText("use state hook")).toBeInTheDocument();
+    cleanupRecovery();
   });
 
   it("does not persist corrected subtitles when processed subtitle and chapter save fails", async () => {

--- a/apps/web/src/features/subtitles/__tests__/subtitlePostProcessorWorkerClient.test.ts
+++ b/apps/web/src/features/subtitles/__tests__/subtitlePostProcessorWorkerClient.test.ts
@@ -25,6 +25,7 @@ async function flushPromises() {
 function createMockWorker() {
   const messageListeners = new Set<(event: MessageEvent) => void>();
   const errorListeners = new Set<(event: ErrorEvent) => void>();
+  const messageErrorListeners = new Set<(event: ErrorEvent) => void>();
   const worker = {
     postMessage: vi.fn(),
     terminate: vi.fn(),
@@ -34,8 +35,12 @@ function createMockWorker() {
         messageListeners.add(listener as (event: MessageEvent) => void);
         return;
       }
-      if (type === "error" || type === "messageerror") {
+      if (type === "error") {
         errorListeners.add(listener as (event: ErrorEvent) => void);
+        return;
+      }
+      if (type === "messageerror") {
+        messageErrorListeners.add(listener as (event: ErrorEvent) => void);
       }
     }),
     removeEventListener: vi.fn((type: string, listener: EventListenerOrEventListenerObject) => {
@@ -44,8 +49,12 @@ function createMockWorker() {
         messageListeners.delete(listener as (event: MessageEvent) => void);
         return;
       }
-      if (type === "error" || type === "messageerror") {
+      if (type === "error") {
         errorListeners.delete(listener as (event: ErrorEvent) => void);
+        return;
+      }
+      if (type === "messageerror") {
+        messageErrorListeners.delete(listener as (event: ErrorEvent) => void);
       }
     }),
     dispatch(data: unknown) {
@@ -55,6 +64,11 @@ function createMockWorker() {
     },
     dispatchError(message: string) {
       for (const listener of errorListeners) {
+        listener({ message } as ErrorEvent);
+      }
+    },
+    dispatchMessageError(message: string) {
+      for (const listener of messageErrorListeners) {
         listener({ message } as ErrorEvent);
       }
     },
@@ -205,6 +219,28 @@ describe("createWorkerBackedHuggingFaceSubtitlePostProcessor", () => {
       "Failed to fetch dynamically imported module: https://ceilf6.github.io/code-tape/assets/transformers.web-Ddnr203B.js";
 
     worker.dispatchError(message);
+
+    await expect(promise).rejects.toThrow("Failed to fetch dynamically imported module");
+    expect(dispatchEvent).toHaveBeenCalledTimes(1);
+    const event = dispatchEvent.mock.calls[0]?.[0];
+    expect(event?.type).toBe("vite:preloadError");
+    expect(event?.cancelable).toBe(true);
+    expect((event as Event & { payload?: unknown }).payload).toMatchObject({ message });
+  });
+
+  it("forwards stale Transformers chunk errors from worker messageerror events to Vite preload recovery", async () => {
+    const worker = createMockWorker();
+    const dispatchEvent = vi.spyOn(globalThis, "dispatchEvent");
+    const postProcessor = createWorkerBackedHuggingFaceSubtitlePostProcessor({
+      workerFactory: () => worker as unknown as Worker,
+    });
+
+    const promise = postProcessor.process({ track: makeTrack() });
+    await flushPromises();
+    const message =
+      "Failed to fetch dynamically imported module: https://ceilf6.github.io/code-tape/assets/transformers.web-Ddnr203B.js";
+
+    worker.dispatchMessageError(message);
 
     await expect(promise).rejects.toThrow("Failed to fetch dynamically imported module");
     expect(dispatchEvent).toHaveBeenCalledTimes(1);

--- a/apps/web/src/features/subtitles/__tests__/subtitlePostProcessorWorkerClient.test.ts
+++ b/apps/web/src/features/subtitles/__tests__/subtitlePostProcessorWorkerClient.test.ts
@@ -25,7 +25,7 @@ async function flushPromises() {
 function createMockWorker() {
   const messageListeners = new Set<(event: MessageEvent) => void>();
   const errorListeners = new Set<(event: ErrorEvent) => void>();
-  const messageErrorListeners = new Set<(event: ErrorEvent) => void>();
+  const messageErrorListeners = new Set<(event: MessageEvent) => void>();
   const worker = {
     postMessage: vi.fn(),
     terminate: vi.fn(),
@@ -40,7 +40,7 @@ function createMockWorker() {
         return;
       }
       if (type === "messageerror") {
-        messageErrorListeners.add(listener as (event: ErrorEvent) => void);
+        messageErrorListeners.add(listener as (event: MessageEvent) => void);
       }
     }),
     removeEventListener: vi.fn((type: string, listener: EventListenerOrEventListenerObject) => {
@@ -54,7 +54,7 @@ function createMockWorker() {
         return;
       }
       if (type === "messageerror") {
-        messageErrorListeners.delete(listener as (event: ErrorEvent) => void);
+        messageErrorListeners.delete(listener as (event: MessageEvent) => void);
       }
     }),
     dispatch(data: unknown) {
@@ -67,9 +67,9 @@ function createMockWorker() {
         listener({ message } as ErrorEvent);
       }
     },
-    dispatchMessageError(message: string) {
+    dispatchMessageError(data: unknown) {
       for (const listener of messageErrorListeners) {
-        listener({ message } as ErrorEvent);
+        listener(new MessageEvent("messageerror", { data }));
       }
     },
   };

--- a/apps/web/src/features/subtitles/__tests__/subtitlePostProcessorWorkerClient.test.ts
+++ b/apps/web/src/features/subtitles/__tests__/subtitlePostProcessorWorkerClient.test.ts
@@ -23,21 +23,39 @@ async function flushPromises() {
 }
 
 function createMockWorker() {
-  const listeners = new Set<(event: MessageEvent) => void>();
+  const messageListeners = new Set<(event: MessageEvent) => void>();
+  const errorListeners = new Set<(event: ErrorEvent) => void>();
   const worker = {
     postMessage: vi.fn(),
     terminate: vi.fn(),
     addEventListener: vi.fn((type: string, listener: EventListenerOrEventListenerObject) => {
-      if (type !== "message" || typeof listener !== "function") return;
-      listeners.add(listener as (event: MessageEvent) => void);
+      if (typeof listener !== "function") return;
+      if (type === "message") {
+        messageListeners.add(listener as (event: MessageEvent) => void);
+        return;
+      }
+      if (type === "error" || type === "messageerror") {
+        errorListeners.add(listener as (event: ErrorEvent) => void);
+      }
     }),
     removeEventListener: vi.fn((type: string, listener: EventListenerOrEventListenerObject) => {
-      if (type !== "message" || typeof listener !== "function") return;
-      listeners.delete(listener as (event: MessageEvent) => void);
+      if (typeof listener !== "function") return;
+      if (type === "message") {
+        messageListeners.delete(listener as (event: MessageEvent) => void);
+        return;
+      }
+      if (type === "error" || type === "messageerror") {
+        errorListeners.delete(listener as (event: ErrorEvent) => void);
+      }
     }),
     dispatch(data: unknown) {
-      for (const listener of listeners) {
+      for (const listener of messageListeners) {
         listener({ data } as MessageEvent);
+      }
+    },
+    dispatchError(message: string) {
+      for (const listener of errorListeners) {
+        listener({ message } as ErrorEvent);
       }
     },
   };
@@ -172,6 +190,28 @@ describe("createWorkerBackedHuggingFaceSubtitlePostProcessor", () => {
 
     await expect(promise).rejects.toThrow("Failed to fetch");
     expect(dispatchEvent).not.toHaveBeenCalled();
+  });
+
+  it("forwards stale Transformers chunk errors from worker error events to Vite preload recovery", async () => {
+    const worker = createMockWorker();
+    const dispatchEvent = vi.spyOn(globalThis, "dispatchEvent");
+    const postProcessor = createWorkerBackedHuggingFaceSubtitlePostProcessor({
+      workerFactory: () => worker as unknown as Worker,
+    });
+
+    const promise = postProcessor.process({ track: makeTrack() });
+    await flushPromises();
+    const message =
+      "Failed to fetch dynamically imported module: https://ceilf6.github.io/code-tape/assets/transformers.web-Ddnr203B.js";
+
+    worker.dispatchError(message);
+
+    await expect(promise).rejects.toThrow("Failed to fetch dynamically imported module");
+    expect(dispatchEvent).toHaveBeenCalledTimes(1);
+    const event = dispatchEvent.mock.calls[0]?.[0];
+    expect(event?.type).toBe("vite:preloadError");
+    expect(event?.cancelable).toBe(true);
+    expect((event as Event & { payload?: unknown }).payload).toMatchObject({ message });
   });
 
   it("terminates in-flight worker inference when the request is aborted", async () => {

--- a/apps/web/src/features/subtitles/subtitlePostProcessorWorkerClient.ts
+++ b/apps/web/src/features/subtitles/subtitlePostProcessorWorkerClient.ts
@@ -220,7 +220,9 @@ export function createWorkerBackedHuggingFaceSubtitlePostProcessor(
       "message" in event && typeof event.message === "string"
         ? event.message
         : "字幕 LLM worker 执行失败";
-    terminateWorker(new Error(message));
+    const error = new Error(message);
+    requestStaleTransformersImportRecovery(error);
+    terminateWorker(error);
   }
 
   return {

--- a/apps/web/src/features/subtitles/subtitlePostProcessorWorkerClient.ts
+++ b/apps/web/src/features/subtitles/subtitlePostProcessorWorkerClient.ts
@@ -215,11 +215,8 @@ export function createWorkerBackedHuggingFaceSubtitlePostProcessor(
     pending.reject(error, response.metrics);
   }
 
-  function handleWorkerError(event: Event | ErrorEvent) {
-    const message =
-      "message" in event && typeof event.message === "string"
-        ? event.message
-        : "字幕 LLM worker 执行失败";
+  function handleWorkerError(event: Event) {
+    const message = getWorkerEventMessage(event);
     const error = new Error(message);
     requestStaleTransformersImportRecovery(error);
     terminateWorker(error);
@@ -263,6 +260,23 @@ function deserializeWorkerError(error: SerializedWorkerError): Error {
 
 function createAbortError(): DOMException {
   return new DOMException("字幕纠错已取消", "AbortError");
+}
+
+function readWorkerEventMessage(value: unknown): string | undefined {
+  if (typeof value === "string") return value;
+  if (value instanceof Error) return value.message;
+  if (!value || typeof value !== "object" || !("message" in value)) return undefined;
+  const message = (value as { message?: unknown }).message;
+  return typeof message === "string" ? message : undefined;
+}
+
+function getWorkerEventMessage(event: Event): string {
+  return (
+    readWorkerEventMessage((event as { message?: unknown }).message) ??
+    readWorkerEventMessage((event as { error?: unknown }).error) ??
+    readWorkerEventMessage((event as { data?: unknown }).data) ??
+    "字幕 LLM worker 执行失败"
+  );
 }
 
 function isAbortError(error: unknown): boolean {


### PR DESCRIPTION
## 关联

Refs #2（总控 issue，不在本 PR 中关闭）
Closes #193

## 改动点

- 在 LLM subtitle postprocessor worker 的 `error` / `messageerror` 事件路径补上 `requestStaleTransformersImportRecovery`，让 worker 内部加载旧 `transformers.web-*.js` 失败时走统一 stale chunk recovery。
- 补充 worker client 回归测试，覆盖 `Failed to fetch dynamically imported module: .../transformers.web-*.js` 从 worker error / messageerror 事件进入 `vite:preloadError`。
- 补充 `SubtitlePanel` 回归测试，覆盖点击“纠错并生成章节”时 stale Transformers chunk 错误触发恢复且不展示原始 import error。
- 按 repo-guard 评论修正 `messageerror` 测试形状：mock 现在使用真实 `MessageEvent("messageerror", { data })`；生产代码从 `event.message`、`event.error?.message`、`MessageEvent.data` 提取可识别错误文本。

## 影响范围

- 仅影响 AI 字幕“纠错并生成章节”的 worker stale chunk 失败兜底路径。
- 不改变 ASR language 设置，仍保持 `chinese`。
- 不改变普通 LLM 业务错误（JSON 格式、未知 segment、重复 correction 等）的校验/展示语义；普通 fetch 失败仍不会触发 stale chunk recovery。

## GitNexus 影响分析摘要

- 风险等级: medium（GitNexus detect_changes）；`handleWorkerError` impact 为 LOW。
- 关键骨架变更: 无 critical contract surface 变更；GitNexus contract 判定 advisory。
- GitNexus 影响面: `detect_changes --scope unstaged` 显示 2 files / 5 symbols，Affected processes: 3；流程为 `HandleWorkerError → ReadWorkerEventMessage`、`HandleWorkerError → IsStaleTransformersChunkImportError`、`HandleWorkerError → DispatchStaleChunkRecoveryEvent`。
- `context handleWorkerError` 显示 outgoing calls 为 `getWorkerEventMessage`、`requestStaleTransformersImportRecovery`、`terminateWorker`；`impact handleWorkerError` 显示 upstream impactedCount 0。

## 自检

- [x] 未修改 `docs/progress.json` 或 `docs/progress.md`
- [x] 已运行 `npm run quality:local`，或说明无法运行的原因
- [x] 涉及 AI 字幕时，已记录一次 `npm run subtitle:postprocess:evaluate` 的“纠错并生成章节”效果验证结果，包含 `representativeOutputSource`、`overallEvaluationDurationMs`，并区分输出校验耗时与真实端到端耗时
  - `representativeOutputSource`: `postprocessor-runner`
  - `overallEvaluationDurationMs`: `1.6915`
  - 输出校验耗时来自 fixture validation，平均 `0.1887ms`、最大 `0.9389ms`；这不是浏览器真实端到端耗时。
- [x] 涉及 AI 字幕点击链路、LLM worker、模型加载或性能时，已记录一次 `npm run subtitle:postprocess:runtime-benchmark` 结果，包含 `postprocessClickToResultReadyDurationMs`、`postProcessTimeoutBudgetMs` 和 `playbackProbeResponsiveDuringPostprocess`
  - `postprocessClickToResultReadyDurationMs`: `37.306`
  - `postProcessTimeoutBudgetMs`: `60000`
  - `playbackProbeResponsiveDuringPostprocess`: `true`
- [x] 已说明改动点和影响范围
- [x] 如果改动关键骨架，已补充契约测试并填写 GitNexus 影响分析摘要
- [ ] 已等待 repo-guard、codex 和 Copilot 评论，并完成必要审查

## 验证

- `npm run quality:predev`：通过（GitNexus contract passed）
- `npm run agent:bootstrap`：通过
- `npm run test -w apps/web -- src/features/subtitles/__tests__/subtitlePostProcessorWorkerClient.test.ts src/features/subtitles/__tests__/SubtitlePanel.test.tsx`：通过（2 files / 37 tests）
- `git diff --check`：通过
- `npm run quality:precommit`：通过（root tests 193/193；web 58 files / 587 tests；production build 通过）
- `npm run quality:local`：通过（GitNexus contract、quality:ci、Playwright e2e 6/6）
- `npm run subtitle:postprocess:evaluate`：通过，failures `[]`
- `npm run subtitle:postprocess:runtime-benchmark`：通过，播放探针响应为 `true`
