### PR TITLE
#196 中长字幕按 60 段窗口分块后处理

### DIFF
--- a/apps/web/src/features/subtitles/__tests__/subtitlePostProcessor.test.ts
+++ b/apps/web/src/features/subtitles/__tests__/subtitlePostProcessor.test.ts
@@ -738,8 +738,8 @@ describe("createHuggingFaceSubtitlePostProcessor", () => {
     expect(cache.put).toHaveBeenCalledWith("model-cache-key", expect.any(Response));
   });
 
-  it("keeps the output budget bounded for long tracks with sparse corrections", async () => {
-    const track = makeTrackWithSegments(100);
+  it("keeps the output budget bounded for a full single-window track", async () => {
+    const track = makeTrackWithSegments(60);
     const pipeline = vi.fn(
       async (
         _prompt: unknown,
@@ -763,9 +763,53 @@ describe("createHuggingFaceSubtitlePostProcessor", () => {
       expect.any(Array),
       expect.objectContaining({ max_new_tokens: expect.any(Number) }),
     );
-    expect(pipeline.mock.calls[0]?.[1]?.max_new_tokens).toBeGreaterThanOrEqual(512);
+    expect(pipeline.mock.calls[0]?.[1]?.max_new_tokens).toBeGreaterThanOrEqual(128);
     expect(pipeline.mock.calls[0]?.[1]?.max_new_tokens).toBeLessThanOrEqual(1_024);
-    expect(result.segments).toHaveLength(100);
+    expect(result.segments).toHaveLength(track.segments.length);
+  });
+
+  it("chunks medium subtitle tracks into 60 segment windows", async () => {
+    for (const [segmentCount, expectedChunkSizes] of [
+      [61, [60, 1]],
+      [120, [60, 60]],
+    ] as const) {
+      const track = makeTrackWithSegments(segmentCount);
+      const pipeline = vi.fn(async (messages: unknown) => {
+        const payload = readPostProcessorPayload(messages);
+        const firstSegment = payload.inputSegments[0];
+        const lastSegment = payload.inputSegments.at(-1);
+        if (!firstSegment || !lastSegment) throw new Error("empty chunk");
+        return [
+          {
+            generated_text: JSON.stringify({
+              segments: [{ id: firstSegment.id, text: `${firstSegment.text} corrected` }],
+              chapters: [
+                {
+                  title: `窗口 ${pipeline.mock.calls.length}`,
+                  startMs: firstSegment.startMs,
+                  endMs: lastSegment.endMs,
+                },
+              ],
+            }),
+          },
+        ];
+      });
+      const postProcessor = createHuggingFaceSubtitlePostProcessor({
+        pipelineFactory: vi.fn(async () => pipeline),
+      });
+
+      const result = await postProcessor.process({ track });
+
+      expect(pipeline.mock.calls.map((call) => readPostProcessorPayload(call[0]).inputSegments.length)).toEqual(
+        expectedChunkSizes,
+      );
+      expect(result.segments.map((segment) => segment.id)).toEqual(
+        expectedChunkSizes.map((_, index) => `subtitle-${index * 60 + 1}`),
+      );
+      expect(result.chapters?.map((chapter) => chapter.startMs)).toEqual(
+        expectedChunkSizes.map((_, index) => index * 60_000),
+      );
+    }
   });
 
   it("chunks oversized subtitle tracks before calling the local LLM", async () => {

--- a/apps/web/src/features/subtitles/__tests__/subtitlePostProcessor.test.ts
+++ b/apps/web/src/features/subtitles/__tests__/subtitlePostProcessor.test.ts
@@ -852,6 +852,9 @@ describe("createHuggingFaceSubtitlePostProcessor", () => {
     });
     expect(pipelineFactory).toHaveBeenCalledTimes(1);
     expect(pipeline).toHaveBeenCalledTimes(3);
+    expect(pipeline.mock.calls.map((call) => readPostProcessorPayload(call[0]).inputSegments.length)).toEqual([
+      60, 60, 1,
+    ]);
     for (const call of pipeline.mock.calls) {
       const payload = readPostProcessorPayload(call[0]);
       expect(payload.inputSegments.length).toBeLessThanOrEqual(60);

--- a/apps/web/src/features/subtitles/subtitlePostProcessor.ts
+++ b/apps/web/src/features/subtitles/subtitlePostProcessor.ts
@@ -111,7 +111,7 @@ async function processSubtitleTrack({
   model: string;
   pipeline: TextGenerationPipeline;
 }): Promise<SubtitleCorrectionResult> {
-  if (input.track.segments.length <= MAX_POSTPROCESSOR_SEGMENTS) {
+  if (input.track.segments.length <= POSTPROCESSOR_CHUNK_SEGMENTS) {
     return processSubtitleTrackChunk({ input, model, pipeline });
   }
 


### PR DESCRIPTION
## 关联

Refs #2（总控 issue，不在本 PR 中关闭）
Closes #196

## 改动点

- 将 `processSubtitleTrack` 的分块阈值从超过 120 段收敛为超过 `POSTPROCESSOR_CHUNK_SEGMENTS`（60）段即进入分块处理。
- 补充 61 段拆为 `60 + 1`、120 段拆为 `60 + 60` 的边界单测，确保中长字幕不会一次性塞给本地 LLM。
- 保持 <=60 段字幕单窗口处理，继续复用既有稀疏 corrections、章节合并和全局 `constrainCorrectionToTrack` 校验。

## 影响范围

- 影响 `apps/web/src/features/subtitles/subtitlePostProcessor.ts` 的 LLM 字幕后处理调度。
- 不更换默认模型，不调整 ASR，ASR `language` 仍保持 `chinese`。
- 对“纠错并生成章节”的中长字幕等待时间与 JSON 稳定性更友好；短字幕路径不增加额外调用。

## GitNexus 影响分析摘要

- 风险等级: `detect_changes` 报告 diff risk 为 high；`impact processSubtitleTrack` 报告 upstream impactedCount=1、risk=LOW。
- 关键骨架变更: 无；`quality:local` 的 contract check 提示未修改 critical contract surface。
- GitNexus 影响面: changed symbol 为 `processSubtitleTrack`；incoming 为 `process`；outgoing 为 `processSubtitleTrackChunk`、`chunkSubtitleTrack`、`constrainCorrectionToTrack`；affected module 为 Subtitles。
- 验证结果: 已运行 `detect_changes`、`context processSubtitleTrack`、`impact processSubtitleTrack`，并在本 PR 限定为字幕后处理窗口调度。

## 自检

- [x] 未修改 `docs/progress.json` 或 `docs/progress.md`
- [x] 已运行 `npm run quality:local`，预推送钩子通过
- [x] 涉及 AI 字幕时，已记录一次 `npm run subtitle:postprocess:evaluate` 的“纠错并生成章节”效果验证结果：representativePassRate=1、representativeJsonValidRate=1、representativeSegmentReferenceValidRate=1、representativeChapterTimelineValidRate=1、overallEvaluationDurationMs≈1.66ms、failures=[]；该命令验证 fixture runner 输出，不代表真实端到端模型加载耗时
- [x] 涉及 AI 字幕点击链路、LLM worker、模型加载或性能时，已记录一次 `npm run subtitle:postprocess:runtime-benchmark` 结果：postprocessClickToResultReadyDurationMs≈30.09ms、playbackProbeResponsiveDuringPostprocess=true
- [x] 已说明改动点和影响范围
- [x] 如果改动关键骨架，已补充契约测试并填写 GitNexus 影响分析摘要
- [ ] 已等待 repo-guard、codex 和 Copilot 评论，并完成必要审查

## 验证

- `GITNEXUS_ANALYZE_TIMEOUT_MS=180000 npm run quality:predev`
- `npm run agent:bootstrap`
- `npm run test -w apps/web -- src/features/subtitles/__tests__/subtitlePostProcessor.test.ts`
- `npm run subtitle:postprocess:evaluate`
- `npm run subtitle:postprocess:runtime-benchmark`
- `git diff --check`
- `GITNEXUS_ANALYZE_TIMEOUT_MS=180000 npm run quality:precommit`
- `npm run quality:local`（pre-push hook：193 node tests、602 web tests、build、6 Playwright e2e passed）