### PR TITLE
fix(#195): 面试官仅 offer 建立连接 + 终止后阻断 stale 信令

### DIFF
--- a/apps/web/src/features/interview/RemoteInterviewWorkbenchPage.tsx
+++ b/apps/web/src/features/interview/RemoteInterviewWorkbenchPage.tsx
@@ -246,6 +246,7 @@ function connectInterviewerSignaling({
   let remoteDescriptionSet = false;
   let activeCandidateConnectionId: string | null = null;
   let pendingRemoteIceCandidates: Array<{
+    connectionId: string;
     candidate: string;
     sdpMid?: string | null;
     sdpMLineIndex?: number | null;
@@ -255,11 +256,17 @@ function connectInterviewerSignaling({
     if (closed) return;
     onConnectionState({ status: "failed", errorMessage });
   };
-  const failAndStopMedia = (errorMessage: string) => {
-    if (closed) return;
+  const stopSession = () => {
+    closed = true;
+    unsubscribeMediaSession?.();
+    unsubscribeMediaSession = null;
     mediaSession.close();
     signalingClient?.close();
     signalingClient = null;
+  };
+  const failAndStopMedia = (errorMessage: string) => {
+    if (closed) return;
+    stopSession();
     onConnectionState({ status: "failed", errorMessage });
   };
   const resetCandidateSession = () => {
@@ -306,21 +313,15 @@ function connectInterviewerSignaling({
     const pending = pendingRemoteIceCandidates;
     pendingRemoteIceCandidates = [];
     for (const candidate of pending) {
+      if (candidate.connectionId !== activeCandidateConnectionId) continue;
       addRemoteIceCandidate(candidate);
     }
   };
-  const shouldApplyCandidateMessage = (message: {
-    role: "candidate" | "interviewer";
-    connectionId: string;
-  }) => {
-    if (message.role !== "candidate") return false;
-    if (
-      activeCandidateConnectionId &&
-      activeCandidateConnectionId !== message.connectionId
-    ) {
+  const claimCandidateConnection = (connectionId: string) => {
+    if (activeCandidateConnectionId && activeCandidateConnectionId !== connectionId) {
       return false;
     }
-    activeCandidateConnectionId = message.connectionId;
+    activeCandidateConnectionId = connectionId;
     return true;
   };
   const answerCandidateOffer = (sdp: string) => {
@@ -362,13 +363,17 @@ function connectInterviewerSignaling({
     message: Extract<InboundSignalingMessage, { kind: "ice-candidate" }>,
   ) => {
     if (closed) return;
-    if (!shouldApplyCandidateMessage(message)) return;
+    if (message.role !== "candidate") return;
+    if (activeCandidateConnectionId && activeCandidateConnectionId !== message.connectionId) {
+      return;
+    }
     const candidate = {
+      connectionId: message.connectionId,
       candidate: message.candidate,
       sdpMid: message.sdpMid ?? null,
       sdpMLineIndex: message.sdpMLineIndex ?? null,
     };
-    if (!remoteDescriptionSet) {
+    if (!activeCandidateConnectionId || !remoteDescriptionSet) {
       pendingRemoteIceCandidates = [...pendingRemoteIceCandidates, candidate];
       return;
     }
@@ -386,9 +391,7 @@ function connectInterviewerSignaling({
       return;
     }
     if (message.kind === "ended") {
-      mediaSession.close();
-      signalingClient?.close();
-      signalingClient = null;
+      stopSession();
       onConnectionState({ status: "failed", errorMessage: "面试房间已结束" });
       return;
     }
@@ -408,7 +411,8 @@ function connectInterviewerSignaling({
       return;
     }
     if (message.kind === "offer") {
-      if (!shouldApplyCandidateMessage(message)) return;
+      if (message.role !== "candidate") return;
+      if (!claimCandidateConnection(message.connectionId)) return;
       answerCandidateOffer(message.sdp);
       return;
     }

--- a/apps/web/src/features/interview/__tests__/RemoteInterviewWorkbenchPage.test.tsx
+++ b/apps/web/src/features/interview/__tests__/RemoteInterviewWorkbenchPage.test.tsx
@@ -1011,6 +1011,110 @@ describe("RemoteInterviewWorkbenchPage interviewer signaling", () => {
     expect(signaling.client.close).toHaveBeenCalledTimes(1);
   });
 
+  it("does not let an orphan candidate ICE claim the connection and block a real offer", async () => {
+    const roomClient = makeRoomClient();
+    const signaling = makeSignalingFactory();
+    const media = makeInterviewerMediaSessionFactory();
+
+    renderInterviewerPage({
+      initialEntry: "/interview/interviewer/room-live?joinCode=JOIN1234",
+      roomClient,
+      createSignalingClient: signaling.create,
+      createMediaSession: media.create,
+    });
+    await waitFor(() => {
+      expect(signaling.create).toHaveBeenCalledTimes(1);
+    });
+
+    act(() => {
+      signaling.emit({
+        kind: "ice-candidate",
+        roomId: "room-live",
+        role: "candidate",
+        connectionId: "stale-candidate",
+        messageId: "stale-ice",
+        sentAt: 1_780_000_000_000,
+        candidate: "candidate:stale",
+        sdpMid: "0",
+        sdpMLineIndex: 0,
+      });
+    });
+    expect(media.session.addRemoteIceCandidate).not.toHaveBeenCalled();
+
+    act(() => {
+      signaling.emit({
+        kind: "offer",
+        roomId: "room-live",
+        role: "candidate",
+        connectionId: "real-candidate",
+        messageId: "real-offer",
+        sentAt: 1_780_000_000_001,
+        sdp: "real-offer-sdp",
+      });
+    });
+
+    await waitFor(() => {
+      expect(media.session.setRemoteDescription).toHaveBeenCalledWith({
+        type: "offer",
+        sdp: "real-offer-sdp",
+      });
+      expect(signaling.client.sendAnswer).toHaveBeenCalledTimes(1);
+    });
+    expect(media.session.addRemoteIceCandidate).not.toHaveBeenCalledWith(
+      expect.objectContaining({ candidate: "candidate:stale" }),
+    );
+  });
+
+  it("ignores stale offer and ICE after the room has ended", async () => {
+    const roomClient = makeRoomClient();
+    const signaling = makeSignalingFactory();
+    const media = makeInterviewerMediaSessionFactory();
+
+    renderInterviewerPage({
+      initialEntry: "/interview/interviewer/room-live?joinCode=JOIN1234",
+      roomClient,
+      createSignalingClient: signaling.create,
+      createMediaSession: media.create,
+    });
+    await waitFor(() => {
+      expect(signaling.create).toHaveBeenCalledTimes(1);
+    });
+
+    act(() => {
+      signaling.emit({ kind: "ended", roomId: "room-live" });
+    });
+    await screen.findByText("面试房间已结束");
+
+    act(() => {
+      signaling.emit({
+        kind: "offer",
+        roomId: "room-live",
+        role: "candidate",
+        connectionId: "late-candidate",
+        messageId: "late-offer",
+        sentAt: 1_780_000_000_002,
+        sdp: "late-offer-sdp",
+      });
+      signaling.emit({
+        kind: "ice-candidate",
+        roomId: "room-live",
+        role: "candidate",
+        connectionId: "late-candidate",
+        messageId: "late-ice",
+        sentAt: 1_780_000_000_003,
+        candidate: "candidate:late",
+        sdpMid: "0",
+        sdpMLineIndex: 0,
+      });
+    });
+
+    expect(media.session.requestLocalMedia).not.toHaveBeenCalled();
+    expect(media.session.setRemoteDescription).not.toHaveBeenCalled();
+    expect(media.session.addRemoteIceCandidate).not.toHaveBeenCalled();
+    expect(signaling.client.sendAnswer).not.toHaveBeenCalled();
+    expect(screen.getByText("面试房间已结束")).toBeInTheDocument();
+  });
+
   it("surfaces a failed connection when WebRTC media session creation throws", async () => {
     const roomClient = makeRoomClient();
     const signaling = makeSignalingFactory();


### PR DESCRIPTION
## 背景

#195（PR #199）已合入 main，但合并发生在我处理 repo-guard 最后一轮「请求修改」反馈之前（auto-merge 在分支变为 CLEAN 后触发）。本 PR 补上那两条尚未落地的修复。父级 Epic #120。

Closes #201

## 修复（repo-guard 第三轮发现）

**[高] 远端 ICE 可在 offer 前抢占 active candidate connection**
此前 `shouldApplyCandidateMessage` 被 offer 与 ICE 共用：当 `activeCandidateConnectionId` 为空时，一个无 offer 的旧/乱序 ICE 也会把自己的 connectionId 写成 active，导致后续不同 connectionId 的真实 offer 被忽略、无法建连。

修复：拆分连接识别 —— 只有 `offer` 通过 `claimCandidateConnection` 建立 active 连接；`ice-candidate` 不再抢占 active，仅在「无 active 或与 active 匹配」时按 connectionId 缓冲，flush 时过滤掉非 active 连接的 ICE。

**[中] 终止/失败路径未阻断后续 stale callback**
此前 `ended` 分支与 `failAndStopMedia` 关闭 socket/media 后没有置 `closed = true`、未注销 media 订阅，旧 socket 排队消息仍能进入 `handleMessage` 并触碰已关闭的 session。

修复：抽出 `stopSession()`（置 `closed = true` + 注销 media 订阅 + 关闭 media/signaling），`ended` 与 signaling error 统一走该路径，后续 stale callback 直接短路。

## 测试

- 新增 `does not let an orphan candidate ICE claim the connection and block a real offer`：孤立 ICE 先到不占用连接，随后真实 offer 仍被 answer。
- 新增 `ignores stale offer and ICE after the room has ended`：`ended` 后再 emit offer/ICE 不调用 `requestLocalMedia`/`setRemoteDescription`/`addRemoteIceCandidate`/`sendAnswer`。
- 本地 `npm run lint:web` 与 `npm run test -w apps/web`（621 passed）、`tsc -b`、`vite build` 全绿。