### PR TITLE
#202 候选人周期性状态快照发送与面试官快照重同步

### DIFF
--- a/apps/web/src/features/interview/CandidateInterviewPage.tsx
+++ b/apps/web/src/features/interview/CandidateInterviewPage.tsx
@@ -21,6 +21,7 @@ import {
   type InterviewMediaSessionState,
 } from "./interviewMediaSession";
 import { createInterviewSyncPublisher } from "./interviewSync";
+import { INITIAL_REMOTE_INTERVIEW_STABLE_STATE } from "./remoteInterviewInitialState";
 import {
   createInterviewRoomClient,
   type InterviewRoomClient,
@@ -178,6 +179,7 @@ function useCandidateInterviewRoomSession({
       channel: context.channel,
       roomId: context.roomId,
       sessionId: context.sessionId,
+      snapshotState: INITIAL_REMOTE_INTERVIEW_STABLE_STATE,
     }).subscribeTo(bus, {
       includeBacklog: true,
       shouldPublishEvent: (event) => !publishedRealtimeEventIdsRef.current.has(event.id),

--- a/apps/web/src/features/interview/__tests__/CandidateInterviewPage.test.tsx
+++ b/apps/web/src/features/interview/__tests__/CandidateInterviewPage.test.tsx
@@ -237,6 +237,56 @@ describe("CandidateInterviewPage", () => {
     });
   });
 
+  it("publishes a periodic state snapshot after enough stable events", async () => {
+    const roomClient = makeRoomClient();
+    const signaling = makeSignalingFactory();
+    const media = makeMediaSessionFactory(
+      {},
+      {
+        eventsDataChannelState: "open",
+      },
+    );
+
+    renderCandidatePage({
+      initialEntry: "/interview/candidate",
+      roomClient,
+      createSignalingClient: signaling.create,
+      createMediaSession: media.create,
+    });
+    await screen.findByText("room-created");
+
+    act(() => {
+      signaling.emit({
+        kind: "joined",
+        roomId: "room-created",
+        role: "interviewer",
+        status: "live",
+      });
+    });
+    await waitFor(() => {
+      expect(signaling.client.sendOffer).toHaveBeenCalledTimes(1);
+    });
+
+    act(() => {
+      for (let seq = 1; seq <= 50; seq += 1) {
+        recorderPageMock.emit(contentEvent(seq, `const v = ${seq};`));
+      }
+    });
+
+    await waitFor(() => {
+      const kinds = vi
+        .mocked(media.eventsDataChannel.send)
+        .mock.calls.map(([data]) => JSON.parse(data).kind);
+      expect(kinds.filter((kind) => kind === "state-snapshot")).toHaveLength(1);
+    });
+    const snapshotCall = vi
+      .mocked(media.eventsDataChannel.send)
+      .mock.calls.map(([data]) => JSON.parse(data))
+      .find((message) => message.kind === "state-snapshot");
+    expect(snapshotCall.snapshotSeq).toBe(50);
+    expect(snapshotCall.state.editor.code).toBe("const v = 50;");
+  });
+
   it("waits for the candidate events DataChannel to open before subscribing and backfills queued events", async () => {
     const roomClient = makeRoomClient();
     const signaling = makeSignalingFactory();

--- a/apps/web/src/features/interview/__tests__/interviewSync.test.ts
+++ b/apps/web/src/features/interview/__tests__/interviewSync.test.ts
@@ -1,10 +1,21 @@
 import { describe, expect, it } from "vitest";
-import type { EventBus, RecordingEvent, ReplayStableState } from "@/shared/recording-schema";
+import {
+  cloneReplayStableState,
+  replayReducer,
+  type EventBus,
+  type RecordingEvent,
+  type ReplayStableState,
+} from "@/shared/recording-schema";
 import {
   createInterviewSyncPublisher,
   createRemoteTimelineBuffer,
   type InterviewRealtimeDataChannel,
 } from "../interviewSync";
+import { INITIAL_REMOTE_INTERVIEW_STABLE_STATE } from "../remoteInterviewInitialState";
+
+function initialStableState(): ReplayStableState {
+  return cloneReplayStableState(INITIAL_REMOTE_INTERVIEW_STABLE_STATE);
+}
 
 function contentEvent(seq: number, code = `code-${seq}`): RecordingEvent {
   return {
@@ -143,6 +154,110 @@ describe("InterviewSyncPublisher", () => {
       ok: false,
       reason: "send-failed",
     });
+  });
+
+  it("publishes a state snapshot reflecting all published events", () => {
+    const { channel, sent } = createFakeChannel();
+    const publisher = createInterviewSyncPublisher({
+      channel,
+      roomId: "room-1",
+      sessionId: "session-1",
+      messageIdProvider: () => "snapshot-message",
+      nowProvider: () => 4321,
+      stateVersionProvider: () => 9,
+      snapshotState: initialStableState(),
+    });
+
+    publisher.publishRecordingEvent(contentEvent(1, "const a = 1;"));
+    publisher.publishRecordingEvent(contentEvent(2, "const a = 2;"));
+    const result = publisher.publishSnapshot();
+
+    expect(result.ok).toBe(true);
+    const expectedState = [contentEvent(1, "const a = 1;"), contentEvent(2, "const a = 2;")].reduce(
+      replayReducer,
+      initialStableState(),
+    );
+    const snapshotPayload = JSON.parse(sent.at(-1)!);
+    expect(snapshotPayload).toEqual({
+      kind: "state-snapshot",
+      roomId: "room-1",
+      sessionId: "session-1",
+      messageId: "snapshot-message",
+      sentAt: 4321,
+      snapshotSeq: 2,
+      snapshotTimeMs: 200,
+      stateVersion: 9,
+      state: expectedState,
+    });
+  });
+
+  it("auto-emits a snapshot every N stable events while subscribed", () => {
+    const { channel, sent } = createFakeChannel();
+    const bus = createFakeEventBus();
+    const publisher = createInterviewSyncPublisher({
+      channel,
+      roomId: "room-1",
+      sessionId: "session-1",
+      snapshotState: initialStableState(),
+      snapshotEventInterval: 3,
+      snapshotTimeIntervalMs: Number.POSITIVE_INFINITY,
+    });
+
+    const unsubscribe = publisher.subscribeTo(bus);
+    for (let seq = 1; seq <= 3; seq += 1) {
+      bus.emit(contentEvent(seq, `const v = ${seq};`));
+    }
+    unsubscribe();
+
+    const kinds = sent.map((raw) => JSON.parse(raw).kind);
+    expect(kinds.filter((kind) => kind === "recording-event")).toHaveLength(3);
+    const snapshots = sent
+      .map((raw) => JSON.parse(raw))
+      .filter((message) => message.kind === "state-snapshot");
+    expect(snapshots).toHaveLength(1);
+    expect(snapshots[0].snapshotSeq).toBe(3);
+  });
+
+  it("auto-emits a snapshot once the time interval elapses", () => {
+    const { channel, sent } = createFakeChannel();
+    const bus = createFakeEventBus();
+    let now = 1000;
+    const publisher = createInterviewSyncPublisher({
+      channel,
+      roomId: "room-1",
+      sessionId: "session-1",
+      nowProvider: () => now,
+      snapshotState: initialStableState(),
+      snapshotEventInterval: Number.POSITIVE_INFINITY,
+      snapshotTimeIntervalMs: 5000,
+    });
+
+    const unsubscribe = publisher.subscribeTo(bus);
+    bus.emit(contentEvent(1, "const v = 1;"));
+    expect(sent.map((raw) => JSON.parse(raw).kind)).toEqual(["recording-event"]);
+
+    now = 6500;
+    bus.emit(contentEvent(2, "const v = 2;"));
+    unsubscribe();
+
+    const snapshots = sent
+      .map((raw) => JSON.parse(raw))
+      .filter((message) => message.kind === "state-snapshot");
+    expect(snapshots).toHaveLength(1);
+    expect(snapshots[0].snapshotSeq).toBe(2);
+  });
+
+  it("does not emit a snapshot when the channel is not open", () => {
+    const { channel, sent } = createFakeChannel("closed");
+    const publisher = createInterviewSyncPublisher({
+      channel,
+      roomId: "room-1",
+      sessionId: "session-1",
+      snapshotState: initialStableState(),
+    });
+
+    expect(publisher.publishSnapshot()).toEqual({ ok: false, reason: "channel-not-open" });
+    expect(sent).toEqual([]);
   });
 });
 

--- a/apps/web/src/features/interview/__tests__/interviewSync.test.ts
+++ b/apps/web/src/features/interview/__tests__/interviewSync.test.ts
@@ -38,6 +38,30 @@ function contentEvent(seq: number, code = `code-${seq}`): RecordingEvent {
   };
 }
 
+function recordStartEvent(seq: number): RecordingEvent {
+  return {
+    id: `event-${seq}`,
+    seq,
+    timestampMs: seq * 100,
+    source: "recorder",
+    track: "main",
+    type: "record-start",
+    payload: {
+      initialLanguage: "javascript",
+      initialFontSize: 18,
+      initialTheme: "light",
+      selectedAudioDeviceId: null,
+      selectedCameraDeviceId: null,
+      mediaCapability: {
+        audio: "available",
+        camera: "available",
+        selectedAudioDeviceId: null,
+        selectedCameraDeviceId: null,
+      },
+    },
+  };
+}
+
 function createFakeChannel(initialState: InterviewRealtimeDataChannel["readyState"] = "open") {
   const sent: string[] = [];
   const channel: InterviewRealtimeDataChannel = {
@@ -258,6 +282,59 @@ describe("InterviewSyncPublisher", () => {
 
     expect(publisher.publishSnapshot()).toEqual({ ok: false, reason: "channel-not-open" });
     expect(sent).toEqual([]);
+  });
+
+  it("seeds the snapshot state from the record-start payload", () => {
+    const { channel, sent } = createFakeChannel();
+    const publisher = createInterviewSyncPublisher({
+      channel,
+      roomId: "room-1",
+      sessionId: "session-1",
+      snapshotState: initialStableState(),
+    });
+
+    publisher.publishRecordingEvent(recordStartEvent(1));
+    publisher.publishSnapshot();
+    const seededOnly = JSON.parse(sent.at(-1)!);
+    expect(seededOnly.state.editor.language).toBe("javascript");
+    expect(seededOnly.state.editor.fontSize).toBe(18);
+    expect(seededOnly.state.editor.theme).toBe("light");
+
+    publisher.publishRecordingEvent(contentEvent(2, "const seeded = true;"));
+    publisher.publishSnapshot();
+    const snapshot = JSON.parse(sent.at(-1)!);
+    // content-change carries its own language; fontSize/theme remain seeded.
+    expect(snapshot.state.editor.fontSize).toBe(18);
+    expect(snapshot.state.editor.theme).toBe("light");
+    expect(snapshot.state.editor.code).toBe("const seeded = true;");
+  });
+
+  it("emits a snapshot after rebuilding deduped backlog past the event threshold", () => {
+    const { channel, sent } = createFakeChannel();
+    const events = Array.from({ length: 3 }, (_, index) => contentEvent(index + 1, `const v = ${index + 1};`));
+    const bus = createFakeEventBus(events.slice());
+    const alreadyPublished = new Set(events.map((event) => event.id));
+    const publisher = createInterviewSyncPublisher({
+      channel,
+      roomId: "room-1",
+      sessionId: "session-1",
+      snapshotState: initialStableState(),
+      snapshotEventInterval: 3,
+      snapshotTimeIntervalMs: Number.POSITIVE_INFINITY,
+    });
+
+    const unsubscribe = publisher.subscribeTo(bus, {
+      includeBacklog: true,
+      shouldPublishEvent: (event) => !alreadyPublished.has(event.id),
+    });
+    unsubscribe();
+
+    const messages = sent.map((raw) => JSON.parse(raw));
+    expect(messages.filter((message) => message.kind === "recording-event")).toHaveLength(0);
+    const snapshots = messages.filter((message) => message.kind === "state-snapshot");
+    expect(snapshots).toHaveLength(1);
+    expect(snapshots[0].snapshotSeq).toBe(3);
+    expect(snapshots[0].state.editor.code).toBe("const v = 3;");
   });
 });
 

--- a/apps/web/src/features/interview/interviewSync.ts
+++ b/apps/web/src/features/interview/interviewSync.ts
@@ -1,4 +1,11 @@
-import type { EventBus, RecordingEvent, ReplayStableState } from "@/shared/recording-schema";
+import {
+  cloneReplayStableState,
+  replayReducer,
+  STABLE_EVENT_TYPES,
+  type EventBus,
+  type RecordingEvent,
+  type ReplayStableState,
+} from "@/shared/recording-schema";
 
 export type InterviewRealtimeDataChannel = {
   readyState: "connecting" | "open" | "closing" | "closed";
@@ -57,6 +64,10 @@ export type InterviewPublishResult =
   | { ok: true; message: InterviewRecordingEventMessage }
   | { ok: false; reason: "channel-not-open" | "send-failed" };
 
+export type InterviewSnapshotPublishResult =
+  | { ok: true; message: InterviewSnapshotMessage }
+  | { ok: false; reason: "channel-not-open" | "send-failed" | "no-published-events" };
+
 export type InterviewSyncPublisherOptions = {
   channel: InterviewRealtimeDataChannel;
   roomId: string;
@@ -64,10 +75,14 @@ export type InterviewSyncPublisherOptions = {
   messageIdProvider?: () => string;
   nowProvider?: () => number;
   stateVersionProvider?: () => number;
+  snapshotState?: ReplayStableState;
+  snapshotEventInterval?: number;
+  snapshotTimeIntervalMs?: number;
 };
 
 export type InterviewSyncPublisher = {
   publishRecordingEvent(event: RecordingEvent): InterviewPublishResult;
+  publishSnapshot(): InterviewSnapshotPublishResult;
   subscribeTo(
     bus: Pick<EventBus, "subscribe"> & Partial<Pick<EventBus, "peek">>,
     options?: InterviewSyncSubscribeOptions,
@@ -86,6 +101,29 @@ export function createInterviewSyncPublisher(
   const messageIdProvider = options.messageIdProvider ?? createMessageId;
   const nowProvider = options.nowProvider ?? (() => Date.now());
   const stateVersionProvider = options.stateVersionProvider ?? (() => 0);
+  const snapshotEventInterval = options.snapshotEventInterval ?? DEFAULT_SNAPSHOT_EVENT_INTERVAL;
+  const snapshotTimeIntervalMs =
+    options.snapshotTimeIntervalMs ?? DEFAULT_SNAPSHOT_TIME_INTERVAL_MS;
+  const tracksSnapshots = options.snapshotState !== undefined;
+
+  let snapshotState = options.snapshotState
+    ? cloneReplayStableState(options.snapshotState)
+    : null;
+  let lastPublishedSeq: number | null = null;
+  let lastPublishedTimestampMs = 0;
+  let stableEventsSinceSnapshot = 0;
+  let lastSnapshotAtMs: number | null = null;
+
+  const advanceSnapshotState = (event: RecordingEvent) => {
+    if (snapshotState) {
+      snapshotState = replayReducer(snapshotState, event);
+    }
+    lastPublishedSeq = event.seq;
+    lastPublishedTimestampMs = event.timestampMs;
+    if (STABLE_EVENT_TYPES.has(event.type)) {
+      stableEventsSinceSnapshot += 1;
+    }
+  };
 
   const publishRecordingEvent = (event: RecordingEvent): InterviewPublishResult => {
     if (options.channel.readyState !== "open") {
@@ -105,19 +143,75 @@ export function createInterviewSyncPublisher(
 
     try {
       options.channel.send(JSON.stringify(message));
-      return { ok: true, message };
     } catch {
       return { ok: false, reason: "send-failed" };
+    }
+
+    advanceSnapshotState(event);
+    return { ok: true, message };
+  };
+
+  const publishSnapshot = (): InterviewSnapshotPublishResult => {
+    if (options.channel.readyState !== "open") {
+      return { ok: false, reason: "channel-not-open" };
+    }
+    if (!snapshotState || lastPublishedSeq === null) {
+      return { ok: false, reason: "no-published-events" };
+    }
+
+    const message: InterviewSnapshotMessage = {
+      kind: "state-snapshot",
+      roomId: options.roomId,
+      sessionId: options.sessionId,
+      messageId: messageIdProvider(),
+      sentAt: nowProvider(),
+      snapshotSeq: lastPublishedSeq,
+      snapshotTimeMs: lastPublishedTimestampMs,
+      stateVersion: stateVersionProvider(),
+      state: cloneReplayStableState(snapshotState),
+    };
+
+    try {
+      options.channel.send(JSON.stringify(message));
+    } catch {
+      return { ok: false, reason: "send-failed" };
+    }
+
+    stableEventsSinceSnapshot = 0;
+    lastSnapshotAtMs = nowProvider();
+    return { ok: true, message };
+  };
+
+  const maybeEmitSnapshot = () => {
+    if (!tracksSnapshots || lastPublishedSeq === null) return;
+    const now = nowProvider();
+    if (lastSnapshotAtMs === null) {
+      lastSnapshotAtMs = now;
+    }
+    const dueByEvents = stableEventsSinceSnapshot >= snapshotEventInterval;
+    const dueByTime = now - lastSnapshotAtMs >= snapshotTimeIntervalMs;
+    if (dueByEvents || dueByTime) {
+      publishSnapshot();
     }
   };
 
   return {
     publishRecordingEvent,
+    publishSnapshot,
     subscribeTo(bus, subscribeOptions = {}) {
       const publishFromSubscription = (event: RecordingEvent) => {
-        if (subscribeOptions.shouldPublishEvent?.(event) === false) return;
+        if (subscribeOptions.shouldPublishEvent?.(event) === false) {
+          // Event was already published by a prior publisher (e.g. after a
+          // DataChannel reopen). Still advance the running snapshot state so a
+          // later snapshot reflects the full published timeline.
+          advanceSnapshotState(event);
+          return;
+        }
         const result = publishRecordingEvent(event);
         subscribeOptions.onPublishResult?.(event, result);
+        if (result.ok) {
+          maybeEmitSnapshot();
+        }
       };
 
       if (subscribeOptions.includeBacklog) {
@@ -128,6 +222,9 @@ export function createInterviewSyncPublisher(
     },
   };
 }
+
+const DEFAULT_SNAPSHOT_EVENT_INTERVAL = 50;
+const DEFAULT_SNAPSHOT_TIME_INTERVAL_MS = 5000;
 
 export type SnapshotRequestNeed = {
   reason: "gap-detected";

--- a/apps/web/src/features/interview/interviewSync.ts
+++ b/apps/web/src/features/interview/interviewSync.ts
@@ -1,4 +1,5 @@
 import {
+  buildInitialReplayStateFromRecordStart,
   cloneReplayStableState,
   replayReducer,
   STABLE_EVENT_TYPES,
@@ -116,7 +117,13 @@ export function createInterviewSyncPublisher(
 
   const advanceSnapshotState = (event: RecordingEvent) => {
     if (snapshotState) {
-      snapshotState = replayReducer(snapshotState, event);
+      // record-start carries the candidate's actual initial setup (language,
+      // font, theme); replayReducer leaves it unchanged, so seed from it
+      // directly — otherwise snapshots would carry hard-coded defaults.
+      snapshotState =
+        event.type === "record-start"
+          ? buildInitialReplayStateFromRecordStart(event.payload)
+          : replayReducer(snapshotState, event);
     }
     lastPublishedSeq = event.seq;
     lastPublishedTimestampMs = event.timestampMs;
@@ -202,9 +209,11 @@ export function createInterviewSyncPublisher(
       const publishFromSubscription = (event: RecordingEvent) => {
         if (subscribeOptions.shouldPublishEvent?.(event) === false) {
           // Event was already published by a prior publisher (e.g. after a
-          // DataChannel reopen). Still advance the running snapshot state so a
-          // later snapshot reflects the full published timeline.
+          // DataChannel reopen). Still advance the running snapshot state and
+          // re-check the snapshot threshold so a reopened channel can resync
+          // from the reconstructed backlog even without new edits.
           advanceSnapshotState(event);
+          maybeEmitSnapshot();
           return;
         }
         const result = publishRecordingEvent(event);


### PR DESCRIPTION
## 概述

实现 issue #202（父 Epic #120），按 `docs/技术方案.md` 十二.6 接通「候选人周期性状态快照」这条最小可用重同步链路：面试官侧的 `RemoteTimelineBuffer.pushSnapshot`（#181 已具备）此前没有任何快照可消费，本 PR 让候选人开始发送 `state-snapshot`。

Closes #202

## 改动

**`interviewSync.ts`（InterviewSyncPublisher）**
- 维护一份随已发布事件用 `replayReducer` 归约的运行态 `ReplayStableState`（仅当传入 `snapshotState` 时启用）。
- 新增 `publishSnapshot()`：基于运行态构造并发送 `state-snapshot`（`snapshotSeq` = 最近已发布事件 seq、`snapshotTimeMs`、`stateVersion`、`state`）。
- 订阅期间自动补发快照：每 `snapshotEventInterval`（默认 50）个稳定状态事件**或**距上次快照满 `snapshotTimeIntervalMs`（默认 5000ms）触发一次；阈值与 `nowProvider` 可注入便于测试。
- 被 `shouldPublishEvent` 去重过滤（通道重连后）的事件仍通过 `advanceSnapshotState` 推进运行态，保证后续快照反映完整已发布时间线。
- 向后兼容：不传 `snapshotState` 时行为与之前一致（既有 9 个测试不变通过）。

**`CandidateInterviewPage.tsx`**
- 创建发布器时传入 `INITIAL_REMOTE_INTERVIEW_STABLE_STATE` 作为快照初始态，接到现有 events DataChannel 发布链路；复用既有「通道未 open 不发 / 重连不重发旧事件」语义。

## 非目标（后续单独 issue）

- 面试官 gap-timeout/hash-mismatch 时主动 `snapshot-request`、候选人按需补发。
- ping/pong 时钟同步与 `playoutDelayMs` 渲染延迟。
- 候选人结束面试保存回放。

## 测试

- `interviewSync.test.ts` 新增：按事件数/时间触发快照、快照 state 与 reducer 等价、通道未 open 不发快照。
- `CandidateInterviewPage.test.tsx` 新增：发布 50 个稳定事件后通过 DataChannel 发出一条 `state-snapshot`，`snapshotSeq=50` 且 `state.editor.code` 正确。
- 本地 `npm run lint:web`、`npm run test -w apps/web`（626 passed）、`npm run build -w apps/web` 全绿。
- 已读取 GitNexus `detect_changes`：影响集中在 `interviewSync.ts` 与 `CandidateInterviewPage.tsx`，公共 API 向后兼容。