### PR TITLE
fix: expose WebRTC interview entry

### DIFF
--- a/apps/web/src/app/AppShell.tsx
+++ b/apps/web/src/app/AppShell.tsx
@@ -37,6 +37,17 @@ export function AppShell() {
           >
             录制
           </NavLink>
+          <NavLink
+            to="/interview/candidate"
+            className={({ isActive }) =>
+              [
+                "rounded-md px-2 py-1 transition-colors",
+                isActive ? "bg-surface-raised text-foreground" : "text-muted hover:text-foreground",
+              ].join(" ")
+            }
+          >
+            面试
+          </NavLink>
         </nav>
         <span className="flex-1" />
         <button

--- a/apps/web/src/app/__tests__/routes.test.tsx
+++ b/apps/web/src/app/__tests__/routes.test.tsx
@@ -1,4 +1,8 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
 import { describe, expect, it } from "vitest";
+import { ThemeProvider } from "@/shared/ui/themeProvider";
+import { AppShell } from "../AppShell";
 import { appRoutes } from "../routes";
 
 describe("appRoutes", () => {
@@ -8,5 +12,22 @@ describe("appRoutes", () => {
     expect(childPaths).toContain("replays/:id");
     expect(childPaths).toContain("cloud/replay/:id");
     expect(childPaths).toContain("s/:token");
+  });
+});
+
+describe("AppShell", () => {
+  it("exposes the candidate interview entry in the top navigation", () => {
+    render(
+      <ThemeProvider>
+        <MemoryRouter>
+          <AppShell />
+        </MemoryRouter>
+      </ThemeProvider>,
+    );
+
+    expect(screen.getByRole("link", { name: "面试" })).toHaveAttribute(
+      "href",
+      "/interview/candidate",
+    );
   });
 });

--- a/apps/web/src/features/interview/CandidateInterviewPage.tsx
+++ b/apps/web/src/features/interview/CandidateInterviewPage.tsx
@@ -1,8 +1,10 @@
 import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import { useParams } from "react-router-dom";
 import {
+  Check,
   CircleDot,
   ClipboardList,
+  Copy,
   Mic,
   MicOff,
   Monitor,
@@ -12,6 +14,7 @@ import {
   Video,
   VideoOff,
 } from "lucide-react";
+import { routerBasename } from "@/app/routerBase";
 import { RecorderPage } from "@/features/recorder/RecorderPage";
 import type { EventBus } from "@/shared/recording-schema";
 import { Toggle, Tooltip } from "@/shared/ui";
@@ -730,6 +733,28 @@ export function CandidateInterviewView({
   const micLabel = mediaState.microphoneEnabled ? "麦克风已开启" : "麦克风已关闭";
   const cameraLabel = mediaState.cameraEnabled ? "摄像头已开启" : "摄像头已关闭";
   const canEndInterview = CANDIDATE_ACTIVE_STATUSES.has(roomState.status);
+  const [copyState, setCopyState] = useState<"idle" | "copied" | "failed">("idle");
+  const interviewerUrl = useMemo(
+    () =>
+      roomId && roomState.joinCode
+        ? buildInterviewerRoomUrl(roomId, roomState.joinCode)
+        : null,
+    [roomId, roomState.joinCode],
+  );
+  const copyLabel =
+    copyState === "copied"
+      ? "链接已复制"
+      : copyState === "failed"
+        ? "复制失败"
+        : "复制面试官链接";
+  const CopyIcon = copyState === "copied" ? Check : Copy;
+  const copyInterviewerUrl = useCallback(() => {
+    if (!interviewerUrl || !navigator.clipboard) return;
+    void navigator.clipboard
+      .writeText(interviewerUrl)
+      .then(() => setCopyState("copied"))
+      .catch(() => setCopyState("failed"));
+  }, [interviewerUrl]);
 
   return (
     <div className="flex h-full min-h-0 flex-col bg-background text-foreground">
@@ -748,6 +773,15 @@ export function CandidateInterviewView({
             <span className="font-mono text-foreground">{roomState.joinCode ?? "等待创建"}</span>
           </div>
         </div>
+        <button
+          type="button"
+          onClick={copyInterviewerUrl}
+          disabled={!interviewerUrl}
+          className="inline-flex items-center gap-2 rounded-md border border-border bg-surface px-3 py-2 text-sm font-medium text-muted transition-colors hover:text-foreground disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          <CopyIcon aria-hidden size={16} />
+          {copyLabel}
+        </button>
         <button
           type="button"
           onClick={onEndInterview}
@@ -841,6 +875,14 @@ export function CandidateInterviewView({
       </div>
     </div>
   );
+}
+
+function buildInterviewerRoomUrl(roomId: string, joinCode: string): string {
+  const path = `/interview/interviewer/${encodeURIComponent(roomId)}?joinCode=${encodeURIComponent(
+    joinCode,
+  )}`;
+  if (typeof window === "undefined") return path;
+  return `${window.location.origin}${routerBasename ?? ""}${path}`;
 }
 
 function MediaStreamTile({

--- a/apps/web/src/features/interview/CandidateInterviewPage.tsx
+++ b/apps/web/src/features/interview/CandidateInterviewPage.tsx
@@ -741,6 +741,9 @@ export function CandidateInterviewView({
         : null,
     [roomId, roomState.joinCode],
   );
+  const clipboardAvailable =
+    typeof navigator !== "undefined" && typeof navigator.clipboard?.writeText === "function";
+  const canCopyInterviewerUrl = Boolean(interviewerUrl && clipboardAvailable);
   const copyLabel =
     copyState === "copied"
       ? "链接已复制"
@@ -748,13 +751,19 @@ export function CandidateInterviewView({
         ? "复制失败"
         : "复制面试官链接";
   const CopyIcon = copyState === "copied" ? Check : Copy;
+  useEffect(() => {
+    setCopyState("idle");
+  }, [interviewerUrl]);
   const copyInterviewerUrl = useCallback(() => {
-    if (!interviewerUrl || !navigator.clipboard) return;
+    if (!interviewerUrl || !clipboardAvailable) {
+      setCopyState("failed");
+      return;
+    }
     void navigator.clipboard
       .writeText(interviewerUrl)
       .then(() => setCopyState("copied"))
       .catch(() => setCopyState("failed"));
-  }, [interviewerUrl]);
+  }, [clipboardAvailable, interviewerUrl]);
 
   return (
     <div className="flex h-full min-h-0 flex-col bg-background text-foreground">
@@ -776,7 +785,7 @@ export function CandidateInterviewView({
         <button
           type="button"
           onClick={copyInterviewerUrl}
-          disabled={!interviewerUrl}
+          disabled={!canCopyInterviewerUrl}
           className="inline-flex items-center gap-2 rounded-md border border-border bg-surface px-3 py-2 text-sm font-medium text-muted transition-colors hover:text-foreground disabled:cursor-not-allowed disabled:opacity-50"
         >
           <CopyIcon aria-hidden size={16} />
@@ -823,6 +832,7 @@ export function CandidateInterviewView({
               {roomState.signalingUrl ? (
                 <Metric label="信令" value={roomState.signalingUrl} />
               ) : null}
+              {interviewerUrl ? <Metric label="面试官链接" value={interviewerUrl} /> : null}
               <Metric label="WebRTC" value={mediaState.connectionState} />
               <Metric label="ICE" value={mediaState.iceConnectionState} />
             </dl>

--- a/apps/web/src/features/interview/__tests__/CandidateInterviewPage.test.tsx
+++ b/apps/web/src/features/interview/__tests__/CandidateInterviewPage.test.tsx
@@ -1,7 +1,7 @@
 import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { StrictMode, type ComponentProps } from "react";
 import { createMemoryRouter, RouterProvider } from "react-router-dom";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { appRoutes } from "@/app/routes";
 import type { EventBus, RecordingEvent } from "@/shared/recording-schema";
 import { ThemeProvider } from "@/shared/ui/themeProvider";
@@ -76,6 +76,10 @@ describe("CandidateInterviewPage", () => {
     recorderPageMock.reset();
   });
 
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
   it("creates a room and connects candidate signaling from the candidate entry route", async () => {
     const roomClient = makeRoomClient({
       createRoom: vi.fn().mockResolvedValue({
@@ -131,6 +135,32 @@ describe("CandidateInterviewPage", () => {
 
     expect(screen.getAllByText("面试官已加入")).toHaveLength(2);
     expect(screen.getByText("面试官在线")).toBeInTheDocument();
+  });
+
+  it("copies the interviewer room link after creating a candidate room", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    vi.stubGlobal("navigator", {
+      ...navigator,
+      clipboard: { writeText },
+    });
+    const roomClient = makeRoomClient();
+    const signaling = makeSignalingFactory();
+
+    renderCandidatePage({
+      initialEntry: "/interview/candidate",
+      roomClient,
+      createSignalingClient: signaling.create,
+    });
+    await screen.findByText("room-created");
+
+    fireEvent.click(screen.getByRole("button", { name: "复制面试官链接" }));
+
+    await waitFor(() => {
+      expect(writeText).toHaveBeenCalledWith(
+        "http://localhost:3000/interview/interviewer/room-created?joinCode=JOIN1234",
+      );
+    });
+    expect(screen.getByText("链接已复制")).toBeInTheDocument();
   });
 
   it("starts the candidate media offer after the interviewer joins", async () => {

--- a/apps/web/src/features/interview/__tests__/CandidateInterviewPage.test.tsx
+++ b/apps/web/src/features/interview/__tests__/CandidateInterviewPage.test.tsx
@@ -163,6 +163,66 @@ describe("CandidateInterviewPage", () => {
     expect(screen.getByText("链接已复制")).toBeInTheDocument();
   });
 
+  it("keeps the interviewer room link visible and disables copy when clipboard is unavailable", async () => {
+    vi.stubGlobal("navigator", {
+      ...navigator,
+      clipboard: undefined,
+    });
+    const roomClient = makeRoomClient();
+    const signaling = makeSignalingFactory();
+
+    renderCandidatePage({
+      initialEntry: "/interview/candidate",
+      roomClient,
+      createSignalingClient: signaling.create,
+    });
+    await screen.findByText("room-created");
+
+    expect(screen.getByRole("button", { name: "复制面试官链接" })).toBeDisabled();
+    expect(
+      screen.getByText("http://localhost:3000/interview/interviewer/room-created?joinCode=JOIN1234"),
+    ).toBeInTheDocument();
+  });
+
+  it("resets the copied state when the interviewer room link changes", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    vi.stubGlobal("navigator", {
+      ...navigator,
+      clipboard: { writeText },
+    });
+    const props: ComponentProps<typeof CandidateInterviewView> = {
+      roomId: "room-1",
+      roomState: {
+        status: "waiting-interviewer",
+        joinCode: "JOIN1234",
+        interviewerOnline: false,
+      },
+      mediaState: makeMediaState(),
+      recordingWorkspace: <div>Recording area</div>,
+    };
+    const { rerender } = render(
+      <TooltipProvider>
+        <CandidateInterviewView {...props} />
+      </TooltipProvider>,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "复制面试官链接" }));
+    expect(await screen.findByRole("button", { name: "链接已复制" })).toBeInTheDocument();
+
+    rerender(
+      <TooltipProvider>
+        <CandidateInterviewView
+          {...props}
+          roomId="room-2"
+          roomState={{ ...props.roomState, joinCode: "JOIN5678" }}
+        />
+      </TooltipProvider>,
+    );
+
+    expect(screen.getByRole("button", { name: "复制面试官链接" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "链接已复制" })).not.toBeInTheDocument();
+  });
+
   it("starts the candidate media offer after the interviewer joins", async () => {
     const roomClient = makeRoomClient();
     const signaling = makeSignalingFactory();

--- a/docs/知识库契约.md
+++ b/docs/知识库契约.md
@@ -11,17 +11,19 @@ npm run agent:bootstrap
 npm run quality:predev
 ```
 
-提交前运行快速质量闸门：
+提交时通过 git hook 自动运行快速质量闸门：
 
 ```bash
-npm run quality:precommit
+git commit
 ```
 
-推送前运行完整质量闸门：
+推送时通过 git hook 自动运行完整质量闸门：
 
 ```bash
-npm run quality:local
+git push
 ```
+
+不要在正常提交/推送流程中手动先跑 `npm run quality:precommit` 或 `npm run quality:local`；这些命令已经分别归 `pre-commit` 和 `pre-push` hook 所有。只有在诊断 hook 失败、做本地预检，或明确使用 `SKIP_QUALITY_HOOKS=1` 绕过 hook 时，才需要手动运行对应质量门。
 
 `contract:local` 会强制执行 `npx --yes gitnexus@1.6.5 analyze --force --index-only`，只刷新 `.gitnexus/` 索引，不注入或重写 `AGENTS.md` / `CLAUDE.md`。本地默认 60 秒超时，CI 默认 180 秒超时；如仓库确实需要更长时间，可设置 `GITNEXUS_ANALYZE_TIMEOUT_MS`。超时会让命令失败，避免 agent 继续依赖陈旧索引。
 

--- a/docs/知识库契约.md
+++ b/docs/知识库契约.md
@@ -23,7 +23,7 @@ git commit
 git push
 ```
 
-不要在正常提交/推送流程中手动先跑 `npm run quality:precommit` 或 `npm run quality:local`；这些命令已经分别归 `pre-commit` 和 `pre-push` hook 所有。只有在诊断 hook 失败、做本地预检，或明确使用 `SKIP_QUALITY_HOOKS=1` 绕过 hook 时，才需要手动运行对应质量门。
+不要在正常提交/推送流程中手动先跑 `npm run quality:precommit` 或 `npm run quality:local`；这些命令已经分别归 `pre-commit` 和 `pre-push` hook 所有。只有在诊断 hook 失败、做本地预检、明确使用 `SKIP_QUALITY_HOOKS=1` 绕过 hook，或当前环境没有安装/触发仓库 hook 时，才需要手动运行对应质量门。
 
 `contract:local` 会强制执行 `npx --yes gitnexus@1.6.5 analyze --force --index-only`，只刷新 `.gitnexus/` 索引，不注入或重写 `AGENTS.md` / `CLAUDE.md`。本地默认 60 秒超时，CI 默认 180 秒超时；如仓库确实需要更长时间，可设置 `GITNEXUS_ANALYZE_TIMEOUT_MS`。超时会让命令失败，避免 agent 继续依赖陈旧索引。
 

--- a/docs/规范工作流程.md
+++ b/docs/规范工作流程.md
@@ -112,11 +112,10 @@ __**一位同学可以同时认领多个任务。**__ 每个 Issue 仍然只能�
 3. 运行 `npm ci` 安装依赖；该命令会自动安装仓库级 git hooks。
 4. 开发前运行 `npm run quality:predev`。
 5. 在新分支完成开发。
-<!-- 6. 提交前运行 `npm run quality:precommit`。
-7. 推送前运行 `npm run quality:local`。 
-已经集成入 githooks 中，不用手动运行
--->
-6. 向主仓库 `main` 提交 PR。
+6. 提交时使用 `git commit`，由 `pre-commit` hook 自动运行 `npm run quality:precommit`。
+7. 推送时使用 `git push`，由 `pre-push` hook 自动运行 `npm run quality:local`。
+8. 如果本地 hook 未安装、不会触发，或你明确使用 `SKIP_QUALITY_HOOKS=1` 绕过 hook，则必须手动运行对应质量门后再提交/推送。
+9. 向主仓库 `main` 提交 PR。
 
 建议分支命名：
 
@@ -318,6 +317,7 @@ bug 修复 PR 合并后：
 ```text
 提交：git commit，由 pre-commit hook 自动运行 npm run quality:precommit
 推送：git push，由 pre-push hook 自动运行 npm run quality:local
+保底：hook 未安装/被绕过时，手动运行对应质量门
 标题：#12 实现录制控制栏
 正文：Closes #12
 ```

--- a/docs/规范工作流程.md
+++ b/docs/规范工作流程.md
@@ -316,8 +316,8 @@ bug 修复 PR 合并后：
 提交 PR：
 
 ```text
-提交前：npm run quality:precommit
-推送前：npm run quality:local
+提交：git commit，由 pre-commit hook 自动运行 npm run quality:precommit
+推送：git push，由 pre-push hook 自动运行 npm run quality:local
 标题：#12 实现录制控制栏
 正文：Closes #12
 ```

--- a/scripts/tests/workflow-rules.test.mjs
+++ b/scripts/tests/workflow-rules.test.mjs
@@ -1201,6 +1201,7 @@ test('agent prompts rely on git hooks for commit and push quality gates', () => 
   assert.match(bootstrapScript, /git commit so the pre-commit hook runs quality:precommit/u);
   assert.match(bootstrapScript, /git push so the pre-push hook runs quality:local/u);
   assert.match(bootstrapScript, /Do not run hook-owned quality gates manually/u);
+  assert.match(bootstrapScript, /without installed hooks/u);
   assert.doesNotMatch(bootstrapScript, /Before pushing or submitting code: run npm run quality:local/u);
 });
 

--- a/scripts/tests/workflow-rules.test.mjs
+++ b/scripts/tests/workflow-rules.test.mjs
@@ -1189,7 +1189,7 @@ test('api package test script runs compiled tests without shell glob expansion',
   assert.ok(existsSync('apps/api/scripts/run-dist-tests.mjs'));
 });
 
-test('agent prompts separate commit and push quality gates', () => {
+test('agent prompts rely on git hooks for commit and push quality gates', () => {
   const agentsPrompt = readFileSync('AGENTS.md', 'utf8');
   const claudePrompt = readFileSync('CLAUDE.md', 'utf8');
   const bootstrapScript = readFileSync('scripts/workflows/contract-check.mjs', 'utf8');
@@ -1198,8 +1198,10 @@ test('agent prompts separate commit and push quality gates', () => {
     assert.match(prompt, /开始任务前.*`npm run quality:predev`/u);
   }
 
-  assert.match(bootstrapScript, /Before committing code: run npm run quality:precommit/u);
-  assert.match(bootstrapScript, /Before pushing or submitting code: run npm run quality:local/u);
+  assert.match(bootstrapScript, /git commit so the pre-commit hook runs quality:precommit/u);
+  assert.match(bootstrapScript, /git push so the pre-push hook runs quality:local/u);
+  assert.match(bootstrapScript, /Do not run hook-owned quality gates manually/u);
+  assert.doesNotMatch(bootstrapScript, /Before pushing or submitting code: run npm run quality:local/u);
 });
 
 test('pages workflow deploys the web app with the GitHub Pages contract', () => {

--- a/scripts/workflows/contract-check.mjs
+++ b/scripts/workflows/contract-check.mjs
@@ -37,7 +37,9 @@ function runBootstrap() {
   console.log('- Commit with git commit so the pre-commit hook runs quality:precommit');
   console.log('- Push with git push so the pre-push hook runs quality:local');
   console.log('- For critical skeleton changes: read GitNexus detect_changes/query/context/impact output');
-  console.log('- Do not run hook-owned quality gates manually unless diagnosing a failure or bypassing hooks');
+  console.log(
+    '- Do not run hook-owned quality gates manually unless diagnosing a failure, bypassing hooks, or working without installed hooks',
+  );
   console.log('- CI remains the final contract gate.');
 }
 

--- a/scripts/workflows/contract-check.mjs
+++ b/scripts/workflows/contract-check.mjs
@@ -34,10 +34,11 @@ function runBootstrap() {
   execFileSync('node', ['scripts/workflows/install-hooks.mjs'], { stdio: 'inherit' });
   console.log('Agent bootstrap complete.');
   console.log('- Before editing code: run npm run quality:predev');
-  console.log('- Before committing code: run npm run quality:precommit');
-  console.log('- Before pushing or submitting code: run npm run quality:local');
+  console.log('- Commit with git commit so the pre-commit hook runs quality:precommit');
+  console.log('- Push with git push so the pre-push hook runs quality:local');
   console.log('- For critical skeleton changes: read GitNexus detect_changes/query/context/impact output');
-  console.log('- Local git hooks run quality gates; CI remains the final contract gate.');
+  console.log('- Do not run hook-owned quality gates manually unless diagnosing a failure or bypassing hooks');
+  console.log('- CI remains the final contract gate.');
 }
 
 function runGitNexusContract({ mode }) {


### PR DESCRIPTION
## 关联

Refs #2（总控 issue，不在本 PR 中关闭）

## 改动点

- 在顶层导航暴露“面试”入口，指向候选人面试创建页。
- 候选人房间创建后提供“复制面试官链接”按钮，链接携带 `roomId` 和 `joinCode`，便于面试官直接进入工作台。
- 补充 Clipboard API 不可用、复制成功、目标链接变化后的回归测试。
- 调整 agent/bootstrap 与流程文档：正常提交/推送依赖 git hooks 触发质量门，同时保留 hook 未安装、被绕过或诊断失败时的手动质量门保底。

## 影响范围

- Web 前端导航与候选人面试页头部交互。
- 本地开发流程提示与流程文档，不改变 CI 最终质量门。
- 不改变 WebRTC 信令、媒体建连、房间 API 或录制回放数据结构。

## GitNexus 影响分析摘要

- 风险等级: MEDIUM
- 关键骨架变更: `docs/知识库契约.md`、`docs/规范工作流程.md`、`scripts/workflows/contract-check.mjs`
- GitNexus 影响面: `detect_changes --scope all --repo code-tape` 报告 4 个文件、7 个变更符号、1 条受影响流程 `CandidateInterviewPage -> Cn`；`impact CandidateInterviewView --repo code-tape --include-tests` 为 LOW，影响限于 `CandidateInterviewPage`、routes、App；`impact runBootstrap --repo code-tape --include-tests` 为 LOW，影响限于 `scripts/workflows/contract-check.mjs`。
- 验证结果: `npm run agent:bootstrap` 输出 hook-owned quality gate 指引并包含未安装 hook 的保底；`node --test scripts/tests/workflow-rules.test.mjs` 通过；`npm run test:web -- CandidateInterviewPage` 通过；带结构化 GitNexus 摘要的 `npm run quality:predev` 通过。完整 `quality:local` 不手动预跑，后续由 `git push` 的 `pre-push` hook 触发。

## 自检

- [x] 未修改 `docs/progress.json` 或 `docs/progress.md`
- [x] 已运行 `npm run quality:local`，或说明无法运行的原因（不手动预跑；由 `git push` 的 `pre-push` hook 触发）
- [x] 涉及 AI 字幕时，已记录一次 `npm run subtitle:postprocess:evaluate` 的“纠错并生成章节”效果验证结果，包含 `representativeOutputSource`、`overallEvaluationDurationMs`，并区分输出校验耗时与真实端到端耗时（不涉及）
- [x] 涉及 AI 字幕点击链路、LLM worker、模型加载或性能时，已记录一次 `npm run subtitle:postprocess:runtime-benchmark` 结果，包含 `postprocessClickToResultReadyDurationMs`、`postProcessTimeoutBudgetMs` 和 `playbackProbeResponsiveDuringPostprocess`（不涉及）
- [x] 已说明改动点和影响范围
- [x] 如果改动关键骨架，已补充契约测试并填写 GitNexus 影响分析摘要
- [ ] 已等待 repo-guard、codex 和 Copilot 评论，并完成必要审查
