### PR TITLE
#207 面试落地页：角色分流入口

### DIFF
--- a/apps/web/src/app/AppShell.tsx
+++ b/apps/web/src/app/AppShell.tsx
@@ -38,7 +38,7 @@ export function AppShell() {
             录制
           </NavLink>
           <NavLink
-            to="/interview/candidate"
+            to="/interview"
             className={({ isActive }) =>
               [
                 "rounded-md px-2 py-1 transition-colors",

--- a/apps/web/src/app/__tests__/routes.test.tsx
+++ b/apps/web/src/app/__tests__/routes.test.tsx
@@ -13,10 +13,16 @@ describe("appRoutes", () => {
     expect(childPaths).toContain("cloud/replay/:id");
     expect(childPaths).toContain("s/:token");
   });
+
+  it("registers the interview lobby route", () => {
+    const childPaths = appRoutes[0]?.children?.map((route) => route.path) ?? [];
+
+    expect(childPaths).toContain("interview");
+  });
 });
 
 describe("AppShell", () => {
-  it("exposes the candidate interview entry in the top navigation", () => {
+  it("exposes the interview lobby entry in the top navigation", () => {
     render(
       <ThemeProvider>
         <MemoryRouter>
@@ -25,9 +31,6 @@ describe("AppShell", () => {
       </ThemeProvider>,
     );
 
-    expect(screen.getByRole("link", { name: "面试" })).toHaveAttribute(
-      "href",
-      "/interview/candidate",
-    );
+    expect(screen.getByRole("link", { name: "面试" })).toHaveAttribute("href", "/interview");
   });
 });

--- a/apps/web/src/app/routes.tsx
+++ b/apps/web/src/app/routes.tsx
@@ -4,6 +4,7 @@ import { RecordingLibraryPage } from "@/features/library/RecordingLibraryPage";
 import { RecorderPage } from "@/features/recorder/RecorderPage";
 import { ReplayPage } from "@/features/player/ReplayPage";
 import { CandidateInterviewPage } from "@/features/interview/CandidateInterviewPage";
+import { InterviewLobbyPage } from "@/features/interview/InterviewLobbyPage";
 import { RemoteInterviewWorkbenchPage } from "@/features/interview/RemoteInterviewWorkbenchPage";
 import { NotFoundPage } from "./NotFoundPage";
 import { routerBasename } from "./routerBase";
@@ -20,6 +21,7 @@ export const appRoutes: RouteObject[] = [
       { path: "replays/:id", element: <ReplayPage source="cloud" /> },
       { path: "cloud/replay/:id", element: <ReplayPage source="cloud" /> },
       { path: "s/:token", element: <ReplayPage source="share" /> },
+      { path: "interview", element: <InterviewLobbyPage /> },
       { path: "interview/interviewer/:roomId", element: <RemoteInterviewWorkbenchPage /> },
       { path: "*", element: <NotFoundPage /> },
     ],

--- a/apps/web/src/features/interview/InterviewLobbyPage.tsx
+++ b/apps/web/src/features/interview/InterviewLobbyPage.tsx
@@ -1,0 +1,99 @@
+import { useState, type FormEvent } from "react";
+import { useNavigate } from "react-router-dom";
+import { ArrowRight, ClipboardList, Monitor, Radio } from "lucide-react";
+import { parseInterviewerLink } from "./interviewerLink";
+
+export function InterviewLobbyPage() {
+  const navigate = useNavigate();
+  const [link, setLink] = useState("");
+  const [error, setError] = useState<string | null>(null);
+
+  const handleJoin = (event: FormEvent) => {
+    event.preventDefault();
+    const parsed = parseInterviewerLink(link);
+    if (!parsed.ok) {
+      setError("链接无效，请粘贴面试官完整链接（含 joinCode）。");
+      return;
+    }
+    setError(null);
+    navigate(
+      `/interview/interviewer/${encodeURIComponent(parsed.roomId)}?joinCode=${encodeURIComponent(
+        parsed.joinCode,
+      )}`,
+    );
+  };
+
+  return (
+    <div className="flex h-full min-h-0 flex-col items-center justify-center bg-background px-4 py-8 text-foreground">
+      <div className="w-full max-w-3xl">
+        <div className="flex items-center gap-2">
+          <Radio aria-hidden size={20} className="text-primary" />
+          <h1 className="font-display text-xl font-semibold">实时面试</h1>
+        </div>
+        <p className="mt-2 text-sm text-muted">
+          选择你的角色加入这场远程面试：候选人发起房间并录制讲解，面试官通过分享链接实时旁观并语音视频沟通。
+        </p>
+
+        <div className="mt-6 grid gap-4 lg:grid-cols-2">
+          <section className="flex flex-col rounded-lg border border-border bg-surface p-5">
+            <div className="flex items-center gap-2">
+              <ClipboardList aria-hidden size={18} className="text-primary" />
+              <h2 className="text-base font-semibold">我是候选人</h2>
+            </div>
+            <p className="mt-2 flex-1 text-sm leading-6 text-muted">
+              发起一场面试，系统会创建房间并生成可分享给面试官的链接。你照常录制代码讲解，操作会实时同步给面试官。
+            </p>
+            <button
+              type="button"
+              onClick={() => navigate("/interview/candidate")}
+              className="mt-4 inline-flex items-center justify-center gap-2 rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition-colors hover:opacity-90"
+            >
+              发起面试
+              <ArrowRight aria-hidden size={16} />
+            </button>
+          </section>
+
+          <section className="flex flex-col rounded-lg border border-border bg-surface p-5">
+            <div className="flex items-center gap-2">
+              <Monitor aria-hidden size={18} className="text-primary" />
+              <h2 className="text-base font-semibold">我是面试官</h2>
+            </div>
+            <p className="mt-2 text-sm leading-6 text-muted">
+              粘贴候选人分享的面试官链接（含 joinCode），加入后即可只读查看候选人编辑器并进行双向音视频通话。
+            </p>
+            <form className="mt-4 flex flex-col gap-2" onSubmit={handleJoin}>
+              <label htmlFor="interviewer-link" className="text-xs font-medium text-muted">
+                面试官链接
+              </label>
+              <input
+                id="interviewer-link"
+                type="text"
+                value={link}
+                onChange={(event) => {
+                  setLink(event.target.value);
+                  if (error) setError(null);
+                }}
+                placeholder="https://…/interview/interviewer/<房间>?joinCode=…"
+                className="rounded-md border border-border bg-background px-3 py-2 text-sm text-foreground outline-none placeholder:text-muted focus:border-primary"
+                aria-invalid={error ? true : undefined}
+                aria-describedby={error ? "interviewer-link-error" : undefined}
+              />
+              {error ? (
+                <p id="interviewer-link-error" role="alert" className="text-xs text-danger">
+                  {error}
+                </p>
+              ) : null}
+              <button
+                type="submit"
+                className="mt-1 inline-flex items-center justify-center gap-2 rounded-md border border-border bg-surface-raised px-4 py-2 text-sm font-medium text-foreground transition-colors hover:bg-surface-raised/80"
+              >
+                加入面试
+                <ArrowRight aria-hidden size={16} />
+              </button>
+            </form>
+          </section>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/features/interview/InterviewLobbyPage.tsx
+++ b/apps/web/src/features/interview/InterviewLobbyPage.tsx
@@ -24,8 +24,8 @@ export function InterviewLobbyPage() {
   };
 
   return (
-    <div className="flex h-full min-h-0 flex-col items-center justify-center bg-background px-4 py-8 text-foreground">
-      <div className="w-full max-w-3xl">
+    <div className="flex h-full min-h-0 flex-col overflow-y-auto bg-background px-4 py-8 text-foreground">
+      <div className="mx-auto my-auto w-full max-w-3xl">
         <div className="flex items-center gap-2">
           <Radio aria-hidden size={20} className="text-primary" />
           <h1 className="font-display text-xl font-semibold">实时面试</h1>

--- a/apps/web/src/features/interview/__tests__/InterviewLobbyPage.test.tsx
+++ b/apps/web/src/features/interview/__tests__/InterviewLobbyPage.test.tsx
@@ -1,0 +1,134 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { createMemoryRouter, RouterProvider, useParams } from "react-router-dom";
+import { describe, expect, it } from "vitest";
+import { ThemeProvider } from "@/shared/ui/themeProvider";
+import { TooltipProvider } from "@/shared/ui/Tooltip";
+import { InterviewLobbyPage } from "../InterviewLobbyPage";
+import { parseInterviewerLink } from "../interviewerLink";
+
+describe("parseInterviewerLink", () => {
+  it("parses a full interviewer URL with origin", () => {
+    expect(
+      parseInterviewerLink(
+        "http://localhost:3000/interview/interviewer/room-abc?joinCode=JOIN1234",
+      ),
+    ).toEqual({ ok: true, roomId: "room-abc", joinCode: "JOIN1234" });
+  });
+
+  it("parses a relative interviewer path", () => {
+    expect(parseInterviewerLink("/interview/interviewer/room-1?joinCode=ABCD5678")).toEqual({
+      ok: true,
+      roomId: "room-1",
+      joinCode: "ABCD5678",
+    });
+  });
+
+  it("decodes an encoded room id", () => {
+    expect(
+      parseInterviewerLink("/interview/interviewer/room%2F1?joinCode=ABCD5678"),
+    ).toEqual({ ok: true, roomId: "room/1", joinCode: "ABCD5678" });
+  });
+
+  it("rejects an empty input", () => {
+    expect(parseInterviewerLink("   ")).toEqual({ ok: false, reason: "empty" });
+  });
+
+  it("rejects a link without joinCode", () => {
+    expect(parseInterviewerLink("/interview/interviewer/room-1")).toEqual({
+      ok: false,
+      reason: "missing-join-code",
+    });
+  });
+
+  it("rejects a malformed joinCode", () => {
+    expect(
+      parseInterviewerLink("/interview/interviewer/room-1?joinCode=SHORT"),
+    ).toEqual({ ok: false, reason: "invalid-join-code" });
+  });
+
+  it("rejects a non-interviewer path", () => {
+    expect(
+      parseInterviewerLink("http://localhost:3000/interview/candidate?joinCode=JOIN1234"),
+    ).toEqual({ ok: false, reason: "not-interviewer-link" });
+  });
+
+  it("rejects unparseable input", () => {
+    expect(parseInterviewerLink("not a url at all !!!")).toEqual({
+      ok: false,
+      reason: "not-interviewer-link",
+    });
+  });
+});
+
+describe("InterviewLobbyPage", () => {
+  it("renders the lobby with start and join sections", () => {
+    renderLobby("/interview");
+
+    expect(screen.getByRole("heading", { name: "实时面试" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "发起面试" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "加入面试" })).toBeInTheDocument();
+  });
+
+  it("navigates to the candidate page when starting an interview", () => {
+    renderLobby("/interview");
+
+    fireEvent.click(screen.getByRole("button", { name: "发起面试" }));
+
+    expect(screen.getByTestId("candidate-stub")).toBeInTheDocument();
+  });
+
+  it("navigates to the interviewer page from a valid pasted link", () => {
+    renderLobby("/interview");
+
+    fireEvent.change(screen.getByLabelText("面试官链接"), {
+      target: {
+        value: "http://localhost:3000/interview/interviewer/room-xyz?joinCode=JOIN1234",
+      },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "加入面试" }));
+
+    expect(screen.getByTestId("interviewer-stub")).toHaveTextContent("room-xyz");
+  });
+
+  it("shows an error and does not navigate for an invalid link", () => {
+    renderLobby("/interview");
+
+    fireEvent.change(screen.getByLabelText("面试官链接"), {
+      target: { value: "/interview/interviewer/room-1?joinCode=BAD" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "加入面试" }));
+
+    expect(screen.queryByTestId("interviewer-stub")).not.toBeInTheDocument();
+    expect(screen.getByText("链接无效，请粘贴面试官完整链接（含 joinCode）。")).toBeInTheDocument();
+  });
+});
+
+function renderLobby(initialEntry: string) {
+  const router = createMemoryRouter(
+    [
+      { path: "/interview", element: <InterviewLobbyPage /> },
+      {
+        path: "/interview/candidate/:roomId?",
+        element: <div data-testid="candidate-stub">candidate</div>,
+      },
+      {
+        path: "/interview/interviewer/:roomId",
+        element: <InterviewerStub />,
+      },
+    ],
+    { initialEntries: [initialEntry] },
+  );
+
+  return render(
+    <ThemeProvider>
+      <TooltipProvider>
+        <RouterProvider router={router} />
+      </TooltipProvider>
+    </ThemeProvider>,
+  );
+}
+
+function InterviewerStub() {
+  const { roomId } = useParams();
+  return <div data-testid="interviewer-stub">{roomId}</div>;
+}

--- a/apps/web/src/features/interview/__tests__/InterviewLobbyPage.test.tsx
+++ b/apps/web/src/features/interview/__tests__/InterviewLobbyPage.test.tsx
@@ -23,6 +23,20 @@ describe("parseInterviewerLink", () => {
     });
   });
 
+  it("parses a link served under a deployment basename", () => {
+    expect(
+      parseInterviewerLink(
+        "https://host.example/code-tape/interview/interviewer/room-1?joinCode=JOIN1234",
+      ),
+    ).toEqual({ ok: true, roomId: "room-1", joinCode: "JOIN1234" });
+  });
+
+  it("parses a basename-prefixed relative path", () => {
+    expect(
+      parseInterviewerLink("/code-tape/interview/interviewer/room-1?joinCode=JOIN1234"),
+    ).toEqual({ ok: true, roomId: "room-1", joinCode: "JOIN1234" });
+  });
+
   it("decodes an encoded room id", () => {
     expect(
       parseInterviewerLink("/interview/interviewer/room%2F1?joinCode=ABCD5678"),
@@ -88,6 +102,19 @@ describe("InterviewLobbyPage", () => {
     fireEvent.click(screen.getByRole("button", { name: "加入面试" }));
 
     expect(screen.getByTestId("interviewer-stub")).toHaveTextContent("room-xyz");
+  });
+
+  it("navigates to the interviewer page from a basename-prefixed link", () => {
+    renderLobby("/interview");
+
+    fireEvent.change(screen.getByLabelText("面试官链接"), {
+      target: {
+        value: "https://host.example/code-tape/interview/interviewer/room-base?joinCode=JOIN1234",
+      },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "加入面试" }));
+
+    expect(screen.getByTestId("interviewer-stub")).toHaveTextContent("room-base");
   });
 
   it("shows an error and does not navigate for an invalid link", () => {

--- a/apps/web/src/features/interview/index.ts
+++ b/apps/web/src/features/interview/index.ts
@@ -84,6 +84,8 @@ export {
   type RemoteInterviewWorkbenchPageProps,
   type RemoteInterviewWorkbenchViewProps,
 } from "./RemoteInterviewWorkbenchPage";
+export { InterviewLobbyPage } from "./InterviewLobbyPage";
+export { parseInterviewerLink, type ParsedInterviewerLink } from "./interviewerLink";
 export { INITIAL_REMOTE_INTERVIEW_STABLE_STATE } from "./remoteInterviewInitialState";
 export {
   createRemoteInterviewWorkbench,

--- a/apps/web/src/features/interview/interviewerLink.ts
+++ b/apps/web/src/features/interview/interviewerLink.ts
@@ -1,0 +1,54 @@
+const JOIN_CODE_PATTERN = /^[0-9A-Za-z]{8}$/u;
+
+export type ParsedInterviewerLink =
+  | { ok: true; roomId: string; joinCode: string }
+  | {
+      ok: false;
+      reason: "empty" | "not-interviewer-link" | "missing-join-code" | "invalid-join-code";
+    };
+
+export function parseInterviewerLink(input: string): ParsedInterviewerLink {
+  const trimmed = input.trim();
+  if (!trimmed) {
+    return { ok: false, reason: "empty" };
+  }
+
+  let url: URL;
+  try {
+    url = new URL(trimmed, defaultBaseUrl());
+  } catch {
+    return { ok: false, reason: "not-interviewer-link" };
+  }
+
+  const match = url.pathname.match(/\/interview\/interviewer\/([^/]+)\/?$/u);
+  if (!match) {
+    return { ok: false, reason: "not-interviewer-link" };
+  }
+
+  let roomId: string;
+  try {
+    roomId = decodeURIComponent(match[1]!);
+  } catch {
+    return { ok: false, reason: "not-interviewer-link" };
+  }
+  if (!roomId) {
+    return { ok: false, reason: "not-interviewer-link" };
+  }
+
+  const joinCode = url.searchParams.get("joinCode")?.trim();
+  if (!joinCode) {
+    return { ok: false, reason: "missing-join-code" };
+  }
+  if (!JOIN_CODE_PATTERN.test(joinCode)) {
+    return { ok: false, reason: "invalid-join-code" };
+  }
+
+  return { ok: true, roomId, joinCode };
+}
+
+function defaultBaseUrl(): string {
+  if (typeof window !== "undefined") {
+    return window.location.origin;
+  }
+  return "http://localhost/";
+}


### PR DESCRIPTION
## 概述

实现 issue #207（父 Epic #120）。此前进入 `/interview/candidate` 会静默自动建房、无明确「发起面试」动作，面试官端 `/interview/interviewer/:roomId` 在导航里也没有入口。本 PR 新增 `/interview` 落地页做角色分流。

Closes #207

## 改动

- **新增 `InterviewLobbyPage.tsx`**：两个区块。
  - 候选人「发起面试」→ `navigate("/interview/candidate")`（沿用现有自动建房 + joinCode + 复制面试官链接）。
  - 面试官「加入面试」→ 粘贴候选人分享的完整链接，解析后跳 `/interview/interviewer/:roomId?joinCode=…`；非法链接展示错误、不跳转。
- **新增 `interviewerLink.ts`**：纯函数 `parseInterviewerLink`（`new URL` 兼容相对/绝对链接，joinCode 按 `^[0-9A-Za-z]{8}$` 校验，与 `RemoteInterviewWorkbenchPage` 一致）。独立模块便于单测并避免 react-refresh 警告。
- **`routes.tsx`**：新增 `/interview` 路由。
- **`AppShell.tsx`**：导航「面试」由 `/interview/candidate` 改指 `/interview`。
- **`index.ts`**：导出新符号。

## 非目标

不改候选人页自动建房逻辑、不改面试官页解析、面试官加入采用粘贴完整链接（非分字段输入）。

## 测试

- `interviewerLink`：完整/相对链接、编码 roomId、缺/非法 joinCode、非 interviewer 路径、不可解析输入。
- 落地页行为：渲染、发起→候选人页、合法链接→面试官页、非法链接不跳转并提示。
- `routes.test.tsx`：`/interview` 路由注册 + 导航指向更新。
- 本地 `npm run lint:web`（0 warning）、`npm run test -w apps/web`（657 passed）、`npm run build -w apps/web` 全绿。
- GitNexus `detect_changes`：low risk，仅 AppShell/appRoutes touched，无受影响流程（纯新增页面/路由/导航）。