### PR TITLE
#209 面试官工作台：运行结果展示与本地设备管理

### DIFF
--- a/apps/web/src/features/interview/RemoteInterviewWorkbenchPage.tsx
+++ b/apps/web/src/features/interview/RemoteInterviewWorkbenchPage.tsx
@@ -636,12 +636,13 @@ export function RemoteInterviewWorkbenchView({
               scrollLeft={editor.scrollLeft}
             />
           </div>
-          <div className="flex max-h-[45%] min-h-0 flex-col border-t border-border">
+          <div className="flex flex-col border-t border-border">
             {hasPreview ? (
               <PreviewPane
                 runtime={previewRuntime}
                 previewHtml={runtime.previewHtml}
-                className="min-h-0 flex-1"
+                showReset={false}
+                className="h-64 shrink-0"
               />
             ) : null}
             <RuntimeOutputPanel runtime={runtime} />

--- a/apps/web/src/features/interview/RemoteInterviewWorkbenchPage.tsx
+++ b/apps/web/src/features/interview/RemoteInterviewWorkbenchPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState, type ReactNode } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import { useParams, useSearchParams } from "react-router-dom";
 import {
   Activity,
@@ -14,6 +14,9 @@ import {
   VideoOff,
 } from "lucide-react";
 import { CodeEditor } from "@/features/editor/CodeEditor";
+import { PreviewPane } from "@/features/runtime-preview/PreviewPane";
+import { RuntimeOutputPanel } from "@/features/runtime-preview/RuntimeOutputPanel";
+import { createIframeRuntime } from "@/features/runtime-preview/iframeRuntime";
 import { Toggle, Tooltip } from "@/shared/ui";
 import {
   createInterviewMediaSession,
@@ -56,6 +59,8 @@ export type RemoteInterviewWorkbenchViewProps = {
   workbenchState: RemoteInterviewWorkbenchState;
   mediaState: InterviewMediaSessionState;
   connectionState: RemoteInterviewConnectionState;
+  onToggleMicrophone?: (enabled: boolean) => void;
+  onToggleCamera?: (enabled: boolean) => void;
 };
 
 export type RemoteInterviewWorkbenchPageProps = {
@@ -230,12 +235,29 @@ function RemoteInterviewWorkbenchRoom({
     }
   }, [mediaSession, roomId, workbenchState.snapshotRequestNeeded]);
 
+  const handleToggleMicrophone = useCallback(
+    (enabled: boolean) => {
+      if (!mediaSession) return;
+      setMediaState(mediaSession.setMicrophoneEnabled(enabled));
+    },
+    [mediaSession],
+  );
+  const handleToggleCamera = useCallback(
+    (enabled: boolean) => {
+      if (!mediaSession) return;
+      setMediaState(mediaSession.setCameraEnabled(enabled));
+    },
+    [mediaSession],
+  );
+
   return (
     <RemoteInterviewWorkbenchView
       roomId={roomId}
       workbenchState={workbenchState}
       mediaState={mediaState}
       connectionState={connectionState}
+      onToggleMicrophone={handleToggleMicrophone}
+      onToggleCamera={handleToggleCamera}
     />
   );
 }
@@ -557,10 +579,15 @@ export function RemoteInterviewWorkbenchView({
   workbenchState,
   mediaState,
   connectionState,
+  onToggleMicrophone,
+  onToggleCamera,
 }: RemoteInterviewWorkbenchViewProps) {
   const editor = workbenchState.stableState.editor;
+  const runtime = workbenchState.stableState.runtime;
   const sync = syncStatusView(workbenchState);
   const connection = connectionStatusView(connectionState);
+  const previewRuntime = useMemo(() => createIframeRuntime(), []);
+  const hasPreview = typeof runtime.previewHtml === "string" && runtime.previewHtml.length > 0;
 
   return (
     <div className="flex h-full min-h-0 flex-col bg-background text-foreground">
@@ -609,6 +636,16 @@ export function RemoteInterviewWorkbenchView({
               scrollLeft={editor.scrollLeft}
             />
           </div>
+          <div className="flex max-h-[45%] min-h-0 flex-col border-t border-border">
+            {hasPreview ? (
+              <PreviewPane
+                runtime={previewRuntime}
+                previewHtml={runtime.previewHtml}
+                className="min-h-0 flex-1"
+              />
+            ) : null}
+            <RuntimeOutputPanel runtime={runtime} />
+          </div>
         </section>
 
         <aside
@@ -617,7 +654,11 @@ export function RemoteInterviewWorkbenchView({
         >
           <ConnectionStatusPanel state={connectionState} view={connection} />
           <SyncDetailPanel state={workbenchState} label={sync.label} detail={sync.detail} />
-          <InterviewMediaPanel state={mediaState} />
+          <InterviewMediaPanel
+            state={mediaState}
+            onToggleMicrophone={onToggleMicrophone}
+            onToggleCamera={onToggleCamera}
+          />
         </aside>
       </div>
     </div>
@@ -672,9 +713,18 @@ function SyncDetailPanel({
   );
 }
 
-function InterviewMediaPanel({ state }: { state: InterviewMediaSessionState }) {
+function InterviewMediaPanel({
+  state,
+  onToggleMicrophone,
+  onToggleCamera,
+}: {
+  state: InterviewMediaSessionState;
+  onToggleMicrophone?: (enabled: boolean) => void;
+  onToggleCamera?: (enabled: boolean) => void;
+}) {
   const micLabel = state.microphoneEnabled ? "麦克风已开启" : "麦克风已关闭";
   const cameraLabel = state.cameraEnabled ? "摄像头已开启" : "摄像头已关闭";
+  const controlsDisabled = !state.localStream;
 
   return (
     <section className="rounded-md border border-border bg-background p-3">
@@ -702,8 +752,8 @@ function InterviewMediaPanel({ state }: { state: InterviewMediaSessionState }) {
         <Tooltip content={micLabel}>
           <Toggle
             pressed={state.microphoneEnabled}
-            onPressedChange={() => {}}
-            disabled
+            onPressedChange={(next) => onToggleMicrophone?.(next)}
+            disabled={controlsDisabled || !onToggleMicrophone}
             label={micLabel}
             icon={<MicOff size={17} />}
             iconPressed={<Mic size={17} />}
@@ -712,8 +762,8 @@ function InterviewMediaPanel({ state }: { state: InterviewMediaSessionState }) {
         <Tooltip content={cameraLabel}>
           <Toggle
             pressed={state.cameraEnabled}
-            onPressedChange={() => {}}
-            disabled
+            onPressedChange={(next) => onToggleCamera?.(next)}
+            disabled={controlsDisabled || !onToggleCamera}
             label={cameraLabel}
             icon={<VideoOff size={17} />}
             iconPressed={<Video size={17} />}

--- a/apps/web/src/features/interview/__tests__/RemoteInterviewWorkbenchPage.test.tsx
+++ b/apps/web/src/features/interview/__tests__/RemoteInterviewWorkbenchPage.test.tsx
@@ -1,4 +1,4 @@
-import { act, render, screen, waitFor } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import type { ComponentProps } from "react";
 import { createMemoryRouter, RouterProvider } from "react-router-dom";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -38,6 +38,16 @@ vi.mock("@/features/editor/CodeEditor", () => ({
       </pre>
     );
   },
+}));
+
+vi.mock("@/features/runtime-preview/PreviewPane", () => ({
+  PreviewPane: ({ previewHtml }: { previewHtml?: string | null }) => (
+    <div aria-label="Mock preview pane" data-preview-html={previewHtml ?? ""} />
+  ),
+}));
+
+vi.mock("@/features/runtime-preview/iframeRuntime", () => ({
+  createIframeRuntime: vi.fn(() => ({})),
 }));
 
 describe("RemoteInterviewWorkbenchPage", () => {
@@ -146,6 +156,88 @@ describe("RemoteInterviewWorkbenchPage", () => {
     expect(screen.getByText("checking")).toBeInTheDocument();
     expect(screen.getByText("事件通道")).toBeInTheDocument();
     expect(screen.getByText("open")).toBeInTheDocument();
+  });
+
+  it("renders the synced runtime console output", () => {
+    renderWorkbenchView({
+      roomId: "room-runtime",
+      workbenchState: makeWorkbenchState({
+        stableState: makeStableState({
+          runtime: {
+            status: "success",
+            stdout: ["hello from candidate"],
+            stderr: [],
+            previewHtml: null,
+            errorMessage: null,
+          },
+        }),
+      }),
+      mediaState: makeMediaState(),
+    });
+
+    expect(screen.getByText("Console")).toBeInTheDocument();
+    expect(screen.getByText("hello from candidate")).toBeInTheDocument();
+    expect(screen.getByText("success")).toBeInTheDocument();
+    expect(screen.queryByLabelText("Mock preview pane")).not.toBeInTheDocument();
+  });
+
+  it("renders the preview pane when the synced runtime has previewHtml", () => {
+    renderWorkbenchView({
+      roomId: "room-preview",
+      workbenchState: makeWorkbenchState({
+        stableState: makeStableState({
+          runtime: {
+            status: "success",
+            stdout: [],
+            stderr: [],
+            previewHtml: "<p>candidate preview</p>",
+            errorMessage: null,
+          },
+        }),
+      }),
+      mediaState: makeMediaState(),
+    });
+
+    const preview = screen.getByLabelText("Mock preview pane");
+    expect(preview).toHaveAttribute("data-preview-html", "<p>candidate preview</p>");
+  });
+
+  it("toggles the interviewer's own microphone and camera once local media is ready", () => {
+    const onToggleMicrophone = vi.fn();
+    const onToggleCamera = vi.fn();
+    const localStream = { id: "local" } as unknown as MediaStream;
+
+    renderWorkbenchView({
+      roomId: "room-devices",
+      workbenchState: makeWorkbenchState(),
+      mediaState: makeMediaState({ localStream }),
+      onToggleMicrophone,
+      onToggleCamera,
+    });
+
+    const micButton = screen.getByRole("button", { name: "麦克风已关闭" });
+    const cameraButton = screen.getByRole("button", { name: "摄像头已关闭" });
+    expect(micButton).toBeEnabled();
+    expect(cameraButton).toBeEnabled();
+
+    fireEvent.click(micButton);
+    fireEvent.click(cameraButton);
+
+    expect(onToggleMicrophone).toHaveBeenCalledWith(true);
+    expect(onToggleCamera).toHaveBeenCalledWith(true);
+  });
+
+  it("keeps device controls disabled until local media is acquired", () => {
+    renderWorkbenchView({
+      roomId: "room-no-media",
+      workbenchState: makeWorkbenchState(),
+      mediaState: makeMediaState({ localStream: null }),
+      onToggleMicrophone: vi.fn(),
+      onToggleCamera: vi.fn(),
+    });
+
+    expect(screen.getByRole("button", { name: "麦克风已关闭" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "摄像头已关闭" })).toBeDisabled();
   });
 
   it("binds local and remote media streams into video elements", async () => {

--- a/apps/web/src/features/player/ReplayPage.tsx
+++ b/apps/web/src/features/player/ReplayPage.tsx
@@ -16,6 +16,7 @@ import { ReplayControls } from "./ReplayControls";
 import { createMediaClockAdapter } from "./mediaClockAdapter";
 import { CodeEditor } from "@/features/editor/CodeEditor";
 import { PreviewPane } from "@/features/runtime-preview/PreviewPane";
+import { RuntimeOutputPanel } from "@/features/runtime-preview/RuntimeOutputPanel";
 import { createIframeRuntime } from "@/features/runtime-preview/iframeRuntime";
 import { createRecordingStore } from "@/features/library/recordingStore";
 import { createCloudRecordingRepository } from "@/features/cloud/cloudRecordingRepository";
@@ -769,36 +770,3 @@ function formatError(err: unknown): string {
   return "unknown error";
 }
 
-function RuntimeOutputPanel({ runtime }: { runtime: ReplayStableState["runtime"] }) {
-  const hasOutput = runtime.stdout.length > 0 || runtime.stderr.length > 0 || runtime.errorMessage;
-
-  return (
-    <section className="border-t border-border bg-background px-4 py-3" aria-label="Runtime output">
-      <div className="mb-2 flex items-center justify-between gap-3">
-        <h2 className="text-xs font-semibold uppercase tracking-wide text-muted">Console</h2>
-        <span className="rounded-sm border border-border px-2 py-0.5 text-[11px] font-medium text-muted">
-          {runtime.status}
-        </span>
-      </div>
-      {hasOutput ? (
-        <div className="max-h-40 space-y-2 overflow-auto font-mono text-xs leading-5">
-          {runtime.stdout.map((line, index) => (
-            <pre key={`stdout-${index}`} className="whitespace-pre-wrap text-foreground">
-              {line}
-            </pre>
-          ))}
-          {runtime.stderr.map((line, index) => (
-            <pre key={`stderr-${index}`} className="whitespace-pre-wrap text-warning">
-              {line}
-            </pre>
-          ))}
-          {runtime.errorMessage ? (
-            <pre className="whitespace-pre-wrap text-danger">{runtime.errorMessage}</pre>
-          ) : null}
-        </div>
-      ) : (
-        <p className="text-xs text-muted">No output</p>
-      )}
-    </section>
-  );
-}

--- a/apps/web/src/features/runtime-preview/PreviewPane.tsx
+++ b/apps/web/src/features/runtime-preview/PreviewPane.tsx
@@ -11,6 +11,8 @@ export type PreviewPaneProps = {
    */
   previewHtml?: string | null;
   onReset?: () => void;
+  /** Hide the reset control for read-only consumers (e.g. interviewer view). */
+  showReset?: boolean;
   className?: string;
 };
 
@@ -27,7 +29,7 @@ export type PreviewPaneProps = {
  *   - 外部 padding=0；让 iframe 100%/100% 填满，避免运行时坐标偏移
  *   - 灰底 + checker pattern 作为「未运行」占位
  */
-export function PreviewPane({ runtime, previewHtml, onReset, className }: PreviewPaneProps) {
+export function PreviewPane({ runtime, previewHtml, onReset, showReset = true, className }: PreviewPaneProps) {
   const hostRef = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
@@ -48,18 +50,20 @@ export function PreviewPane({ runtime, previewHtml, onReset, className }: Previe
       className={["relative h-full w-full bg-surface", className].filter(Boolean).join(" ")}
       aria-label="Runtime preview pane"
     >
-      <div className="absolute right-2 top-2 z-10">
-        <IconButton
-          label="重置预览"
-          icon={<RefreshCcw size={15} />}
-          size="sm"
-          variant="subtle"
-          onClick={() => {
-            runtime.reset();
-            onReset?.();
-          }}
-        />
-      </div>
+      {showReset ? (
+        <div className="absolute right-2 top-2 z-10">
+          <IconButton
+            label="重置预览"
+            icon={<RefreshCcw size={15} />}
+            size="sm"
+            variant="subtle"
+            onClick={() => {
+              runtime.reset();
+              onReset?.();
+            }}
+          />
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/apps/web/src/features/runtime-preview/RuntimeOutputPanel.tsx
+++ b/apps/web/src/features/runtime-preview/RuntimeOutputPanel.tsx
@@ -1,0 +1,39 @@
+import type { ReplayStableState } from "@/shared/recording-schema";
+
+export type RuntimeOutputPanelProps = {
+  runtime: ReplayStableState["runtime"];
+};
+
+export function RuntimeOutputPanel({ runtime }: RuntimeOutputPanelProps) {
+  const hasOutput = runtime.stdout.length > 0 || runtime.stderr.length > 0 || runtime.errorMessage;
+
+  return (
+    <section className="border-t border-border bg-background px-4 py-3" aria-label="Runtime output">
+      <div className="mb-2 flex items-center justify-between gap-3">
+        <h2 className="text-xs font-semibold uppercase tracking-wide text-muted">Console</h2>
+        <span className="rounded-sm border border-border px-2 py-0.5 text-[11px] font-medium text-muted">
+          {runtime.status}
+        </span>
+      </div>
+      {hasOutput ? (
+        <div className="max-h-40 space-y-2 overflow-auto font-mono text-xs leading-5">
+          {runtime.stdout.map((line, index) => (
+            <pre key={`stdout-${index}`} className="whitespace-pre-wrap text-foreground">
+              {line}
+            </pre>
+          ))}
+          {runtime.stderr.map((line, index) => (
+            <pre key={`stderr-${index}`} className="whitespace-pre-wrap text-warning">
+              {line}
+            </pre>
+          ))}
+          {runtime.errorMessage ? (
+            <pre className="whitespace-pre-wrap text-danger">{runtime.errorMessage}</pre>
+          ) : null}
+        </div>
+      ) : (
+        <p className="text-xs text-muted">No output</p>
+      )}
+    </section>
+  );
+}

--- a/apps/web/src/features/runtime-preview/__tests__/PreviewPane.test.tsx
+++ b/apps/web/src/features/runtime-preview/__tests__/PreviewPane.test.tsx
@@ -28,4 +28,13 @@ describe("PreviewPane", () => {
 
     expect(runtime.reset).toHaveBeenCalledTimes(1);
   });
+
+  it("hides the reset action when showReset is false", async () => {
+    const runtime = makeRuntime();
+
+    render(<PreviewPane runtime={runtime} showReset={false} />);
+    await waitFor(() => expect(runtime.mount).toHaveBeenCalled());
+
+    expect(screen.queryByRole("button", { name: "重置预览" })).not.toBeInTheDocument();
+  });
 });

--- a/apps/web/src/features/runtime-preview/__tests__/RuntimeOutputPanel.test.tsx
+++ b/apps/web/src/features/runtime-preview/__tests__/RuntimeOutputPanel.test.tsx
@@ -1,0 +1,46 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import type { ReplayStableState } from "@/shared/recording-schema";
+import { RuntimeOutputPanel } from "../RuntimeOutputPanel";
+
+function makeRuntime(
+  patch: Partial<ReplayStableState["runtime"]> = {},
+): ReplayStableState["runtime"] {
+  return {
+    status: "idle",
+    stdout: [],
+    stderr: [],
+    previewHtml: null,
+    errorMessage: null,
+    ...patch,
+  };
+}
+
+describe("RuntimeOutputPanel", () => {
+  it("renders the status badge and a No output placeholder when empty", () => {
+    render(<RuntimeOutputPanel runtime={makeRuntime({ status: "idle" })} />);
+
+    expect(screen.getByText("Console")).toBeInTheDocument();
+    expect(screen.getByText("idle")).toBeInTheDocument();
+    expect(screen.getByText("No output")).toBeInTheDocument();
+  });
+
+  it("renders stdout, stderr, and error lines", () => {
+    render(
+      <RuntimeOutputPanel
+        runtime={makeRuntime({
+          status: "error",
+          stdout: ["out line"],
+          stderr: ["warn line"],
+          errorMessage: "boom",
+        })}
+      />,
+    );
+
+    expect(screen.getByText("out line")).toBeInTheDocument();
+    expect(screen.getByText("warn line")).toBeInTheDocument();
+    expect(screen.getByText("boom")).toBeInTheDocument();
+    expect(screen.getByText("error")).toBeInTheDocument();
+    expect(screen.queryByText("No output")).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## 概述

实现 issue #209（父 Epic #120）。实测面试官工作台两处缺口：(1) 已同步候选人 runtime 但未渲染运行结果/CONSOLE；(2) 麦克风/摄像头 Toggle 被硬编码 disabled、无法管理本地设备。

Closes #209

## 改动

- **抽共享 `RuntimeOutputPanel`**：从 `ReplayPage.tsx` 文件内私有函数移到 `features/runtime-preview/RuntimeOutputPanel.tsx` 并导出，ReplayPage 改为 import，渲染行为完全不变。补同目录契约测试 `runtime-preview/__tests__/RuntimeOutputPanel.test.tsx`。
- **面试官运行结果展示**：左栏编辑器下方新增只读运行区。有 `previewHtml` 时用现有 `PreviewPane`（沙箱 iframe，`createIframeRuntime`）渲染候选人预览；下方始终展示 `RuntimeOutputPanel` 控制台。数据来自已同步的 `workbenchState.stableState.runtime`（经 replayReducer 同步），面试官只读、无运行/重置入口。
- **面试官本地设备管理**：`InterviewMediaPanel` 的麦克风/摄像头 Toggle 接到 `mediaSession.setMicrophoneEnabled/setCameraEnabled` 并 `setMediaState` 同步；`localStream` 未就绪时禁用。

## 非目标

- 不改候选人页设备 Toggle（候选人侧同样禁用，本次仅修面试官；可后续单开）。
- 不让面试官编辑代码/运行/重置（只读）。
- 不改 runtime 同步链路（已有）。

## GitNexus 影响分析摘要

- 风险等级: MEDIUM
- 关键骨架变更: 触及 runtime-preview 关键目录（新增 `features/runtime-preview/RuntimeOutputPanel.tsx`，从 `ReplayPage` 抽取的纯展示组件，行为保持），并已补同目录契约测试 `runtime-preview/__tests__/RuntimeOutputPanel.test.tsx`。
- GitNexus 影响面: 已跑 detect_changes，变更集中在 `RemoteInterviewWorkbenchPage.tsx` 与 runtime-preview 抽取；受影响 process 均为 `RemoteInterviewWorkbenchView` 既有 render→editor 链路（行为未变）。已用 context/impact 复核 `RuntimeOutputPanel` 抽取为行为保持、ReplayPage 仅改为 import。
- 验证结果: lint:web 0 warning；test -w apps/web 666 passed（含新增 runtime-preview 与面试官 view 测试）；player 测试 103 passed 无回归；tsc -b 与 vite build 通过。

## 测试

- 新增面试官 view 测试：渲染同步 runtime 控制台（stdout/status/No output）、有 previewHtml 时渲染预览、设备 Toggle 在 localStream 就绪后可点击并以正确参数回调、未就绪时禁用。
- 新增 `RuntimeOutputPanel` 契约测试（runtime-preview 关键目录）。
- ReplayPage/player 测试无回归。