### PR TITLE
#211 面试官工作台布局对齐候选人（两栏）

### DIFF
--- a/apps/web/src/features/interview/RemoteInterviewWorkbenchPage.tsx
+++ b/apps/web/src/features/interview/RemoteInterviewWorkbenchPage.tsx
@@ -1,19 +1,17 @@
-import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useParams, useSearchParams } from "react-router-dom";
 import {
-  Activity,
   CircleDot,
   Mic,
   MicOff,
   Monitor,
-  Radio,
   SignalHigh,
   TriangleAlert,
-  UserRound,
   Video,
   VideoOff,
 } from "lucide-react";
 import { CodeEditor } from "@/features/editor/CodeEditor";
+import { CameraPreview } from "@/features/media/CameraPreview";
 import { PreviewPane } from "@/features/runtime-preview/PreviewPane";
 import { RuntimeOutputPanel } from "@/features/runtime-preview/RuntimeOutputPanel";
 import { createIframeRuntime } from "@/features/runtime-preview/iframeRuntime";
@@ -602,18 +600,40 @@ export function RemoteInterviewWorkbenchView({
             <span className="max-w-[18rem] truncate font-mono text-foreground">{roomId}</span>
           </div>
         </div>
+
         <div
           role="status"
           aria-live="polite"
+          className={`inline-flex max-w-[22rem] items-center gap-2 rounded-md border px-3 py-2 text-sm ${connection.toneClass}`}
+        >
+          <TriangleAlert aria-hidden size={16} className="shrink-0" />
+          <span className="truncate font-medium">{connection.label}</span>
+          {connectionState.errorMessage ? (
+            <span className="truncate text-xs opacity-90">{connectionState.errorMessage}</span>
+          ) : null}
+        </div>
+        <div
+          role="status"
+          aria-live="polite"
+          title={sync.detail}
           className={`inline-flex items-center gap-2 rounded-md border px-3 py-2 text-sm ${sync.toneClass}`}
         >
           <sync.Icon aria-hidden size={16} />
           <span className="font-medium">{sync.label}</span>
         </div>
+
+        <HeaderMediaControls
+          state={mediaState}
+          onToggleMicrophone={onToggleMicrophone}
+          onToggleCamera={onToggleCamera}
+        />
       </header>
 
-      <div className="grid min-h-0 flex-1 grid-cols-1 lg:grid-cols-[minmax(0,1fr)_22rem]">
-        <section aria-label="候选人编辑器" className="flex min-h-0 flex-col border-r border-border">
+      <div className="grid min-h-0 flex-1 grid-cols-1 md:grid-cols-[1fr_minmax(320px,420px)]">
+        <section
+          aria-label="候选人编辑器"
+          className="relative flex min-h-0 flex-col border-r border-border"
+        >
           <div className="flex min-h-11 flex-wrap items-center gap-3 border-b border-border bg-background px-4 py-2 text-xs text-muted">
             <span className="font-mono uppercase tracking-normal text-foreground">
               {editor.language}
@@ -622,7 +642,7 @@ export function RemoteInterviewWorkbenchView({
             <span>applied seq {workbenchState.lastAppliedSeq}</span>
             <span>next seq {workbenchState.expectedSeq}</span>
           </div>
-          <div className="min-h-0 flex-1">
+          <div className="relative min-h-0 flex-1">
             <CodeEditor
               language={editor.language}
               initialValue={editor.code}
@@ -635,86 +655,34 @@ export function RemoteInterviewWorkbenchView({
               scrollTop={editor.scrollTop}
               scrollLeft={editor.scrollLeft}
             />
-          </div>
-          <div className="flex flex-col border-t border-border">
-            {hasPreview ? (
-              <PreviewPane
-                runtime={previewRuntime}
-                previewHtml={runtime.previewHtml}
-                showReset={false}
-                className="h-64 shrink-0"
-              />
-            ) : null}
-            <RuntimeOutputPanel runtime={runtime} />
+            <CameraPreview
+              stream={mediaState.remoteStream}
+              enabled={Boolean(mediaState.remoteStream)}
+              position={REMOTE_VIDEO_POSITION}
+              draggable={false}
+            />
           </div>
         </section>
 
-        <aside
-          aria-label="实时面试侧栏"
-          className="flex min-h-0 flex-col gap-4 overflow-auto bg-surface px-4 py-4"
-        >
-          <ConnectionStatusPanel state={connectionState} view={connection} />
-          <SyncDetailPanel state={workbenchState} label={sync.label} detail={sync.detail} />
-          <InterviewMediaPanel
-            state={mediaState}
-            onToggleMicrophone={onToggleMicrophone}
-            onToggleCamera={onToggleCamera}
-          />
-        </aside>
+        <section aria-label="候选人运行结果" className="flex min-h-0 flex-col">
+          {hasPreview ? (
+            <PreviewPane
+              runtime={previewRuntime}
+              previewHtml={runtime.previewHtml}
+              showReset={false}
+              className="min-h-0 flex-1"
+            />
+          ) : null}
+          <RuntimeOutputPanel runtime={runtime} />
+        </section>
       </div>
     </div>
   );
 }
 
-function ConnectionStatusPanel({
-  state,
-  view,
-}: {
-  state: RemoteInterviewConnectionState;
-  view: { label: string; detail: string; toneClass: string };
-}) {
-  return (
-    <section
-      role="status"
-      aria-live="polite"
-      className={`rounded-md border p-3 ${view.toneClass}`}
-    >
-      <div className="flex items-center gap-2">
-        <TriangleAlert aria-hidden size={16} />
-        <h2 className="text-sm font-semibold">房间连接</h2>
-      </div>
-      <p className="mt-3 text-sm font-medium">{view.label}</p>
-      <p className="mt-1 text-xs leading-5">{state.errorMessage ?? view.detail}</p>
-    </section>
-  );
-}
+const REMOTE_VIDEO_POSITION = { x: 72, y: 72 };
 
-function SyncDetailPanel({
-  state,
-  label,
-  detail,
-}: {
-  state: RemoteInterviewWorkbenchState;
-  label: string;
-  detail: string;
-}) {
-  return (
-    <section className="rounded-md border border-border bg-background p-3">
-      <div className="flex items-center gap-2">
-        <Activity aria-hidden size={16} className="text-primary" />
-        <h2 className="text-sm font-semibold">同步状态</h2>
-      </div>
-      <p className="mt-3 text-sm font-medium text-foreground">{label}</p>
-      <p className="mt-1 text-xs leading-5 text-muted">{detail}</p>
-      <dl className="mt-3 grid grid-cols-2 gap-2 text-xs">
-        <Metric label="已应用" value={`seq ${state.lastAppliedSeq}`} />
-        <Metric label="下一个" value={`seq ${state.expectedSeq}`} />
-      </dl>
-    </section>
-  );
-}
-
-function InterviewMediaPanel({
+function HeaderMediaControls({
   state,
   onToggleMicrophone,
   onToggleCamera,
@@ -728,117 +696,27 @@ function InterviewMediaPanel({
   const controlsDisabled = !state.localStream;
 
   return (
-    <section className="rounded-md border border-border bg-background p-3">
-      <div className="flex items-center gap-2">
-        <Radio aria-hidden size={16} className="text-primary" />
-        <h2 className="text-sm font-semibold">音视频</h2>
-      </div>
-
-      <div className="mt-3 grid gap-3">
-        <MediaStreamTile
-          title="候选人视频"
-          stream={state.remoteStream}
-          muted={false}
-          placeholder={<UserRound aria-hidden size={28} />}
+    <div className="flex items-center gap-2">
+      <Tooltip content={micLabel}>
+        <Toggle
+          pressed={state.microphoneEnabled}
+          onPressedChange={(next) => onToggleMicrophone?.(next)}
+          disabled={controlsDisabled || !onToggleMicrophone}
+          label={micLabel}
+          icon={<MicOff size={17} />}
+          iconPressed={<Mic size={17} />}
         />
-        <MediaStreamTile
-          title="本地预览"
-          stream={state.localStream}
-          muted
-          placeholder={<Monitor aria-hidden size={28} />}
+      </Tooltip>
+      <Tooltip content={cameraLabel}>
+        <Toggle
+          pressed={state.cameraEnabled}
+          onPressedChange={(next) => onToggleCamera?.(next)}
+          disabled={controlsDisabled || !onToggleCamera}
+          label={cameraLabel}
+          icon={<VideoOff size={17} />}
+          iconPressed={<Video size={17} />}
         />
-      </div>
-
-      <div className="mt-3 flex items-center gap-2">
-        <Tooltip content={micLabel}>
-          <Toggle
-            pressed={state.microphoneEnabled}
-            onPressedChange={(next) => onToggleMicrophone?.(next)}
-            disabled={controlsDisabled || !onToggleMicrophone}
-            label={micLabel}
-            icon={<MicOff size={17} />}
-            iconPressed={<Mic size={17} />}
-          />
-        </Tooltip>
-        <Tooltip content={cameraLabel}>
-          <Toggle
-            pressed={state.cameraEnabled}
-            onPressedChange={(next) => onToggleCamera?.(next)}
-            disabled={controlsDisabled || !onToggleCamera}
-            label={cameraLabel}
-            icon={<VideoOff size={17} />}
-            iconPressed={<Video size={17} />}
-          />
-        </Tooltip>
-        <span className="ml-auto text-xs text-muted">{state.signalingState}</span>
-      </div>
-
-      <dl className="mt-3 grid gap-2 text-xs">
-        <Metric label="WebRTC" value={state.connectionState} />
-        <Metric label="ICE" value={state.iceConnectionState} />
-        <Metric label="事件通道" value={state.eventsDataChannelState} />
-      </dl>
-    </section>
-  );
-}
-
-function MediaStreamTile({
-  title,
-  stream,
-  muted,
-  placeholder,
-}: {
-  title: string;
-  stream: MediaStream | null;
-  muted: boolean;
-  placeholder: ReactNode;
-}) {
-  const videoRef = useRef<HTMLVideoElement | null>(null);
-
-  useEffect(() => {
-    const video = videoRef.current;
-    if (!video) return undefined;
-    video.srcObject = stream;
-    return () => {
-      video.srcObject = null;
-    };
-  }, [stream]);
-
-  return (
-    <figure className="overflow-hidden rounded-md border border-border bg-surface-raised">
-      <div className="aspect-video bg-surface">
-        {stream ? (
-          <video
-            ref={videoRef}
-            aria-label={`${title}画面`}
-            className="h-full w-full object-cover"
-            autoPlay
-            muted={muted}
-            playsInline
-          />
-        ) : (
-          <div
-            role="img"
-            aria-label={`${title}占位`}
-            className="flex h-full w-full items-center justify-center text-muted"
-          >
-            {placeholder}
-          </div>
-        )}
-      </div>
-      <figcaption className="flex items-center justify-between px-3 py-2 text-xs">
-        <span className="font-medium text-foreground">{title}</span>
-        <span className="text-muted">{stream ? "已绑定" : "等待媒体"}</span>
-      </figcaption>
-    </figure>
-  );
-}
-
-function Metric({ label, value }: { label: string; value: string | number }) {
-  return (
-    <div className="flex items-center justify-between gap-3 rounded-md bg-surface px-2 py-1.5">
-      <dt className="text-muted">{label}</dt>
-      <dd className="truncate font-mono text-foreground">{value}</dd>
+      </Tooltip>
     </div>
   );
 }

--- a/apps/web/src/features/interview/RemoteInterviewWorkbenchPage.tsx
+++ b/apps/web/src/features/interview/RemoteInterviewWorkbenchPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import { useParams, useSearchParams } from "react-router-dom";
 import {
   CircleDot,
@@ -7,11 +7,11 @@ import {
   Monitor,
   SignalHigh,
   TriangleAlert,
+  UserRound,
   Video,
   VideoOff,
 } from "lucide-react";
 import { CodeEditor } from "@/features/editor/CodeEditor";
-import { CameraPreview } from "@/features/media/CameraPreview";
 import { PreviewPane } from "@/features/runtime-preview/PreviewPane";
 import { RuntimeOutputPanel } from "@/features/runtime-preview/RuntimeOutputPanel";
 import { createIframeRuntime } from "@/features/runtime-preview/iframeRuntime";
@@ -655,12 +655,14 @@ export function RemoteInterviewWorkbenchView({
               scrollTop={editor.scrollTop}
               scrollLeft={editor.scrollLeft}
             />
-            <CameraPreview
-              stream={mediaState.remoteStream}
-              enabled={Boolean(mediaState.remoteStream)}
-              position={REMOTE_VIDEO_POSITION}
-              draggable={false}
-            />
+            <div className="pointer-events-none absolute bottom-4 right-4 z-50 h-32 w-32 overflow-hidden rounded-full border border-border bg-surface-raised shadow-elevation-2">
+              <MediaVideo
+                stream={mediaState.remoteStream}
+                muted={false}
+                label="候选人视频"
+                placeholder={<UserRound aria-hidden size={28} />}
+              />
+            </div>
           </div>
         </section>
 
@@ -680,8 +682,6 @@ export function RemoteInterviewWorkbenchView({
   );
 }
 
-const REMOTE_VIDEO_POSITION = { x: 72, y: 72 };
-
 function HeaderMediaControls({
   state,
   onToggleMicrophone,
@@ -697,6 +697,14 @@ function HeaderMediaControls({
 
   return (
     <div className="flex items-center gap-2">
+      <div className="h-9 w-9 overflow-hidden rounded-md border border-border bg-surface-raised">
+        <MediaVideo
+          stream={state.localStream}
+          muted
+          label="本地预览"
+          placeholder={<Monitor aria-hidden size={16} />}
+        />
+      </div>
       <Tooltip content={micLabel}>
         <Toggle
           pressed={state.microphoneEnabled}
@@ -718,6 +726,52 @@ function HeaderMediaControls({
         />
       </Tooltip>
     </div>
+  );
+}
+
+function MediaVideo({
+  stream,
+  muted,
+  label,
+  placeholder,
+}: {
+  stream: MediaStream | null;
+  muted: boolean;
+  label: string;
+  placeholder: ReactNode;
+}) {
+  const videoRef = useRef<HTMLVideoElement | null>(null);
+
+  useEffect(() => {
+    const video = videoRef.current;
+    if (!video) return undefined;
+    video.srcObject = stream;
+    return () => {
+      video.srcObject = null;
+    };
+  }, [stream]);
+
+  if (!stream) {
+    return (
+      <div
+        role="img"
+        aria-label={`${label}占位`}
+        className="flex h-full w-full items-center justify-center text-muted"
+      >
+        {placeholder}
+      </div>
+    );
+  }
+
+  return (
+    <video
+      ref={videoRef}
+      aria-label={`${label}画面`}
+      className="h-full w-full object-cover"
+      autoPlay
+      muted={muted}
+      playsInline
+    />
   );
 }
 

--- a/apps/web/src/features/interview/RemoteInterviewWorkbenchPage.tsx
+++ b/apps/web/src/features/interview/RemoteInterviewWorkbenchPage.tsx
@@ -615,11 +615,13 @@ export function RemoteInterviewWorkbenchView({
         <div
           role="status"
           aria-live="polite"
-          title={sync.detail}
-          className={`inline-flex items-center gap-2 rounded-md border px-3 py-2 text-sm ${sync.toneClass}`}
+          className={`inline-flex max-w-[24rem] items-center gap-2 rounded-md border px-3 py-2 text-sm ${sync.toneClass}`}
         >
-          <sync.Icon aria-hidden size={16} />
+          <sync.Icon aria-hidden size={16} className="shrink-0" />
           <span className="font-medium">{sync.label}</span>
+          {workbenchState.syncStatus === "waiting-for-snapshot" ? (
+            <span className="truncate text-xs opacity-90">{sync.detail}</span>
+          ) : null}
         </div>
 
         <HeaderMediaControls

--- a/apps/web/src/features/interview/__tests__/RemoteInterviewWorkbenchPage.test.tsx
+++ b/apps/web/src/features/interview/__tests__/RemoteInterviewWorkbenchPage.test.tsx
@@ -88,7 +88,7 @@ describe("RemoteInterviewWorkbenchPage", () => {
 
     expect(screen.getByRole("heading", { name: "面试官工作台" })).toBeInTheDocument();
     expect(screen.getByText("room-42")).toBeInTheDocument();
-    expect(screen.getAllByText("实时同步")).toHaveLength(2);
+    expect(screen.getByText("实时同步")).toBeInTheDocument();
 
     const editorProps = latestCodeEditorProps();
     expect(editorProps).toMatchObject({
@@ -126,12 +126,11 @@ describe("RemoteInterviewWorkbenchPage", () => {
       mediaState: makeMediaState(),
     });
 
-    expect(screen.getAllByText("等待候选人状态快照")).toHaveLength(2);
-    expect(screen.getByText("缺失事件 seq 5，已保留 seq 3 的稳定状态")).toBeInTheDocument();
+    expect(screen.getByText("等待候选人状态快照")).toBeInTheDocument();
     expect(latestCodeEditorProps().value).toBe("const lastStable = true;");
   });
 
-  it("renders media placeholders and disabled controls from media session state", () => {
+  it("renders disabled device controls in the header before local media is ready", () => {
     renderWorkbenchView({
       roomId: "room-media",
       workbenchState: makeWorkbenchState(),
@@ -144,18 +143,8 @@ describe("RemoteInterviewWorkbenchPage", () => {
       }),
     });
 
-    expect(screen.getByText("本地预览")).toBeInTheDocument();
-    expect(screen.getByText("候选人视频")).toBeInTheDocument();
-    expect(screen.getByRole("img", { name: "本地预览占位" })).toBeInTheDocument();
-    expect(screen.getByRole("img", { name: "候选人视频占位" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "麦克风已关闭" })).toBeDisabled();
     expect(screen.getByRole("button", { name: "摄像头已关闭" })).toBeDisabled();
-    expect(screen.getByText("WebRTC")).toBeInTheDocument();
-    expect(screen.getByText("connecting")).toBeInTheDocument();
-    expect(screen.getByText("ICE")).toBeInTheDocument();
-    expect(screen.getByText("checking")).toBeInTheDocument();
-    expect(screen.getByText("事件通道")).toBeInTheDocument();
-    expect(screen.getByText("open")).toBeInTheDocument();
   });
 
   it("renders the synced runtime console output", () => {
@@ -240,7 +229,7 @@ describe("RemoteInterviewWorkbenchPage", () => {
     expect(screen.getByRole("button", { name: "摄像头已关闭" })).toBeDisabled();
   });
 
-  it("binds local and remote media streams into video elements", async () => {
+  it("binds the candidate remote stream into the camera preview video", async () => {
     const originalSrcObjectDescriptor = Object.getOwnPropertyDescriptor(
       HTMLVideoElement.prototype,
       "srcObject",
@@ -265,10 +254,8 @@ describe("RemoteInterviewWorkbenchPage", () => {
         }),
       });
 
-      expect(screen.getByLabelText("本地预览画面")).toBeInTheDocument();
-      expect(screen.getByLabelText("候选人视频画面")).toBeInTheDocument();
+      expect(screen.getByLabelText("Camera preview")).toBeInTheDocument();
       await waitFor(() => {
-        expect(setSrcObject).toHaveBeenCalledWith(localStream);
         expect(setSrcObject).toHaveBeenCalledWith(remoteStream);
       });
     } finally {
@@ -340,9 +327,9 @@ describe("RemoteInterviewWorkbenchPage", () => {
       expect(latestCodeEditorProps().value).toBe("const fromCandidate = true;");
     });
     expect(latestCodeEditorProps().readOnly).toBe(true);
-    expect(screen.getAllByText("实时同步")).toHaveLength(2);
-    expect(screen.getByText("seq 1")).toBeInTheDocument();
-    expect(screen.getByText("seq 2")).toBeInTheDocument();
+    expect(screen.getByText("实时同步")).toBeInTheDocument();
+    expect(screen.getByText("applied seq 1")).toBeInTheDocument();
+    expect(screen.getByText("next seq 2")).toBeInTheDocument();
   });
 
   it("detaches the DataChannel receiver when the interviewer workbench unmounts", () => {

--- a/apps/web/src/features/interview/__tests__/RemoteInterviewWorkbenchPage.test.tsx
+++ b/apps/web/src/features/interview/__tests__/RemoteInterviewWorkbenchPage.test.tsx
@@ -127,6 +127,7 @@ describe("RemoteInterviewWorkbenchPage", () => {
     });
 
     expect(screen.getByText("等待候选人状态快照")).toBeInTheDocument();
+    expect(screen.getByText("缺失事件 seq 5，已保留 seq 3 的稳定状态")).toBeInTheDocument();
     expect(latestCodeEditorProps().value).toBe("const lastStable = true;");
   });
 

--- a/apps/web/src/features/interview/__tests__/RemoteInterviewWorkbenchPage.test.tsx
+++ b/apps/web/src/features/interview/__tests__/RemoteInterviewWorkbenchPage.test.tsx
@@ -229,7 +229,7 @@ describe("RemoteInterviewWorkbenchPage", () => {
     expect(screen.getByRole("button", { name: "摄像头已关闭" })).toBeDisabled();
   });
 
-  it("binds the candidate remote stream into the camera preview video", async () => {
+  it("binds remote stream to an unmuted video and local stream to a muted preview", async () => {
     const originalSrcObjectDescriptor = Object.getOwnPropertyDescriptor(
       HTMLVideoElement.prototype,
       "srcObject",
@@ -254,8 +254,14 @@ describe("RemoteInterviewWorkbenchPage", () => {
         }),
       });
 
-      expect(screen.getByLabelText("Camera preview")).toBeInTheDocument();
+      const remoteVideo = screen.getByLabelText("候选人视频画面") as HTMLVideoElement;
+      const localVideo = screen.getByLabelText("本地预览画面") as HTMLVideoElement;
+      // Candidate audio must be audible to the interviewer.
+      expect(remoteVideo.muted).toBe(false);
+      // Local self-preview is muted to avoid echo.
+      expect(localVideo.muted).toBe(true);
       await waitFor(() => {
+        expect(setSrcObject).toHaveBeenCalledWith(localStream);
         expect(setSrcObject).toHaveBeenCalledWith(remoteStream);
       });
     } finally {


### PR DESCRIPTION
## 概述

实现 issue #211（父 Epic #120）。此前面试官工作台是「编辑器 / 运行结果纵向堆叠 + 右侧独立侧栏」，与候选人（RecorderPage）「编辑器 | 运行预览+CONSOLE 右栏」不一致。本 PR 把面试官主区域对齐候选人。

Closes #211

## 改动（仅 `RemoteInterviewWorkbenchView`）

- 主区域改为与候选人一致的两栏 `grid grid-cols-[1fr_minmax(320px,420px)]`：
  - 左栏：只读 `CodeEditor` + 候选人远端视频圆形浮窗。
  - 右栏：`hasPreview` 时 `PreviewPane`（`showReset={false}`，`flex-1`）+ `RuntimeOutputPanel`。
- 面试官特有的房间连接状态、同步状态、麦克风/摄像头开关 + 本地预览折叠进顶部 header；连接失败时 header 徽章内可见展示 errorMessage；等待快照时可见展示缺口 seq 详情。
- 移除独立 `<aside>` 侧栏及 `ConnectionStatusPanel`/`SyncDetailPanel`/`InterviewMediaPanel`/`MediaStreamTile`/`Metric`。

### 关于远端视频为何不复用 CameraPreview（验收口径修正）

issue #211 与本 PR 初版曾计划复用 `@/features/media/CameraPreview` 展示候选人远端视频。但 `CameraPreview` 的 `<video>` **硬编码 `muted`**（它是本地自预览组件，静音以避免回声）。若复用它展示候选人远端流，面试官将**听不到候选人声音**，违反 PRD「双向音视频通话」。因此改用专用的 `MediaVideo`：

- 候选人远端流 `MediaVideo muted={false}`（可听到候选人音频），保留与候选人页一致的圆形浮窗视觉（外层容器控制尺寸/圆角/定位）。
- 面试官本地自预览 `MediaVideo muted`（避免回声），放在 header。
- `MediaVideo` 无 stream 时始终渲染占位（候选人媒体未协商/权限拒绝时仍可见状态），不会像 CameraPreview 那样被 `opacity-0` 隐藏。

## 测试

- 远端 video `muted===false`、本地 video `muted===true`，两路 srcObject 均绑定；等待快照时缺口详情可见；设备开关在本地媒体就绪后可用。
- 本地 `npm run lint:web`（0 warning）、`npm run test -w apps/web`（667 passed）、`tsc -b`、`build` 全绿。