### PR TITLE
#215 修复编辑器格式化快捷键

### DIFF
--- a/apps/web/e2e/editor-shortcuts.spec.ts
+++ b/apps/web/e2e/editor-shortcuts.spec.ts
@@ -14,11 +14,12 @@ test("primary slash comments the current editor line", async ({ page }) => {
 test("shift alt f formats the current editor document", async ({ page }) => {
   await openRecorder(page);
 
-  await page.keyboard.type("function demo(){return 1;}");
+  await page.keyboard.type("function demo(){\n\t\treturn 1;");
   await page.keyboard.press("Shift+Alt+F");
 
   await expect(editorLines(page)).toContainText("function demo() {");
   await expect(editorLines(page)).toContainText("return 1;");
+  await expect(editorLines(page)).toContainText("}");
 });
 
 test("primary g opens Monaco go to line", async ({ page }) => {

--- a/apps/web/e2e/editor-shortcuts.spec.ts
+++ b/apps/web/e2e/editor-shortcuts.spec.ts
@@ -14,7 +14,7 @@ test("primary slash comments the current editor line", async ({ page }) => {
 test("shift alt f formats the current editor document", async ({ page }) => {
   await openRecorder(page);
 
-  await page.keyboard.type("function demo(){\n\t\treturn 1;");
+  await pasteIntoEditor(page, "function demo(){\n\t\treturn 1;\n}");
   await page.keyboard.press("Shift+Alt+F");
 
   await expect(editorLines(page)).toContainText("function demo() {");
@@ -30,6 +30,15 @@ test("primary g opens Monaco go to line", async ({ page }) => {
 
   await expect(page.locator(".quick-input-widget")).toBeVisible();
 });
+
+async function pasteIntoEditor(page: Page, text: string): Promise<void> {
+  await page.context().grantPermissions(["clipboard-read", "clipboard-write"]);
+  await page.evaluate(async (nextText) => {
+    await navigator.clipboard.writeText(nextText);
+  }, text);
+  await page.keyboard.press(`${PRIMARY_MODIFIER}+V`);
+  await expect(editorLines(page)).toContainText(text.split("\n")[0] ?? text);
+}
 
 async function openRecorder(page: Page): Promise<void> {
   await page.goto("/record", { waitUntil: "domcontentloaded" });

--- a/apps/web/src/features/capture/__tests__/editorProducer.test.ts
+++ b/apps/web/src/features/capture/__tests__/editorProducer.test.ts
@@ -265,6 +265,47 @@ describe("createEditorProducer", () => {
     });
   });
 
+  it("can mark the next content change as a format operation", () => {
+    const env = setup();
+    const mounted = editor("function demo(){\n\t\treturn 1;\n}");
+    env.setEditor(mounted);
+
+    env.producer.markNextChangeAsFormat();
+    mounted.changeContent("function demo() {\n  return 1;\n}\n", {
+      changes: [{ text: "function demo() {\n  return 1;\n}\n" }],
+    });
+
+    expect(env.bus.drain()[0]).toMatchObject({
+      type: "content-change",
+      payload: {
+        code: "function demo() {\n  return 1;\n}\n",
+        changeReason: "format",
+        flushedBy: "format",
+      },
+    });
+  });
+
+  it("does not leak a canceled format signal into later edits", async () => {
+    const env = setup();
+    const mounted = editor("const value = 1;");
+    env.setEditor(mounted);
+
+    const cancel = env.producer.markNextChangeAsFormat();
+    cancel();
+    await Promise.resolve();
+    mounted.changeContent("const value = 12;", { changes: [{ text: "2" }] });
+    vi.advanceTimersByTime(300);
+
+    expect(env.bus.drain()[0]).toMatchObject({
+      type: "content-change",
+      payload: {
+        code: "const value = 12;",
+        changeReason: "input",
+        flushedBy: "debounce",
+      },
+    });
+  });
+
   it("flushes paste, undo, redo, pause, stop, and snapshot boundaries immediately", async () => {
     const env = setup();
     const mounted = editor("old");

--- a/apps/web/src/features/capture/editorProducer.ts
+++ b/apps/web/src/features/capture/editorProducer.ts
@@ -51,6 +51,8 @@ export const createEditorProducer: CreateEditorProducer = (deps): EditorProducer
   let pendingContent: PendingContent | null = null;
   let pendingScroll: ScrollPosition | null = null;
   let pasteSignalPending = false;
+  let formatSignalPending = false;
+  let formatSignalToken = 0;
   let lastContentHash: string | null = null;
   let version = 0;
   let pausedState: ReplayStableState | null = null;
@@ -176,8 +178,13 @@ export const createEditorProducer: CreateEditorProducer = (deps): EditorProducer
     event: ContentChangedEvent,
   ) => {
     if (!isListening()) return;
-    const changeReason = pasteSignalPending ? "paste" : classifyContentChange(event);
+    const changeReason = formatSignalPending
+      ? "format"
+      : pasteSignalPending
+        ? "paste"
+        : classifyContentChange(event);
     pasteSignalPending = false;
+    formatSignalPending = false;
     const code = getEditorValue(editor);
     const existingCount = pendingContent?.changeCount ?? 0;
     pendingContent = {
@@ -208,6 +215,23 @@ export const createEditorProducer: CreateEditorProducer = (deps): EditorProducer
     });
   };
 
+  const handleFormatSignal = () => {
+    if (!isListening()) return () => {};
+    const token = formatSignalToken + 1;
+    formatSignalToken = token;
+    formatSignalPending = true;
+    queueMicrotask(() => {
+      if (formatSignalToken === token) {
+        formatSignalPending = false;
+      }
+    });
+    return () => {
+      if (formatSignalToken === token) {
+        formatSignalPending = false;
+      }
+    };
+  };
+
   const bindEditor = (editor: MonacoEditor.IStandaloneCodeEditor) => {
     currentEditor = editor;
     currentLanguage = deps.getCurrentLanguage();
@@ -227,6 +251,7 @@ export const createEditorProducer: CreateEditorProducer = (deps): EditorProducer
       emitContent("snapshot");
     }
     pasteSignalPending = false;
+    formatSignalPending = false;
     clearScrollTimer();
     disposeEditorListeners();
     if (nextEditor) bindEditor(nextEditor);
@@ -333,6 +358,9 @@ export const createEditorProducer: CreateEditorProducer = (deps): EditorProducer
     flushPending() {
       if (!isListening()) return;
       emitContent("run");
+    },
+    markNextChangeAsFormat() {
+      return handleFormatSignal();
     },
     async takeSnapshot(): Promise<RecordingSnapshot | null> {
       syncEditor();

--- a/apps/web/src/features/capture/types.ts
+++ b/apps/web/src/features/capture/types.ts
@@ -45,6 +45,8 @@ export type EditorProducerDeps = ProducerCommonDeps & {
 export type EditorProducerHandle = EventProducer & {
   /** Force-flush any pending content-change before the controller stops or pauses. */
   flushPending(): void;
+  /** Mark the next Monaco content-change as a format operation. Returns a cancel callback. */
+  markNextChangeAsFormat(): () => void;
   /** Take a stable-state snapshot of the editor for packageBuilder / resume-baseline. */
   takeSnapshot(): Promise<RecordingSnapshot | null>;
   /** Imperatively change the language (also emits the language-change event). */

--- a/apps/web/src/features/editor/CodeEditor.tsx
+++ b/apps/web/src/features/editor/CodeEditor.tsx
@@ -42,9 +42,15 @@ type MonacoEnvironmentHost = typeof globalThis & {
 
 let workerPromise: Promise<WorkerConstructors> | null = null;
 let monacoPromise: Promise<MonacoModule> | null = null;
+let prettierFormatterPromise: Promise<PrettierFormatter> | null = null;
 let themesDefined = false;
 let workersConfigured = false;
 const COLLAPSED_SELECTION_PULSE_MS = 420;
+const FORMAT_ACTION_ID = "editor.action.formatDocument";
+
+type PrettierFormatter = {
+  format(source: string, language: RecordingLanguage): Promise<string | null>;
+};
 
 function monacoTheme(theme: CodeEditorProps["theme"]): MonacoTheme {
   return theme === "dark" ? "code-tape-dark" : "code-tape-light";
@@ -236,7 +242,12 @@ export const CodeEditor = forwardRef<CodeEditorHandle, CodeEditorProps>(function
         const contentChangeDisposable = editor.onDidChangeModelContent(() => {
           onChangeRef.current?.();
         });
-        registerEditorCommands(monaco, editor, (command) => onCommandRef.current?.(command));
+        registerEditorCommands(
+          monaco,
+          editor,
+          () => latestPropsRef.current.readOnly,
+          (command) => onCommandRef.current?.(command),
+        );
         applyControlledEditorState(editor, currentProps);
         pulseCollapsedSelection(editor, currentProps.selection, collapsedSelectionDecorationIdsRef, collapsedSelectionTimerRef);
         onMountRef.current?.(editor);
@@ -328,6 +339,7 @@ export const CodeEditor = forwardRef<CodeEditorHandle, CodeEditorProps>(function
 function registerEditorCommands(
   _monaco: MonacoModule,
   editor: Monaco.editor.IStandaloneCodeEditor,
+  isReadOnly: () => boolean,
   onCommand: (command: CodeEditorCommand) => void,
 ) {
   editor.onKeyDown((event) => {
@@ -342,7 +354,8 @@ function registerEditorCommands(
 
     if (isFormatShortcut(event)) {
       consumeShortcut(event);
-      editor.trigger("keyboard", "editor.action.formatDocument", null);
+      if (isReadOnly()) return;
+      void formatEditorDocument(editor);
       onCommand("format");
       return;
     }
@@ -360,6 +373,64 @@ function registerEditorCommands(
       onCommand("go-to-line");
     }
   });
+}
+
+async function formatEditorDocument(editor: Monaco.editor.IStandaloneCodeEditor) {
+  const originalValue = editor.getValue();
+  const action = typeof editor.getAction === "function" ? editor.getAction(FORMAT_ACTION_ID) : null;
+
+  if (action) {
+    await action.run();
+  } else {
+    editor.trigger("keyboard", FORMAT_ACTION_ID, null);
+  }
+
+  if (editor.getValue() !== originalValue) return;
+
+  const language = editor.getModel()?.getLanguageId() as RecordingLanguage | undefined;
+  if (!language || !isPrettierSupportedLanguage(language)) return;
+
+  try {
+    const formatter = await loadPrettierFormatter();
+    const formatted = await formatter.format(originalValue, language);
+    if (formatted && formatted !== originalValue) {
+      editor.setValue(formatted);
+    }
+  } catch (error) {
+    console.warn("Failed to format editor document", error);
+  }
+}
+
+function isPrettierSupportedLanguage(language: RecordingLanguage): boolean {
+  return language === "javascript" || language === "typescript";
+}
+
+function loadPrettierFormatter(): Promise<PrettierFormatter> {
+  prettierFormatterPromise ??= (async () => {
+    const [prettier, babelPlugin, estreePlugin, typescriptPlugin] = await Promise.all([
+      import("prettier/standalone"),
+      import("prettier/plugins/babel"),
+      import("prettier/plugins/estree"),
+      import("prettier/plugins/typescript"),
+    ]);
+    return {
+      async format(source: string, language: RecordingLanguage) {
+        const parser = language === "typescript" ? "typescript" : "babel";
+        return prettier.format(source, {
+          parser,
+          plugins: [babelPlugin, estreePlugin, typescriptPlugin],
+          tabWidth: 2,
+          useTabs: false,
+          semi: true,
+          singleQuote: false,
+        });
+      },
+    };
+  })().catch((error: unknown) => {
+    prettierFormatterPromise = null;
+    throw error;
+  });
+  return prettierFormatterPromise;
 }
 
 function isPrimaryShortcut(event: Monaco.IKeyboardEvent, key: string): boolean {

--- a/apps/web/src/features/editor/CodeEditor.tsx
+++ b/apps/web/src/features/editor/CodeEditor.tsx
@@ -409,7 +409,17 @@ async function formatEditorDocument(
   try {
     const formatter = await loadPrettierFormatter();
     const formatted = await formatter.format(originalValue, language);
-    if (!formatted || formatted === originalValue || isReadOnly() || editor.getValue() !== originalValue) return;
+    const currentModel = editor.getModel();
+    if (
+      !formatted ||
+      formatted === originalValue ||
+      isReadOnly() ||
+      editor.getValue() !== originalValue ||
+      currentModel !== model ||
+      currentModel.getLanguageId() !== language
+    ) {
+      return;
+    }
     const cancelFormatSignal = onBeforeFormatApply();
     const currentSelection = editor.getSelection();
     const endCursorState = currentSelection ? [currentSelection] : undefined;

--- a/apps/web/src/features/editor/CodeEditor.tsx
+++ b/apps/web/src/features/editor/CodeEditor.tsx
@@ -387,15 +387,24 @@ async function formatEditorDocument(editor: Monaco.editor.IStandaloneCodeEditor)
 
   if (editor.getValue() !== originalValue) return;
 
-  const language = editor.getModel()?.getLanguageId() as RecordingLanguage | undefined;
+  const model = editor.getModel();
+  if (!model) return;
+  const language = model.getLanguageId() as RecordingLanguage | undefined;
   if (!language || !isPrettierSupportedLanguage(language)) return;
 
   try {
     const formatter = await loadPrettierFormatter();
     const formatted = await formatter.format(originalValue, language);
-    if (formatted && formatted !== originalValue) {
-      editor.setValue(formatted);
-    }
+    if (!formatted || formatted === originalValue || editor.getValue() !== originalValue) return;
+    editor.pushUndoStop();
+    editor.executeEdits("code-tape-format", [
+      {
+        range: model.getFullModelRange(),
+        text: formatted,
+        forceMoveMarkers: true,
+      },
+    ]);
+    editor.pushUndoStop();
   } catch (error) {
     console.warn("Failed to format editor document", error);
   }

--- a/apps/web/src/features/editor/CodeEditor.tsx
+++ b/apps/web/src/features/editor/CodeEditor.tsx
@@ -25,6 +25,7 @@ export type CodeEditorProps = {
   onMount?(editor: Monaco.editor.IStandaloneCodeEditor): void;
   onChange?(): void;
   onCommand?(command: CodeEditorCommand): void;
+  onBeforeFormatApply?(): (() => void) | void;
 };
 
 type MonacoModule = typeof Monaco;
@@ -159,6 +160,7 @@ export const CodeEditor = forwardRef<CodeEditorHandle, CodeEditorProps>(function
     onMount,
     onChange,
     onCommand,
+    onBeforeFormatApply,
   },
   ref,
 ) {
@@ -183,6 +185,7 @@ export const CodeEditor = forwardRef<CodeEditorHandle, CodeEditorProps>(function
   const onMountRef = useRef(onMount);
   const onChangeRef = useRef(onChange);
   const onCommandRef = useRef(onCommand);
+  const onBeforeFormatApplyRef = useRef(onBeforeFormatApply);
   const [loadError, setLoadError] = useState<unknown>(null);
 
   latestPropsRef.current = {
@@ -199,6 +202,7 @@ export const CodeEditor = forwardRef<CodeEditorHandle, CodeEditorProps>(function
   onMountRef.current = onMount;
   onChangeRef.current = onChange;
   onCommandRef.current = onCommand;
+  onBeforeFormatApplyRef.current = onBeforeFormatApply;
 
   useImperativeHandle(
     ref,
@@ -247,6 +251,7 @@ export const CodeEditor = forwardRef<CodeEditorHandle, CodeEditorProps>(function
           editor,
           () => latestPropsRef.current.readOnly,
           (command) => onCommandRef.current?.(command),
+          () => onBeforeFormatApplyRef.current?.(),
         );
         applyControlledEditorState(editor, currentProps);
         pulseCollapsedSelection(editor, currentProps.selection, collapsedSelectionDecorationIdsRef, collapsedSelectionTimerRef);
@@ -341,6 +346,7 @@ function registerEditorCommands(
   editor: Monaco.editor.IStandaloneCodeEditor,
   isReadOnly: () => boolean,
   onCommand: (command: CodeEditorCommand) => void,
+  onBeforeFormatApply: () => (() => void) | void,
 ) {
   editor.onKeyDown((event) => {
     const browserEvent = event.browserEvent;
@@ -355,7 +361,7 @@ function registerEditorCommands(
     if (isFormatShortcut(event)) {
       consumeShortcut(event);
       if (isReadOnly()) return;
-      void formatEditorDocument(editor);
+      void formatEditorDocument(editor, isReadOnly, onBeforeFormatApply);
       onCommand("format");
       return;
     }
@@ -375,7 +381,11 @@ function registerEditorCommands(
   });
 }
 
-async function formatEditorDocument(editor: Monaco.editor.IStandaloneCodeEditor) {
+async function formatEditorDocument(
+  editor: Monaco.editor.IStandaloneCodeEditor,
+  isReadOnly: () => boolean,
+  onBeforeFormatApply: () => (() => void) | void,
+) {
   const originalValue = editor.getValue();
   const action = typeof editor.getAction === "function" ? editor.getAction(FORMAT_ACTION_ID) : null;
 
@@ -385,7 +395,7 @@ async function formatEditorDocument(editor: Monaco.editor.IStandaloneCodeEditor)
     editor.trigger("keyboard", FORMAT_ACTION_ID, null);
   }
 
-  if (editor.getValue() !== originalValue) return;
+  if (isReadOnly() || editor.getValue() !== originalValue) return;
 
   const model = editor.getModel();
   if (!model) return;
@@ -395,16 +405,26 @@ async function formatEditorDocument(editor: Monaco.editor.IStandaloneCodeEditor)
   try {
     const formatter = await loadPrettierFormatter();
     const formatted = await formatter.format(originalValue, language);
-    if (!formatted || formatted === originalValue || editor.getValue() !== originalValue) return;
-    editor.pushUndoStop();
-    editor.executeEdits("code-tape-format", [
-      {
-        range: model.getFullModelRange(),
-        text: formatted,
-        forceMoveMarkers: true,
-      },
-    ]);
-    editor.pushUndoStop();
+    if (!formatted || formatted === originalValue || isReadOnly() || editor.getValue() !== originalValue) return;
+    const cancelFormatSignal = onBeforeFormatApply();
+    try {
+      editor.pushUndoStop();
+      const applied = editor.executeEdits("code-tape-format", [
+        {
+          range: model.getFullModelRange(),
+          text: formatted,
+          forceMoveMarkers: true,
+        },
+      ]);
+      if (!applied) {
+        cancelFormatSignal?.();
+        return;
+      }
+      editor.pushUndoStop();
+    } catch (error) {
+      cancelFormatSignal?.();
+      throw error;
+    }
   } catch (error) {
     console.warn("Failed to format editor document", error);
   }

--- a/apps/web/src/features/editor/CodeEditor.tsx
+++ b/apps/web/src/features/editor/CodeEditor.tsx
@@ -389,10 +389,14 @@ async function formatEditorDocument(
   const originalValue = editor.getValue();
   const action = typeof editor.getAction === "function" ? editor.getAction(FORMAT_ACTION_ID) : null;
 
-  if (action) {
-    await action.run();
-  } else {
-    editor.trigger("keyboard", FORMAT_ACTION_ID, null);
+  try {
+    if (action) {
+      await action.run();
+    } else {
+      editor.trigger("keyboard", FORMAT_ACTION_ID, null);
+    }
+  } catch (error) {
+    console.warn("Monaco format action failed", error);
   }
 
   if (isReadOnly() || editor.getValue() !== originalValue) return;

--- a/apps/web/src/features/editor/CodeEditor.tsx
+++ b/apps/web/src/features/editor/CodeEditor.tsx
@@ -411,15 +411,21 @@ async function formatEditorDocument(
     const formatted = await formatter.format(originalValue, language);
     if (!formatted || formatted === originalValue || isReadOnly() || editor.getValue() !== originalValue) return;
     const cancelFormatSignal = onBeforeFormatApply();
+    const currentSelection = editor.getSelection();
+    const endCursorState = currentSelection ? [currentSelection] : undefined;
     try {
       editor.pushUndoStop();
-      const applied = editor.executeEdits("code-tape-format", [
-        {
-          range: model.getFullModelRange(),
-          text: formatted,
-          forceMoveMarkers: true,
-        },
-      ]);
+      const applied = editor.executeEdits(
+        "code-tape-format",
+        [
+          {
+            range: model.getFullModelRange(),
+            text: formatted,
+            forceMoveMarkers: true,
+          },
+        ],
+        endCursorState,
+      );
       if (!applied) {
         cancelFormatSignal?.();
         return;

--- a/apps/web/src/features/editor/__tests__/CodeEditor.test.tsx
+++ b/apps/web/src/features/editor/__tests__/CodeEditor.test.tsx
@@ -30,6 +30,10 @@ const monacoMock = vi.hoisted(() => {
       return this.value;
     }
 
+    getLanguageId() {
+      return this.language;
+    }
+
     setValue(next: string) {
       this.value = next;
     }
@@ -86,6 +90,10 @@ const monacoMock = vi.hoisted(() => {
 
     getValue() {
       return this.options.model.getValue();
+    }
+
+    getModel() {
+      return this.options.model;
     }
 
     dispose() {
@@ -148,6 +156,15 @@ const monacoMock = vi.hoisted(() => {
   };
 });
 
+const prettierMock = vi.hoisted(() => ({
+  format: vi.fn(async (source: string, options: { parser?: string }) => {
+    if (source === "function demo(){\n\t\treturn 1;\n}" && options.parser === "babel") {
+      return "function demo() {\n  return 1;\n}\n";
+    }
+    return source;
+  }),
+}));
+
 vi.mock("monaco-editor/esm/vs/editor/editor.api", () => ({
   editor: monacoMock.editor,
   KeyMod: monacoMock.KeyMod,
@@ -171,6 +188,12 @@ vi.mock("monaco-editor/esm/vs/editor/editor.worker?worker", () => ({
 vi.mock("monaco-editor/esm/vs/language/typescript/ts.worker?worker", () => ({
   default: monacoMock.MockTsWorker,
 }));
+vi.mock("prettier/standalone", () => ({
+  format: prettierMock.format,
+}));
+vi.mock("prettier/plugins/babel", () => ({}));
+vi.mock("prettier/plugins/estree", () => ({}));
+vi.mock("prettier/plugins/typescript", () => ({}));
 
 describe("CodeEditor", () => {
   beforeEach(() => {
@@ -184,6 +207,7 @@ describe("CodeEditor", () => {
     monacoMock.editor.defineTheme.mockClear();
     monacoMock.editor.setTheme.mockClear();
     monacoMock.editor.setModelLanguage.mockClear();
+    prettierMock.format.mockClear();
     delete (globalThis as { MonacoEnvironment?: unknown }).MonacoEnvironment;
   });
 
@@ -457,6 +481,49 @@ describe("CodeEditor", () => {
     });
 
     expect(editor.trigger).toHaveBeenCalledWith("keyboard", "editor.action.formatDocument", null);
+  });
+
+  it("uses a JS formatter fallback when Monaco format action leaves the document unchanged", async () => {
+    const { CodeEditor } = await import("../CodeEditor");
+    render(
+      <CodeEditor
+        language="javascript"
+        initialValue={"function demo(){\n\t\treturn 1;\n}"}
+        fontSize={14}
+        theme="dark"
+      />,
+    );
+    await waitFor(() => expect(monacoMock.editor.create).toHaveBeenCalledTimes(1));
+    const editor = monacoMock.editors[0];
+
+    pressEditorShortcut(editor, { key: "f", shiftKey: true, altKey: true });
+
+    await waitFor(() => expect(editor.getValue()).toBe("function demo() {\n  return 1;\n}\n"));
+    expect(prettierMock.format).toHaveBeenCalledWith(
+      "function demo(){\n\t\treturn 1;\n}",
+      expect.objectContaining({ parser: "babel", tabWidth: 2, useTabs: false }),
+    );
+  });
+
+  it("does not run formatter fallback for read-only replay editors", async () => {
+    const { CodeEditor } = await import("../CodeEditor");
+    render(
+      <CodeEditor
+        language="javascript"
+        initialValue={"function demo(){\n\t\treturn 1;\n}"}
+        fontSize={14}
+        theme="dark"
+        readOnly
+      />,
+    );
+    await waitFor(() => expect(monacoMock.editor.create).toHaveBeenCalledTimes(1));
+    const editor = monacoMock.editors[0];
+
+    pressEditorShortcut(editor, { key: "f", shiftKey: true, altKey: true });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(editor.getValue()).toBe("function demo(){\n\t\treturn 1;\n}");
+    expect(prettierMock.format).not.toHaveBeenCalled();
   });
 
   it("configures JS/TS workers and disposes editor resources on unmount", async () => {

--- a/apps/web/src/features/editor/__tests__/CodeEditor.test.tsx
+++ b/apps/web/src/features/editor/__tests__/CodeEditor.test.tsx
@@ -596,6 +596,54 @@ describe("CodeEditor", () => {
     expect(editor.setValue).not.toHaveBeenCalled();
   });
 
+  it("does not apply pending formatter fallback after the editor becomes read-only", async () => {
+    let resolveFormat: (formatted: string) => void = () => {
+      throw new Error("format promise was not created");
+    };
+    prettierMock.format.mockImplementationOnce(
+      () =>
+        new Promise<string>((resolve) => {
+          resolveFormat = resolve;
+        }),
+    );
+    const { CodeEditor } = await import("../CodeEditor");
+    const onBeforeFormatApply = vi.fn();
+    const { rerender } = render(
+      <CodeEditor
+        language="javascript"
+        initialValue={"function demo(){\n\t\treturn 1;\n}"}
+        fontSize={14}
+        theme="dark"
+        onBeforeFormatApply={onBeforeFormatApply}
+      />,
+    );
+    await waitFor(() => expect(monacoMock.editor.create).toHaveBeenCalledTimes(1));
+    const editor = monacoMock.editors[0];
+
+    pressEditorShortcut(editor, { key: "f", shiftKey: true, altKey: true });
+    await waitFor(() => expect(prettierMock.format).toHaveBeenCalledTimes(1));
+
+    rerender(
+      <CodeEditor
+        language="javascript"
+        initialValue={"function demo(){\n\t\treturn 1;\n}"}
+        fontSize={14}
+        theme="dark"
+        readOnly
+        onBeforeFormatApply={onBeforeFormatApply}
+      />,
+    );
+    await act(async () => {
+      resolveFormat("function demo() {\n  return 1;\n}\n");
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(editor.getValue()).toBe("function demo(){\n\t\treturn 1;\n}");
+    expect(editor.executeEdits).not.toHaveBeenCalled();
+    expect(onBeforeFormatApply).not.toHaveBeenCalled();
+  });
+
   it("does not run formatter fallback for read-only replay editors", async () => {
     const { CodeEditor } = await import("../CodeEditor");
     render(

--- a/apps/web/src/features/editor/__tests__/CodeEditor.test.tsx
+++ b/apps/web/src/features/editor/__tests__/CodeEditor.test.tsx
@@ -34,6 +34,17 @@ const monacoMock = vi.hoisted(() => {
       return this.language;
     }
 
+    getFullModelRange() {
+      const lines = this.value.split("\n");
+      const lastLine = lines[lines.length - 1] ?? "";
+      return {
+        startLineNumber: 1,
+        startColumn: 1,
+        endLineNumber: lines.length,
+        endColumn: lastLine.length + 1,
+      };
+    }
+
     setValue(next: string) {
       this.value = next;
     }
@@ -62,6 +73,12 @@ const monacoMock = vi.hoisted(() => {
     setScrollTop = vi.fn();
     setScrollLeft = vi.fn();
     trigger = vi.fn();
+    pushUndoStop = vi.fn(() => true);
+    executeEdits = vi.fn((_source: string, edits: Array<{ text: string }>) => {
+      const [edit] = edits;
+      if (edit) this.options.model.setValue(edit.text);
+      return true;
+    });
     addCommand = vi.fn((keybinding: number, handler: () => void) => {
       this.commands.push({ keybinding, handler });
       return `command-${this.commands.length}`;
@@ -498,10 +515,22 @@ describe("CodeEditor", () => {
     );
     await waitFor(() => expect(monacoMock.editor.create).toHaveBeenCalledTimes(1));
     const editor = monacoMock.editors[0];
+    const originalRange = monacoMock.models[0].getFullModelRange();
 
     pressEditorShortcut(editor, { key: "f", shiftKey: true, altKey: true });
 
     await waitFor(() => expect(editor.getValue()).toBe("function demo() {\n  return 1;\n}\n"));
+    expect(editor.setValue).not.toHaveBeenCalled();
+    expect(editor.executeEdits).toHaveBeenCalledWith(
+      "code-tape-format",
+      [
+        expect.objectContaining({
+          range: originalRange,
+          text: "function demo() {\n  return 1;\n}\n",
+        }),
+      ],
+    );
+    expect(editor.pushUndoStop).toHaveBeenCalledTimes(2);
     expect(prettierMock.format).toHaveBeenCalledWith(
       "function demo(){\n\t\treturn 1;\n}",
       expect.objectContaining({ parser: "babel", tabWidth: 2, useTabs: false }),
@@ -528,6 +557,43 @@ describe("CodeEditor", () => {
       "const value:number=1;",
       expect.objectContaining({ parser: "typescript", tabWidth: 2, useTabs: false }),
     );
+  });
+
+  it("does not overwrite edits made while the formatter fallback is pending", async () => {
+    let resolveFormat: (formatted: string) => void = () => {
+      throw new Error("format promise was not created");
+    };
+    prettierMock.format.mockImplementationOnce(
+      () =>
+        new Promise<string>((resolve) => {
+          resolveFormat = resolve;
+        }),
+    );
+    const { CodeEditor } = await import("../CodeEditor");
+    render(
+      <CodeEditor
+        language="javascript"
+        initialValue={"function demo(){\n\t\treturn 1;\n}"}
+        fontSize={14}
+        theme="dark"
+      />,
+    );
+    await waitFor(() => expect(monacoMock.editor.create).toHaveBeenCalledTimes(1));
+    const editor = monacoMock.editors[0];
+
+    pressEditorShortcut(editor, { key: "f", shiftKey: true, altKey: true });
+    await waitFor(() => expect(prettierMock.format).toHaveBeenCalledTimes(1));
+
+    monacoMock.models[0].setValue("const userKeptTyping = true;");
+    await act(async () => {
+      resolveFormat("function demo() {\n  return 1;\n}\n");
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(editor.getValue()).toBe("const userKeptTyping = true;");
+    expect(editor.executeEdits).not.toHaveBeenCalled();
+    expect(editor.setValue).not.toHaveBeenCalled();
   });
 
   it("does not run formatter fallback for read-only replay editors", async () => {

--- a/apps/web/src/features/editor/__tests__/CodeEditor.test.tsx
+++ b/apps/web/src/features/editor/__tests__/CodeEditor.test.tsx
@@ -161,6 +161,9 @@ const prettierMock = vi.hoisted(() => ({
     if (source === "function demo(){\n\t\treturn 1;\n}" && options.parser === "babel") {
       return "function demo() {\n  return 1;\n}\n";
     }
+    if (source === "const value:number=1;" && options.parser === "typescript") {
+      return "const value: number = 1;\n";
+    }
     return source;
   }),
 }));
@@ -502,6 +505,28 @@ describe("CodeEditor", () => {
     expect(prettierMock.format).toHaveBeenCalledWith(
       "function demo(){\n\t\treturn 1;\n}",
       expect.objectContaining({ parser: "babel", tabWidth: 2, useTabs: false }),
+    );
+  });
+
+  it("uses a TypeScript formatter fallback when Monaco format action leaves the document unchanged", async () => {
+    const { CodeEditor } = await import("../CodeEditor");
+    render(
+      <CodeEditor
+        language="typescript"
+        initialValue="const value:number=1;"
+        fontSize={14}
+        theme="dark"
+      />,
+    );
+    await waitFor(() => expect(monacoMock.editor.create).toHaveBeenCalledTimes(1));
+    const editor = monacoMock.editors[0];
+
+    pressEditorShortcut(editor, { key: "f", shiftKey: true, altKey: true });
+
+    await waitFor(() => expect(editor.getValue()).toBe("const value: number = 1;\n"));
+    expect(prettierMock.format).toHaveBeenCalledWith(
+      "const value:number=1;",
+      expect.objectContaining({ parser: "typescript", tabWidth: 2, useTabs: false }),
     );
   });
 

--- a/apps/web/src/features/editor/__tests__/CodeEditor.test.tsx
+++ b/apps/web/src/features/editor/__tests__/CodeEditor.test.tsx
@@ -692,6 +692,54 @@ describe("CodeEditor", () => {
     expect(onBeforeFormatApply).not.toHaveBeenCalled();
   });
 
+  it("does not apply pending formatter fallback after the editor language changes", async () => {
+    let resolveFormat: (formatted: string) => void = () => {
+      throw new Error("format promise was not created");
+    };
+    prettierMock.format.mockImplementationOnce(
+      () =>
+        new Promise<string>((resolve) => {
+          resolveFormat = resolve;
+        }),
+    );
+    const { CodeEditor } = await import("../CodeEditor");
+    const onBeforeFormatApply = vi.fn();
+    const { rerender } = render(
+      <CodeEditor
+        language="typescript"
+        initialValue="const value:number=1;"
+        fontSize={14}
+        theme="dark"
+        onBeforeFormatApply={onBeforeFormatApply}
+      />,
+    );
+    await waitFor(() => expect(monacoMock.editor.create).toHaveBeenCalledTimes(1));
+    const editor = monacoMock.editors[0];
+
+    pressEditorShortcut(editor, { key: "f", shiftKey: true, altKey: true });
+    await waitFor(() => expect(prettierMock.format).toHaveBeenCalledTimes(1));
+
+    rerender(
+      <CodeEditor
+        language="javascript"
+        initialValue="const value:number=1;"
+        fontSize={14}
+        theme="dark"
+        onBeforeFormatApply={onBeforeFormatApply}
+      />,
+    );
+    await waitFor(() => expect(monacoMock.editor.setModelLanguage).toHaveBeenCalledWith(monacoMock.models[0], "javascript"));
+    await act(async () => {
+      resolveFormat("const value: number = 1;\n");
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(editor.getValue()).toBe("const value:number=1;");
+    expect(editor.executeEdits).not.toHaveBeenCalled();
+    expect(onBeforeFormatApply).not.toHaveBeenCalled();
+  });
+
   it("does not run formatter fallback for read-only replay editors", async () => {
     const { CodeEditor } = await import("../CodeEditor");
     render(

--- a/apps/web/src/features/editor/__tests__/CodeEditor.test.tsx
+++ b/apps/web/src/features/editor/__tests__/CodeEditor.test.tsx
@@ -73,6 +73,7 @@ const monacoMock = vi.hoisted(() => {
     setScrollTop = vi.fn();
     setScrollLeft = vi.fn();
     trigger = vi.fn();
+    getAction = vi.fn(() => null as { run(): Promise<void> | void } | null);
     pushUndoStop = vi.fn(() => true);
     executeEdits = vi.fn((_source: string, edits: Array<{ text: string }>) => {
       const [edit] = edits;
@@ -535,6 +536,33 @@ describe("CodeEditor", () => {
       "function demo(){\n\t\treturn 1;\n}",
       expect.objectContaining({ parser: "babel", tabWidth: 2, useTabs: false }),
     );
+  });
+
+  it("uses the formatter fallback when the Monaco format action rejects", async () => {
+    const { CodeEditor } = await import("../CodeEditor");
+    const consoleWarn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    render(
+      <CodeEditor
+        language="javascript"
+        initialValue={"function demo(){\n\t\treturn 1;\n}"}
+        fontSize={14}
+        theme="dark"
+      />,
+    );
+    await waitFor(() => expect(monacoMock.editor.create).toHaveBeenCalledTimes(1));
+    const editor = monacoMock.editors[0];
+    const actionError = new Error("format action failed");
+    editor.getAction.mockReturnValueOnce({
+      run: vi.fn(async () => {
+        throw actionError;
+      }),
+    });
+
+    pressEditorShortcut(editor, { key: "f", shiftKey: true, altKey: true });
+
+    await waitFor(() => expect(editor.getValue()).toBe("function demo() {\n  return 1;\n}\n"));
+    expect(consoleWarn).toHaveBeenCalledWith("Monaco format action failed", actionError);
+    consoleWarn.mockRestore();
   });
 
   it("uses a TypeScript formatter fallback when Monaco format action leaves the document unchanged", async () => {

--- a/apps/web/src/features/editor/__tests__/CodeEditor.test.tsx
+++ b/apps/web/src/features/editor/__tests__/CodeEditor.test.tsx
@@ -66,7 +66,15 @@ const monacoMock = vi.hoisted(() => {
       this.options.model.setValue(next);
     });
     setPosition = vi.fn();
-    setSelection = vi.fn();
+    selection = {
+      startLineNumber: 1,
+      startColumn: 1,
+      endLineNumber: 1,
+      endColumn: 1,
+    };
+    setSelection = vi.fn((next: typeof this.selection) => {
+      this.selection = next;
+    });
     deltaDecorations = vi.fn((_oldDecorations: string[], newDecorations: unknown[]) =>
       newDecorations.map((_decoration, index) => `decoration-${index + 1}`),
     );
@@ -112,6 +120,10 @@ const monacoMock = vi.hoisted(() => {
 
     getModel() {
       return this.options.model;
+    }
+
+    getSelection() {
+      return this.selection;
     }
 
     dispose() {
@@ -517,6 +529,13 @@ describe("CodeEditor", () => {
     await waitFor(() => expect(monacoMock.editor.create).toHaveBeenCalledTimes(1));
     const editor = monacoMock.editors[0];
     const originalRange = monacoMock.models[0].getFullModelRange();
+    const originalSelection = {
+      startLineNumber: 2,
+      startColumn: 3,
+      endLineNumber: 2,
+      endColumn: 9,
+    };
+    editor.selection = originalSelection;
 
     pressEditorShortcut(editor, { key: "f", shiftKey: true, altKey: true });
 
@@ -530,6 +549,7 @@ describe("CodeEditor", () => {
           text: "function demo() {\n  return 1;\n}\n",
         }),
       ],
+      [originalSelection],
     );
     expect(editor.pushUndoStop).toHaveBeenCalledTimes(2);
     expect(prettierMock.format).toHaveBeenCalledWith(

--- a/apps/web/src/features/recorder/RecorderPage.tsx
+++ b/apps/web/src/features/recorder/RecorderPage.tsx
@@ -679,6 +679,7 @@ export function RecorderPage({ onEventBusReady }: RecorderPageProps = {}) {
             onCommand={(command) => {
               if (command === "run") void handleRun();
             }}
+            onBeforeFormatApply={() => stack.editorProducer.markNextChangeAsFormat()}
           />
           <CameraPreview
             stream={mediaStream}

--- a/apps/web/src/features/recorder/__tests__/RecorderPage.camera-preview.test.tsx
+++ b/apps/web/src/features/recorder/__tests__/RecorderPage.camera-preview.test.tsx
@@ -29,6 +29,7 @@ const recorderPageCameraPreviewMock = vi.hoisted(() => {
     stop: vi.fn(),
     dispose: vi.fn(),
     flushPending: vi.fn(),
+    markNextChangeAsFormat: vi.fn(() => vi.fn()),
     takeSnapshot: vi.fn(async () => null),
   } as unknown as EditorProducerHandle;
 

--- a/apps/web/src/features/recorder/__tests__/RecorderPage.test.tsx
+++ b/apps/web/src/features/recorder/__tests__/RecorderPage.test.tsx
@@ -43,6 +43,7 @@ const recorderPageMock = vi.hoisted(() => {
     previewHtml: "<div>ok</div>",
   }));
   const flushPending = vi.fn();
+  const markNextChangeAsFormat = vi.fn(() => vi.fn());
   const editorProducer = {
     start: vi.fn(),
     pause: vi.fn(),
@@ -50,6 +51,7 @@ const recorderPageMock = vi.hoisted(() => {
     stop: vi.fn(),
     dispose: vi.fn(),
     flushPending,
+    markNextChangeAsFormat,
     takeSnapshot: vi.fn(async () => null),
     setLanguage: vi.fn((next: RecordingLanguage) => {
       editorProducerDeps?.setModelLanguage?.(editorModel as never, next);
@@ -211,6 +213,7 @@ const recorderPageMock = vi.hoisted(() => {
       vi.mocked(editorProducer.dispose).mockClear();
       vi.mocked(editorProducer.takeSnapshot).mockClear();
       vi.mocked(editorProducer.setLanguage).mockClear();
+      vi.mocked(editorProducer.markNextChangeAsFormat).mockClear();
       mediaProducer.start.mockClear();
       mediaProducer.pause.mockClear();
       mediaProducer.resume.mockClear();
@@ -459,6 +462,18 @@ describe("RecorderPage", () => {
       }),
     );
     expect(recorderPageMock.flushPending).toHaveBeenCalledTimes(1);
+  });
+
+  it("marks editor fallback formatting as a format content change", async () => {
+    const { RecorderPage } = await import("../RecorderPage");
+    const cancel = vi.fn();
+    vi.mocked(recorderPageMock.editorProducer.markNextChangeAsFormat).mockReturnValueOnce(cancel);
+
+    render(<RecorderPage />);
+    await waitFor(() => expect(recorderPageMock.codeEditorProps?.onBeforeFormatApply).toBeTypeOf("function"));
+
+    expect(recorderPageMock.codeEditorProps?.onBeforeFormatApply?.()).toBe(cancel);
+    expect(recorderPageMock.editorProducer.markNextChangeAsFormat).toHaveBeenCalledTimes(1);
   });
 
   it("automatically runs changed code after the editor is idle", async () => {


### PR DESCRIPTION
## 关联

Refs #2（总控 issue，不在本 PR 中关闭）
Closes #215

## 改动点

- 格式化快捷键先执行 Monaco `editor.action.formatDocument`，若文档未变化则懒加载 Prettier，对 JavaScript/TypeScript 做可靠 fallback 格式化。
- 只读回放/远程面试编辑器会消费格式化快捷键但不改内容，避免回放状态被快捷键污染。
- 扩展 CodeEditor 单测与 Playwright 快捷键 e2e，覆盖 Tab 缩进后 `Shift+Alt+F` 归整代码。

## 影响范围

- 主要影响 `CodeEditor` 的格式化快捷键路径。
- `CodeEditor` 被录制页、回放页、远程面试工作台复用；已针对 read-only 场景增加单测，并回跑相关调用方测试。
- Prettier 仅在 Monaco action 无效且用户触发格式化时动态加载，不进入首屏主路径。

## GitNexus 影响分析摘要

- 风险等级: high（`CodeEditor` 被 Recorder / Player / Interview 复用）
- 关键骨架变更: 否，`npm run contract:local` 判定无 critical contract surface changed
- GitNexus 影响面: `RemoteInterviewWorkbenchView`、`ReplayPage`、`RecorderPage` 直接依赖 `CodeEditor`；二级影响包含 `CandidateInterviewPage` 和路由入口。
- 验证结果: 已补充 read-only 防护测试，并运行 `RecorderPage.test.tsx`、`ReplayPage.test.tsx`、`RemoteInterviewWorkbenchPage.test.tsx`、完整 `quality:local`。

## 自检

- [x] 未修改 `docs/progress.json` 或 `docs/progress.md`
- [x] 已运行 `npm run quality:local`，或说明无法运行的原因
- [x] 涉及 AI 字幕时，已记录一次 `npm run subtitle:postprocess:evaluate` 的“纠错并生成章节”效果验证结果，包含 `representativeOutputSource`、`overallEvaluationDurationMs`，并区分输出校验耗时与真实端到端耗时（不涉及 AI 字幕）
- [x] 涉及 AI 字幕点击链路、LLM worker、模型加载或性能时，已记录一次 `npm run subtitle:postprocess:runtime-benchmark` 结果，包含 `postprocessClickToResultReadyDurationMs`、`postProcessTimeoutBudgetMs` 和 `playbackProbeResponsiveDuringPostprocess`（不涉及 AI 字幕）
- [x] 已说明改动点和影响范围
- [x] 如果改动关键骨架，已补充契约测试并填写 GitNexus 影响分析摘要（非关键骨架；已填写 GitNexus 摘要）
- [ ] 已等待 repo-guard、codex 和 Copilot 评论，并完成必要审查