### PR TITLE
#217 合并字幕生成与 LLM 优化流程

### DIFF
--- a/apps/web/src/features/subtitles/SubtitlePanel.tsx
+++ b/apps/web/src/features/subtitles/SubtitlePanel.tsx
@@ -213,6 +213,65 @@ export function SubtitlePanel({
       status !== "generating" &&
       status !== "post-processing",
   );
+  const shouldGenerateBeforePostProcess = Boolean(postProcessor && canGenerate);
+  const primaryActionLabel = shouldGenerateBeforePostProcess
+    ? "生成字幕并优化"
+    : track && postProcessor
+      ? "优化字幕和章节"
+      : "生成字幕";
+  const canRunPrimaryAction = shouldGenerateBeforePostProcess
+    ? canGenerate
+    : track && postProcessor
+      ? canPostProcess
+      : canGenerate;
+
+  const postProcessTrack = async (
+    baseTrack: SubtitleTrack,
+    requestVersion: number,
+    abortController: AbortController,
+  ) => {
+    if (!postProcessor) return;
+    setStatus("post-processing");
+    try {
+      const correction = await runWithPostProcessTimeout(
+        postProcessor.process({
+          track: baseTrack,
+          context: postProcessorContext,
+          signal: abortController.signal,
+        }),
+        {
+          abortController,
+          timeoutMs: postProcessTimeoutMs,
+        },
+      );
+      if (!isCurrentGeneration(requestVersionRef, requestVersion, abortController)) return;
+      const result = applySubtitleCorrection(baseTrack, correction, { durationMs });
+      const hasInvalidCorrection = result.warnings.some((warning) => warning.code === "invalid-correction");
+      if (hasInvalidCorrection) {
+        setWarnings(result.warnings);
+        setStatus("ready");
+        return;
+      }
+      await store.saveWithChapters(result.track, result.chapters);
+      if (!isCurrentGeneration(requestVersionRef, requestVersion, abortController)) return;
+      setTrack(result.track);
+      setChapters(result.chapters);
+      setWarnings(result.warnings);
+      setStatus("ready");
+    } catch (err) {
+      if (isPostProcessTimeoutError(err)) {
+        if (requestVersionRef.current !== requestVersion || generationAbortRef.current !== abortController) return;
+        setError(formatSubtitleError(err));
+        setStatus("error");
+        return;
+      }
+      if (abortController.signal.aborted || requestVersionRef.current !== requestVersion) return;
+      if (requestStaleTransformersImportRecovery(err)) return;
+      setError(formatSubtitleError(err));
+      setStatus("error");
+    }
+  };
+
   const generateSubtitles = async () => {
     if (!recordingId || !mediaBlob || !hasAudio) return;
     const requestVersion = requestVersionRef.current + 1;
@@ -240,6 +299,10 @@ export function SubtitlePanel({
       if (!isCurrentGeneration(requestVersionRef, requestVersion, abortController)) return;
       setTrack(nextTrack);
       setChapters([]);
+      if (postProcessor) {
+        await postProcessTrack(nextTrack, requestVersion, abortController);
+        return;
+      }
       setStatus("ready");
     } catch (err) {
       if (abortController.signal.aborted || requestVersionRef.current !== requestVersion) return;
@@ -261,51 +324,23 @@ export function SubtitlePanel({
     cancelPendingPostProcessorWarmUp(postProcessorWarmUpRef, postProcessor);
     const abortController = new AbortController();
     generationAbortRef.current = abortController;
-    setStatus("post-processing");
     setError(null);
     setWarnings([]);
     try {
-      const correction = await runWithPostProcessTimeout(
-        postProcessor.process({
-          track,
-          context: postProcessorContext,
-          signal: abortController.signal,
-        }),
-        {
-          abortController,
-          timeoutMs: postProcessTimeoutMs,
-        },
-      );
-      if (!isCurrentGeneration(requestVersionRef, requestVersion, abortController)) return;
-      const result = applySubtitleCorrection(track, correction, { durationMs });
-      const hasInvalidCorrection = result.warnings.some((warning) => warning.code === "invalid-correction");
-      if (hasInvalidCorrection) {
-        setWarnings(result.warnings);
-        setStatus("ready");
-        return;
-      }
-      await store.saveWithChapters(result.track, result.chapters);
-      if (!isCurrentGeneration(requestVersionRef, requestVersion, abortController)) return;
-      setTrack(result.track);
-      setChapters(result.chapters);
-      setWarnings(result.warnings);
-      setStatus("ready");
-    } catch (err) {
-      if (isPostProcessTimeoutError(err)) {
-        if (requestVersionRef.current !== requestVersion || generationAbortRef.current !== abortController) return;
-        setError(formatSubtitleError(err));
-        setStatus("error");
-        return;
-      }
-      if (abortController.signal.aborted || requestVersionRef.current !== requestVersion) return;
-      if (requestStaleTransformersImportRecovery(err)) return;
-      setError(formatSubtitleError(err));
-      setStatus("error");
+      await postProcessTrack(track, requestVersion, abortController);
     } finally {
       if (generationAbortRef.current === abortController) {
         generationAbortRef.current = null;
       }
     }
+  };
+
+  const runPrimarySubtitleAction = () => {
+    if (!shouldGenerateBeforePostProcess && track && postProcessor) {
+      void postProcessSubtitles();
+      return;
+    }
+    void generateSubtitles();
   };
 
   return (
@@ -322,35 +357,19 @@ export function SubtitlePanel({
           ) : null}
         </div>
         <div className="flex max-w-full shrink-0 flex-wrap items-center justify-end gap-2">
-          {track && postProcessor ? (
-            <button
-              type="button"
-              aria-label="纠错并生成章节"
-              disabled={!canPostProcess}
-              onClick={postProcessSubtitles}
-              className={buttonClassName}
-            >
-              {status === "post-processing" ? (
-                <Loader2 aria-hidden size={14} className="animate-spin" />
-              ) : (
-                <WandSparkles aria-hidden size={14} />
-              )}
-              <span>纠错并生成章节</span>
-            </button>
-          ) : null}
           <button
             type="button"
-            aria-label="生成字幕"
-            disabled={!canGenerate}
-            onClick={generateSubtitles}
+            aria-label={primaryActionLabel}
+            disabled={!canRunPrimaryAction}
+            onClick={runPrimarySubtitleAction}
             className={buttonClassName}
           >
-            {status === "generating" ? (
+            {status === "generating" || status === "post-processing" ? (
               <Loader2 aria-hidden size={14} className="animate-spin" />
             ) : (
               <WandSparkles aria-hidden size={14} />
             )}
-            <span>生成字幕</span>
+            <span>{primaryActionLabel}</span>
           </button>
         </div>
       </div>

--- a/apps/web/src/features/subtitles/__tests__/SubtitlePanel.test.tsx
+++ b/apps/web/src/features/subtitles/__tests__/SubtitlePanel.test.tsx
@@ -55,6 +55,10 @@ async function flushPromises() {
   await Promise.resolve();
 }
 
+const GENERATE_SUBTITLES_LABEL = "生成字幕";
+const GENERATE_AND_OPTIMIZE_LABEL = "生成字幕并优化";
+const OPTIMIZE_SUBTITLES_LABEL = "优化字幕和章节";
+
 describe("SubtitlePanel", () => {
   afterEach(() => {
     vi.restoreAllMocks();
@@ -86,10 +90,11 @@ describe("SubtitlePanel", () => {
         onSeek={onSeek}
         store={store}
         transcriber={transcriber}
+        postProcessor={null}
       />,
     );
 
-    const generateButton = screen.getByRole("button", { name: "生成字幕" });
+    const generateButton = screen.getByRole("button", { name: GENERATE_SUBTITLES_LABEL });
 
     await waitFor(() => expect(generateButton).not.toBeDisabled());
 
@@ -111,6 +116,83 @@ describe("SubtitlePanel", () => {
         source: "huggingface-local",
       }),
     );
+  });
+
+  it("uses one click to show ASR subtitles before applying local LLM corrections and chapters", async () => {
+    const store = createMemorySubtitleStore();
+    const transcription = createDeferred<SubtitleTrackDraft>();
+    const postProcessing = createDeferred<SubtitleCorrectionResult>();
+    const transcriber: SubtitleTranscriber = {
+      transcribe: vi.fn(() => transcription.promise),
+    };
+    const postProcessor: SubtitlePostProcessor = {
+      process: vi.fn(() => postProcessing.promise),
+    };
+
+    render(
+      <SubtitlePanel
+        recordingId="recording-1"
+        mediaBlob={new Blob(["webm"], { type: "video/webm" })}
+        hasAudio
+        durationMs={3_000}
+        currentTimeMs={1_500}
+        onSeek={vi.fn()}
+        store={store}
+        transcriber={transcriber}
+        postProcessor={postProcessor}
+      />,
+    );
+
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: GENERATE_AND_OPTIMIZE_LABEL })).not.toBeDisabled(),
+    );
+    fireEvent.click(screen.getByRole("button", { name: GENERATE_AND_OPTIMIZE_LABEL }));
+
+    await act(async () => {
+      transcription.resolve({
+        model: "onnx-community/whisper-tiny",
+        source: "huggingface-local",
+        segments: [
+          { id: "subtitle-1", startMs: 0, endMs: 1_000, text: "use state hook" },
+          { id: "subtitle-2", startMs: 1_000, endMs: 3_000, text: "render result" },
+        ],
+      });
+      await flushPromises();
+    });
+
+    expect(screen.getByText("use state hook")).toBeInTheDocument();
+    expect(screen.getByText("render result")).toBeInTheDocument();
+    expect(postProcessor.process).toHaveBeenCalledWith(
+      expect.objectContaining({
+        track: expect.objectContaining({
+          recordingId: "recording-1",
+          segments: expect.arrayContaining([
+            expect.objectContaining({ id: "subtitle-1", text: "use state hook" }),
+          ]),
+        }),
+      }),
+    );
+    await expect(store.load("recording-1")).resolves.toEqual(
+      expect.objectContaining({
+        segments: expect.arrayContaining([
+          expect.objectContaining({ id: "subtitle-2", text: "render result" }),
+        ]),
+      }),
+    );
+
+    await act(async () => {
+      postProcessing.resolve({
+        segments: [{ id: "subtitle-1", text: "useState hook" }],
+        chapters: [{ title: "代码实现", startMs: 1_000, endMs: 3_000 }],
+      });
+      await flushPromises();
+    });
+
+    await waitFor(() => expect(screen.getByText("useState hook")).toBeInTheDocument());
+    expect(screen.getByRole("button", { name: /代码实现/ })).toBeInTheDocument();
+    await expect(store.loadChapters("recording-1")).resolves.toEqual([
+      { id: "chapter-1", title: "代码实现", startMs: 1_000, endMs: 3_000 },
+    ]);
   });
 
   it("recovers from stale Transformers chunks during subtitle generation without showing the raw import error", async () => {
@@ -143,10 +225,11 @@ describe("SubtitlePanel", () => {
         onSeek={vi.fn()}
         store={store}
         transcriber={transcriber}
+        postProcessor={null}
       />,
     );
 
-    const generateButton = screen.getByRole("button", { name: "生成字幕" });
+    const generateButton = screen.getByRole("button", { name: GENERATE_SUBTITLES_LABEL });
     await waitFor(() => expect(generateButton).not.toBeDisabled());
 
     fireEvent.click(generateButton);
@@ -193,11 +276,11 @@ describe("SubtitlePanel", () => {
       />,
     );
 
-    await waitFor(() => expect(screen.getByRole("button", { name: "生成字幕" })).not.toBeDisabled());
-    fireEvent.click(screen.getByRole("button", { name: "生成字幕" }));
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: GENERATE_AND_OPTIMIZE_LABEL })).not.toBeDisabled(),
+    );
+    fireEvent.click(screen.getByRole("button", { name: GENERATE_AND_OPTIMIZE_LABEL }));
     await waitFor(() => expect(screen.getByText("use state hook")).toBeInTheDocument());
-
-    fireEvent.click(screen.getByRole("button", { name: "纠错并生成章节" }));
 
     await waitFor(() => expect(screen.getByText("useState hook")).toBeInTheDocument());
     expect(screen.getByRole("button", { name: /代码实现/ })).toHaveAttribute(
@@ -241,7 +324,7 @@ describe("SubtitlePanel", () => {
     render(
       <SubtitlePanel
         recordingId="recording-1"
-        mediaBlob={new Blob(["webm"], { type: "video/webm" })}
+        mediaBlob={null}
         hasAudio
         durationMs={3_000}
         currentTimeMs={500}
@@ -260,7 +343,7 @@ describe("SubtitlePanel", () => {
 
     await waitFor(() => expect(screen.getByText("use state hook")).toBeInTheDocument());
 
-    fireEvent.click(screen.getByRole("button", { name: "纠错并生成章节" }));
+    fireEvent.click(screen.getByRole("button", { name: OPTIMIZE_SUBTITLES_LABEL }));
     fireEvent.click(screen.getByRole("button", { name: "render result" }));
     fireEvent.click(screen.getByRole("button", { name: /已有章节/ }));
 
@@ -306,11 +389,11 @@ describe("SubtitlePanel", () => {
       />,
     );
 
-    await waitFor(() => expect(screen.getByRole("button", { name: "生成字幕" })).not.toBeDisabled());
-    fireEvent.click(screen.getByRole("button", { name: "生成字幕" }));
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: GENERATE_AND_OPTIMIZE_LABEL })).not.toBeDisabled(),
+    );
+    fireEvent.click(screen.getByRole("button", { name: GENERATE_AND_OPTIMIZE_LABEL }));
     await waitFor(() => expect(screen.getByText("use state hook")).toBeInTheDocument());
-
-    fireEvent.click(screen.getByRole("button", { name: "纠错并生成章节" }));
 
     await waitFor(() => expect(screen.getByRole("alert")).toHaveTextContent("LLM JSON parse failed"));
     expect(screen.getByText("use state hook")).toBeInTheDocument();
@@ -347,7 +430,7 @@ describe("SubtitlePanel", () => {
     render(
       <SubtitlePanel
         recordingId="recording-1"
-        mediaBlob={new Blob(["webm"], { type: "video/webm" })}
+        mediaBlob={null}
         hasAudio
         durationMs={1_000}
         currentTimeMs={0}
@@ -366,7 +449,7 @@ describe("SubtitlePanel", () => {
 
     await waitFor(() => expect(screen.getByText("use state hook")).toBeInTheDocument());
 
-    fireEvent.click(screen.getByRole("button", { name: "纠错并生成章节" }));
+    fireEvent.click(screen.getByRole("button", { name: OPTIMIZE_SUBTITLES_LABEL }));
 
     await waitFor(() => expect(reload).toHaveBeenCalledTimes(1));
     expect(screen.queryByRole("alert")).not.toBeInTheDocument();
@@ -401,7 +484,7 @@ describe("SubtitlePanel", () => {
     render(
       <SubtitlePanel
         recordingId="recording-1"
-        mediaBlob={new Blob(["webm"], { type: "video/webm" })}
+        mediaBlob={null}
         hasAudio
         durationMs={1_000}
         currentTimeMs={0}
@@ -420,7 +503,7 @@ describe("SubtitlePanel", () => {
 
     await waitFor(() => expect(screen.getByText("use state hook")).toBeInTheDocument());
 
-    fireEvent.click(screen.getByRole("button", { name: "纠错并生成章节" }));
+    fireEvent.click(screen.getByRole("button", { name: OPTIMIZE_SUBTITLES_LABEL }));
 
     await waitFor(() => expect(screen.getByRole("alert")).toHaveTextContent("atomic write failed"));
     expect(screen.getByText("use state hook")).toBeInTheDocument();
@@ -454,7 +537,7 @@ describe("SubtitlePanel", () => {
     render(
       <SubtitlePanel
         recordingId="recording-1"
-        mediaBlob={new Blob(["webm"], { type: "video/webm" })}
+        mediaBlob={null}
         hasAudio
         durationMs={3_000}
         currentTimeMs={500}
@@ -473,7 +556,7 @@ describe("SubtitlePanel", () => {
 
     await waitFor(() => expect(screen.getByRole("button", { name: /已有章节/ })).toBeInTheDocument());
 
-    fireEvent.click(screen.getByRole("button", { name: "纠错并生成章节" }));
+    fireEvent.click(screen.getByRole("button", { name: OPTIMIZE_SUBTITLES_LABEL }));
 
     await waitFor(() =>
       expect(screen.getByRole("alert")).toHaveTextContent(
@@ -520,7 +603,7 @@ describe("SubtitlePanel", () => {
     render(
       <SubtitlePanel
         recordingId="recording-1"
-        mediaBlob={new Blob(["webm"], { type: "video/webm" })}
+        mediaBlob={null}
         hasAudio
         durationMs={3_000}
         currentTimeMs={500}
@@ -542,7 +625,7 @@ describe("SubtitlePanel", () => {
 
     vi.useFakeTimers();
     try {
-      fireEvent.click(screen.getByRole("button", { name: "纠错并生成章节" }));
+      fireEvent.click(screen.getByRole("button", { name: OPTIMIZE_SUBTITLES_LABEL }));
       await act(async () => {
         await flushPromises();
       });
@@ -567,7 +650,7 @@ describe("SubtitlePanel", () => {
     expect(onSeek).toHaveBeenCalledWith(0);
     await expect(store.load("recording-1")).resolves.toEqual(originalTrack);
     await expect(store.loadChapters("recording-1")).resolves.toEqual(existingChapters);
-    expect(screen.getByRole("button", { name: "纠错并生成章节" })).not.toBeDisabled();
+    expect(screen.getByRole("button", { name: OPTIMIZE_SUBTITLES_LABEL })).not.toBeDisabled();
   });
 
   it("ignores stale local LLM timeout after switching recordings", async () => {
@@ -600,7 +683,7 @@ describe("SubtitlePanel", () => {
       ),
     };
     const props = {
-      mediaBlob: new Blob(["webm"], { type: "video/webm" }),
+      mediaBlob: null,
       hasAudio: true,
       durationMs: 1_000,
       currentTimeMs: 0,
@@ -623,7 +706,7 @@ describe("SubtitlePanel", () => {
 
     vi.useFakeTimers();
     try {
-      fireEvent.click(screen.getByRole("button", { name: "纠错并生成章节" }));
+      fireEvent.click(screen.getByRole("button", { name: OPTIMIZE_SUBTITLES_LABEL }));
       await act(async () => {
         await flushPromises();
       });
@@ -665,10 +748,11 @@ describe("SubtitlePanel", () => {
         onSeek={vi.fn()}
         store={createMemorySubtitleStore()}
         transcriber={transcriber}
+        postProcessor={null}
       />,
     );
 
-    const generateButton = screen.getByRole("button", { name: "生成字幕" });
+    const generateButton = screen.getByRole("button", { name: GENERATE_SUBTITLES_LABEL });
 
     await waitFor(() => expect(generateButton).not.toBeDisabled());
 
@@ -704,10 +788,11 @@ describe("SubtitlePanel", () => {
             segments: [],
           })),
         }}
+        postProcessor={null}
       />,
     );
 
-    const generateButton = screen.getByRole("button", { name: "生成字幕" });
+    const generateButton = screen.getByRole("button", { name: GENERATE_SUBTITLES_LABEL });
 
     await waitFor(() => expect(generateButton).toBeDisabled());
 
@@ -786,12 +871,13 @@ describe("SubtitlePanel", () => {
         onSeek={vi.fn()}
         store={store}
         transcriber={transcriber}
+        postProcessor={null}
       />,
     );
 
-    await waitFor(() => expect(screen.getByRole("button", { name: "生成字幕" })).not.toBeDisabled());
+    await waitFor(() => expect(screen.getByRole("button", { name: GENERATE_SUBTITLES_LABEL })).not.toBeDisabled());
 
-    fireEvent.click(screen.getByRole("button", { name: "生成字幕" }));
+    fireEvent.click(screen.getByRole("button", { name: GENERATE_SUBTITLES_LABEL }));
 
     rerender(
       <SubtitlePanel
@@ -803,6 +889,7 @@ describe("SubtitlePanel", () => {
         onSeek={vi.fn()}
         store={store}
         transcriber={transcriber}
+        postProcessor={null}
       />,
     );
 
@@ -1201,7 +1288,7 @@ describe("SubtitlePanel", () => {
     render(
       <SubtitlePanel
         recordingId="recording-1"
-        mediaBlob={new Blob(["webm"], { type: "video/webm" })}
+        mediaBlob={null}
         hasAudio
         durationMs={1_000}
         currentTimeMs={0}
@@ -1225,7 +1312,7 @@ describe("SubtitlePanel", () => {
     expect(requestIdleCallback).toHaveBeenCalledTimes(1);
     expect(postProcessorWarmUp).not.toHaveBeenCalled();
 
-    fireEvent.click(screen.getByRole("button", { name: "纠错并生成章节" }));
+    fireEvent.click(screen.getByRole("button", { name: OPTIMIZE_SUBTITLES_LABEL }));
 
     await waitFor(() => expect(process).toHaveBeenCalledTimes(1));
     await waitFor(() => expect(screen.getByText("useState hook")).toBeInTheDocument());
@@ -1277,7 +1364,7 @@ describe("SubtitlePanel", () => {
     await waitFor(() => expect(screen.getByText("Old subtitles.")).toBeInTheDocument());
     expect(requestIdleCallback).toHaveBeenCalledTimes(1);
 
-    fireEvent.click(screen.getByRole("button", { name: "生成字幕" }));
+    fireEvent.click(screen.getByRole("button", { name: GENERATE_AND_OPTIMIZE_LABEL }));
 
     await waitFor(() => expect(screen.getByText("New subtitles.")).toBeInTheDocument());
     expect(cancelIdleCallback).toHaveBeenCalledWith(1);
@@ -1338,7 +1425,7 @@ describe("SubtitlePanel", () => {
     await waitFor(() => expect(screen.getByText("Old subtitles.")).toBeInTheDocument());
     expect(requestIdleCallback).toHaveBeenCalledTimes(1);
 
-    fireEvent.click(screen.getByRole("button", { name: "生成字幕" }));
+    fireEvent.click(screen.getByRole("button", { name: GENERATE_AND_OPTIMIZE_LABEL }));
 
     await waitFor(() => expect(cancelIdleCallback).toHaveBeenCalledWith(1));
     await act(async () => {
@@ -1424,7 +1511,7 @@ describe("SubtitlePanel", () => {
       await flushPromises();
     });
 
-    fireEvent.click(screen.getByRole("button", { name: "生成字幕" }));
+    fireEvent.click(screen.getByRole("button", { name: GENERATE_AND_OPTIMIZE_LABEL }));
 
     await waitFor(() => expect(transcribe).toHaveBeenCalledTimes(1));
     expect(events).toEqual(["warmUp", "dispose", "transcribe"]);
@@ -1469,7 +1556,7 @@ describe("SubtitlePanel", () => {
     render(
       <SubtitlePanel
         recordingId="recording-1"
-        mediaBlob={new Blob(["webm"], { type: "video/webm" })}
+        mediaBlob={null}
         hasAudio
         durationMs={1_000}
         currentTimeMs={0}
@@ -1499,7 +1586,7 @@ describe("SubtitlePanel", () => {
       await flushPromises();
     });
 
-    fireEvent.click(screen.getByRole("button", { name: "纠错并生成章节" }));
+    fireEvent.click(screen.getByRole("button", { name: OPTIMIZE_SUBTITLES_LABEL }));
 
     await waitFor(() => expect(process).toHaveBeenCalledTimes(1));
     expect(events).toEqual(["warmUp", "process"]);

--- a/apps/web/src/features/subtitles/__tests__/SubtitlePanel.test.tsx
+++ b/apps/web/src/features/subtitles/__tests__/SubtitlePanel.test.tsx
@@ -370,9 +370,13 @@ describe("SubtitlePanel", () => {
       })),
     };
     const postProcessor: SubtitlePostProcessor = {
-      process: vi.fn(async () => {
-        throw new Error("LLM JSON parse failed");
-      }),
+      process: vi
+        .fn()
+        .mockRejectedValueOnce(new Error("LLM JSON parse failed"))
+        .mockResolvedValueOnce({
+          segments: [{ id: "subtitle-1", text: "useState hook" }],
+          chapters: [{ title: "失败后重试", startMs: 0, endMs: 1_000 }],
+        }),
     };
 
     render(
@@ -397,6 +401,15 @@ describe("SubtitlePanel", () => {
 
     await waitFor(() => expect(screen.getByRole("alert")).toHaveTextContent("LLM JSON parse failed"));
     expect(screen.getByText("use state hook")).toBeInTheDocument();
+
+    const retryButton = screen.getByRole("button", { name: GENERATE_AND_OPTIMIZE_LABEL });
+    await waitFor(() => expect(retryButton).not.toBeDisabled());
+    fireEvent.click(retryButton);
+
+    await waitFor(() => expect(screen.getByText("useState hook")).toBeInTheDocument());
+    expect(screen.getByRole("button", { name: /失败后重试/ })).toBeInTheDocument();
+    expect(transcriber.transcribe).toHaveBeenCalledTimes(2);
+    expect(postProcessor.process).toHaveBeenCalledTimes(2);
   });
 
   it("recovers from stale Transformers chunks during local LLM post-processing without showing the raw import error", async () => {

--- a/apps/web/src/features/subtitles/__tests__/SubtitlePanel.test.tsx
+++ b/apps/web/src/features/subtitles/__tests__/SubtitlePanel.test.tsx
@@ -412,6 +412,66 @@ describe("SubtitlePanel", () => {
     expect(postProcessor.process).toHaveBeenCalledTimes(2);
   });
 
+  it("clears persisted chapters after regenerating ASR subtitles when local LLM post-processing fails", async () => {
+    const previousTrack: SubtitleTrack = {
+      recordingId: "recording-1",
+      generatedAt: "2026-05-28T00:00:00.000Z",
+      model: "onnx-community/whisper-tiny",
+      source: "huggingface-local",
+      segments: [{ id: "subtitle-1", startMs: 0, endMs: 1_000, text: "old subtitle" }],
+    };
+    const store = createMemorySubtitleStore();
+    await store.saveWithChapters(previousTrack, [
+      { id: "chapter-1", title: "旧章节", startMs: 0, endMs: 1_000 },
+    ]);
+    const transcriber: SubtitleTranscriber = {
+      transcribe: vi.fn(async () => ({
+        model: "onnx-community/whisper-tiny",
+        source: "huggingface-local" as const,
+        segments: [{ id: "subtitle-1", startMs: 0, endMs: 1_000, text: "new ASR subtitle" }],
+      })),
+    };
+    const postProcessor: SubtitlePostProcessor = {
+      process: vi.fn(async () => {
+        throw new Error("LLM JSON parse failed");
+      }),
+    };
+    const panelProps = {
+      recordingId: "recording-1",
+      mediaBlob: new Blob(["webm"], { type: "video/webm" }),
+      hasAudio: true,
+      durationMs: 1_000,
+      currentTimeMs: 0,
+      onSeek: vi.fn(),
+      store,
+      transcriber,
+      postProcessor,
+    } satisfies Parameters<typeof SubtitlePanel>[0];
+
+    const { unmount } = render(<SubtitlePanel {...panelProps} />);
+
+    await waitFor(() => expect(screen.getByText("old subtitle")).toBeInTheDocument());
+    expect(screen.getByRole("button", { name: /旧章节/ })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: GENERATE_AND_OPTIMIZE_LABEL }));
+
+    await waitFor(() => expect(screen.getByText("new ASR subtitle")).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByRole("alert")).toHaveTextContent("LLM JSON parse failed"));
+    expect(screen.queryByRole("button", { name: /旧章节/ })).not.toBeInTheDocument();
+    await expect(store.loadChapters("recording-1")).resolves.toEqual([]);
+    await expect(store.load("recording-1")).resolves.toEqual(
+      expect.objectContaining({
+        segments: [expect.objectContaining({ text: "new ASR subtitle" })],
+      }),
+    );
+
+    unmount();
+    render(<SubtitlePanel {...panelProps} mediaBlob={null} />);
+
+    await waitFor(() => expect(screen.getByText("new ASR subtitle")).toBeInTheDocument());
+    expect(screen.queryByRole("button", { name: /旧章节/ })).not.toBeInTheDocument();
+  });
+
   it("recovers from stale Transformers chunks during local LLM post-processing without showing the raw import error", async () => {
     const originalTrack: SubtitleTrack = {
       recordingId: "recording-1",

--- a/apps/web/src/features/subtitles/__tests__/subtitlePostProcessorRuntimeBenchmark.test.tsx
+++ b/apps/web/src/features/subtitles/__tests__/subtitlePostProcessorRuntimeBenchmark.test.tsx
@@ -122,7 +122,7 @@ describe("subtitle postprocessor runtime benchmark", () => {
     render(
       <SubtitlePanel
         recordingId="recording-1"
-        mediaBlob={new Blob(["webm"], { type: "video/webm" })}
+        mediaBlob={null}
         hasAudio
         durationMs={3_000}
         currentTimeMs={500}
@@ -138,7 +138,7 @@ describe("subtitle postprocessor runtime benchmark", () => {
     await waitFor(() => expect(warmUpEndedAt).toBeGreaterThanOrEqual(warmUpStartedAt));
 
     clickStartedAt = performance.now();
-    fireEvent.click(screen.getByRole("button", { name: "纠错并生成章节" }));
+    fireEvent.click(screen.getByRole("button", { name: "优化字幕和章节" }));
     await waitFor(() => expect(postProcessor.process).toHaveBeenCalled());
 
     fireEvent.click(screen.getByRole("button", { name: "render result" }));

--- a/docs/技术方案.md
+++ b/docs/技术方案.md
@@ -2981,6 +2981,7 @@ P1 云端方案的主线是：**本地录制包先完整生成，云端只负责
 - 回放页在编辑器下方展示字幕，当前播放时间命中的字幕行高亮并自动滚动到可见区域。
 - 点击字幕行调用播放器 `seek(startMs)`，跳转到对应讲解时间继续回放。
 - 有音频的回放页可以提前 warm-up 本地 ASR 模型，点击生成时复用已加载 pipeline；warm-up 只下载/初始化模型，不提前转写音频，同一录制媒体只尝试一次预热，避免渲染抖动造成重复模型加载。
+- 当本地 LLM 后处理能力可用时，字幕主操作按钮可以显式发起一键 ASR -> LLM 流程：先生成、保存并展示 ASR 字幕，再在后台继续做纠错和章节生成；LLM 完成后用校验通过的结果刷新字幕与章节。
 - 无音频、媒体缺失、模型加载失败、识别失败时，回放主流程不受影响，只展示可恢复的错误或降级状态。
 
 默认不进入最小展示版的能力：
@@ -2988,7 +2989,7 @@ P1 云端方案的主线是：**本地录制包先完整生成，云端只负责
 - 不把字幕写入 `RecordingPackageV1` 主 schema，避免核心包校验和迁移复杂度扩大。
 - 不默认上传录音到 Hugging Face Inference API、Spaces 或其他第三方托管服务。
 - 不在前端代码、文档、测试 fixture、PR 描述中保存 Hugging Face token。
-- 不把 LLM 纠错或章节生成作为基础字幕验收前置条件；二者是 ASR 字幕生成之后的增强链路，失败时必须回退到原始 ASR 字幕。
+- 不把 LLM 纠错或章节生成作为基础字幕验收前置条件；二者是 ASR 字幕生成之后的增强阶段，可以由同一次用户点击的主操作串联触发，失败时必须保留原始 ASR 字幕并允许重试。
 
 ### 2. 稳定架构
 
@@ -3034,7 +3035,7 @@ P1+ 最小展示版默认使用 Hugging Face Hub 上兼容 Transformers.js 的 A
 - 任务：`automatic-speech-recognition`
 - 运行库：`@huggingface/transformers`
 - 识别语言策略：调用 Whisper 时使用 `task: "transcribe"` 和 `language: "chinese"`，优先覆盖中文讲解这个主要产品场景；英文短句和代码术语尽量保留在原始 ASR 字幕中，后续 LLM 后处理只负责纠错和章节生成，不再额外说明语言风格。
-- 加载策略：有音频的回放页可以先调用 `SubtitleTranscriber.warmUp()` 动态 import 和下载模型，降低首次点击“生成字幕”的等待；实际音频转写仍只在用户点击后发生。同一录制媒体只触发一次 warm-up，避免上层 render 或测试替身身份不稳定时重复加载。无音频或纯事件流回放不主动加载模型，warm-up 失败不阻断回放，点击生成时可以重试。
+- 加载策略：有音频的回放页可以先调用 `SubtitleTranscriber.warmUp()` 动态 import 和下载模型，降低首次点击字幕主操作的等待；实际音频转写仍只在用户点击后发生。同一录制媒体只触发一次 warm-up，避免上层 render 或测试替身身份不稳定时重复加载。无音频或纯事件流回放不主动加载模型，warm-up 失败不阻断回放，点击生成时可以重试。
 
 公开模型不需要 Hugging Face token。若后续切换到私有模型或团队模型，token 只能通过本机登录态、环境变量或后端密钥管理提供：
 
@@ -3085,23 +3086,23 @@ export type SubtitleCorrectionResult = {
 
 后处理效果与稳定性评测基线：
 
-- `npm run subtitle:postprocess:evaluate` 使用固定输入 fixture 评估“纠错并生成章节”输出；代表性样例会通过当前 `SubtitlePostProcessor` 接口运行，并用 deterministic mock model output 替代真实 Hugging Face 推理结果，避免把网络、模型下载或 WebGPU/WASM 初始化耗时混入模型输出质量判断。
+- `npm run subtitle:postprocess:evaluate` 使用固定输入 fixture 评估字幕后处理的纠错和章节输出；代表性样例会通过当前 `SubtitlePostProcessor` 接口运行，并用 deterministic mock model output 替代真实 Hugging Face 推理结果，避免把网络、模型下载或 WebGPU/WASM 初始化耗时混入模型输出质量判断。
 - 评测样例至少覆盖中文前端讲解、代码变量/框架术语修正、稀疏 `segments` 输出、章节标题命中和章节时间线合法性；同时包含非法 JSON、unknown segment、重复 segment 和章节乱序/重叠的负例，确保后续模型或 prompt 变更能暴露稳定性回退。
 - 该命令输出 `representativeOutputSource=postprocessor-runner` 证明代表性样例来自当前后处理器接口调用，而不是直接读取 fixture 内嵌答案；负例仍使用静态坏输出验证 evaluator 能暴露非法 JSON、unknown segment、重复 segment 和非法章节时间线。
 - 该命令输出 `overallEvaluationDurationMs` 作为本地评测入口从 fixture 样例评估到指标生成的整体耗时；`averageFixtureValidationDurationMs` 与 `maxFixtureValidationDurationMs` 只表示单条输出解析和契约校验耗时。
-- 这些耗时字段可作为后续 prompt、模型或 fallback 变更的可重复本地性能基线，但不能替代浏览器点击“纠错并生成章节”后的真实端到端等待时间。
+- 这些耗时字段可作为后续 prompt、模型或 fallback 变更的可重复本地性能基线，但不能替代浏览器点击主操作触发后处理后的真实端到端等待时间。
 - PR 涉及 AI 字幕后处理时，需要在描述或自检中记录一次该命令输出摘要，包括 `representativeOutputSource`、代表性样例通过率、JSON/segment/章节指标、`overallEvaluationDurationMs` 以及输出校验耗时，作为 repo-guard、Codex 和人工审查的共同质量基线；真实模型下载、初始化、推理和 worker 通信耗时需要用单独的 runtime benchmark 记录。
-- `npm run subtitle:postprocess:runtime-benchmark` 覆盖浏览器侧 React/jsdom 点击路径：预置已有字幕轨，注入可控 mock postProcessor，点击“纠错并生成章节”，记录模型/worker 预热、点击到 worker 调用、mock 推理等待、结果提交到 UI 和点击到结果可用的耗时。
-- runtime benchmark 输出 `postprocessClickToResultReadyDurationMs`、`postProcessTimeoutBudgetMs`、`modelWorkerWarmUpDurationMs`、`clickToPostProcessorCallDurationMs`、`mockWorkerInferenceDurationMs`、`resultToUiCommitDurationMs` 和 `playbackProbeResponsiveDuringPostprocess`。其中 `postProcessTimeoutBudgetMs` 是点击“纠错并生成章节”后允许本地 LLM worker 返回的默认超时预算；`playbackProbeResponsiveDuringPostprocess=true` 表示 LLM 后处理 pending 时字幕行和已有章节仍能触发 seek，不阻塞播放操作。
+- `npm run subtitle:postprocess:runtime-benchmark` 覆盖浏览器侧 React/jsdom 点击路径：预置已有字幕轨，注入可控 mock postProcessor，点击主操作进入“优化字幕和章节”，记录模型/worker 预热、点击到 worker 调用、mock 推理等待、结果提交到 UI 和点击到结果可用的耗时。
+- runtime benchmark 输出 `postprocessClickToResultReadyDurationMs`、`postProcessTimeoutBudgetMs`、`modelWorkerWarmUpDurationMs`、`clickToPostProcessorCallDurationMs`、`mockWorkerInferenceDurationMs`、`resultToUiCommitDurationMs` 和 `playbackProbeResponsiveDuringPostprocess`。其中 `postProcessTimeoutBudgetMs` 是主操作触发本地 LLM worker 后允许返回的默认超时预算；`playbackProbeResponsiveDuringPostprocess=true` 表示 LLM 后处理 pending 时字幕行和已有章节仍能触发 seek，不阻塞播放操作。
 - 该 runtime benchmark 不下载真实 Hugging Face 模型，也不调用外部 API；它用于稳定覆盖 UI 点击链路、worker/推理等待的时间分段和播放不阻塞契约。真实模型冷启动、网络缓存、WASM 初始化和长字幕推理仍需要在后续模型变更 PR 中补充真实浏览器 smoke 或手工记录。
 - `npm run subtitle:postprocess:real-model-smoke` 是手工执行的真实默认模型 smoke/benchmark：它使用当前公开 `ceilf6/code-tape-subtitle-postprocessor-onnx` 和代表性短字幕 fixture 跑一次 `SubtitlePostProcessor`，从 Web runtime 导出的默认配置读取并校验实际 `wasm/q8` 后端，输出 `pipelineReadyDurationMs`、`generationDurationMs`、`totalDurationMs`、`jsonValid`、`segmentReferenceValid`、`chapterTimelineValid`、术语/章节命中率以及 `errorType`。若脚本期望配置和 Web runtime 默认配置不一致，必须直接失败而不是输出误导性基线。该命令会下载或读取真实模型缓存，受网络、浏览器/Node WASM 后端和机器性能影响，不纳入 `quality:local` 硬门禁；涉及默认模型、prompt 或真实性能判断的 PR 应手工记录一次输出摘要。
 
 浏览器本地 LLM 的运行约束：
 
 - 推理发生在用户浏览器内，优先 WebGPU，缺失时回退 WASM/CPU；参数规模、量化类型、prompt 长度和输出 token 数以首次加载、内存占用和移动端可用性为硬约束。
-- 模型加载可以在回放页空闲时提前 warm-up，但只下载/初始化模型，不提前处理字幕内容；有音频媒体时可以预热本地 LLM，ASR 完成后用户触发“纠错并生成章节”才运行后处理。
+- 模型加载可以在回放页空闲时提前 warm-up，但只下载/初始化模型，不提前处理字幕内容；有音频媒体时可以预热本地 LLM，LLM 后处理只能由用户点击字幕主操作触发，不在页面加载、ASR warm-up 或媒体切换时自动处理字幕内容。有音频且可转写时，主操作先运行 ASR 并立即展示结果，再继续运行 LLM 后处理；已有字幕但缺少可转写媒体时，主操作只运行“优化字幕和章节”。
 - LLM 生成阶段必须在浏览器 Web Worker 中运行；`SubtitlePanel` 只能更新后台处理状态和接收最终结果，字幕行、章节跳转和播放器进度条仍留在主线程响应用户操作。录制切换、用户取消或组件卸载时，主线程通过 `AbortController` 终止未完成 worker 请求，避免旧结果污染当前字幕。
-- 点击“纠错并生成章节”的后处理请求默认使用 60s 超时预算；超时后必须取消 worker 请求、保留当前字幕轨和已有合法章节、展示可恢复错误，并允许用户继续 seek 或再次重试。该预算偏保守，用于防止无限卡死，不作为真实模型性能达标阈值。
+- 主操作触发的后处理请求默认使用 60s 超时预算；超时后必须取消 worker 请求、保留当前字幕轨和已有合法章节、展示可恢复错误，并允许用户继续 seek 或再次重试。该预算偏保守，用于防止无限卡死，不作为真实模型性能达标阈值。
 - Worker-backed LLM client 应上报不含字幕正文、代码正文和运行输出正文的阶段耗时 metrics，至少包含 `phase`、`status`、`model`、`workerLoadDurationMs`、`workerRequestDurationMs` 和 `totalDurationMs`，用于定位 worker 创建、warm-up 和 process 阶段的性能瓶颈。
 - 本地小模型输出采用稀疏 `segments` 契约，因此动态 `max_new_tokens` 必须以章节和少量变更为预算，而不是按“每个字幕都完整重写”估算；长字幕轨要按时间连续的 segment 窗口分块后处理，每个窗口独立输出稀疏 corrections 和章节，应用层再合并并做全局 segment/章节校验，避免单次 prompt、输出 token 和 JSON 稳定性超出浏览器本地小模型可接受范围。
 - 输出 schema 校验必须在应用层完成，不能相信模型自报格式正确。

--- a/scripts/tests/workflow-rules.test.mjs
+++ b/scripts/tests/workflow-rules.test.mjs
@@ -607,6 +607,8 @@ test('technical plan owns P1 plus AI subtitle architecture and HF token boundary
   assert.match(technicalPlan, /warm-up 只下载\/初始化模型，不提前转写音频/u);
   assert.match(technicalPlan, /实际音频转写仍只在用户点击后发生/u);
   assert.match(technicalPlan, /同一录制媒体只触发一次 warm-up/u);
+  assert.match(technicalPlan, /字幕主操作按钮可以显式发起一键 ASR -> LLM 流程/u);
+  assert.match(technicalPlan, /先生成、保存并展示 ASR 字幕[\s\S]*LLM 完成后/u);
   assert.match(technicalPlan, /不得把 token 打包进浏览器 bundle/u);
   assert.match(technicalPlan, /浏览器本地推理只拉取公开模型资产/u);
   assert.match(technicalPlan, /不得携带 Hugging Face token/u);
@@ -614,6 +616,8 @@ test('technical plan owns P1 plus AI subtitle architecture and HF token boundary
   assert.match(technicalPlan, /prompt 只描述目标和输出格式/u);
   assert.match(technicalPlan, /优先保证本地小模型稳定输出可解析 JSON/u);
   assert.match(technicalPlan, /有音频媒体时可以预热本地 LLM/u);
+  assert.match(technicalPlan, /LLM 后处理只能由用户点击字幕主操作触发/u);
+  assert.match(technicalPlan, /主操作先运行 ASR 并立即展示结果，再继续运行 LLM 后处理/u);
   assert.match(technicalPlan, /默认模型：`ceilf6\/code-tape-subtitle-postprocessor-onnx`/u);
   assert.match(technicalPlan, /WASM `q8` ONNX 资产/u);
   assert.match(technicalPlan, /`q4f16` \/ `q4` 资产/u);


### PR DESCRIPTION
## 关联

Refs #2（总控 issue，不在本 PR 中关闭）
Closes #217

## 改动点

- 将字幕区原本的“生成字幕”和“纠错并生成章节”合并为一个主按钮：可 ASR 时显示“生成字幕并优化”，仅能处理已有字幕时显示“优化字幕和章节”，纯 ASR 注入场景保留“生成字幕”。
- 串联 ASR 与本地 LLM：点击后先保存并展示原始 ASR 字幕，随后自动执行 LLM 纠错与章节生成，LLM 失败时保留 ASR 字幕。
- 补充一键链路、ASR-only、已有字幕优化、pending seek、timeout、stale chunk recovery、warm-up 等测试覆盖，并更新运行时 benchmark 入口文案。

## 影响范围

- 影响 `SubtitlePanel` 的主操作按钮、字幕生成状态流、LLM 后处理复用逻辑。
- 影响字幕相关单测和 `subtitle:postprocess:runtime-benchmark` 测试入口。
- 不修改 `RecordingPackageV1`，字幕/章节仍作为派生资产经 `SubtitleStore` 保存。

## GitNexus 影响分析摘要

- 风险等级: HIGH
- 风险说明: `detect_changes` 标记字幕链路改动风险较高，后续文档契约修正属于 authority-docs 变更。
- 关键骨架变更: 未修改 schema、API、workflow、进度文件；同步更新 `docs/技术方案.md` 并补充 authority-docs 契约测试。
- GitNexus 影响面: 已运行 `detect_changes` 和 `context`。`detect_changes` 影响 `SubtitlePanel`、`generateSubtitles`、`postProcessSubtitles`，覆盖 PostProcess timeout/invalid correction/normalize chapters、Generate subtitles stale chunk recovery 和 warm-up cancellation 等 7 条执行流；`context SubtitlePanel` 确认上游为 `ReplayPage`，下游为 `SubtitleChapterList`、字幕格式化/错误处理、warm-up 调度与 `onSeek` 等面板内协作点。
- 验证结果: 已补充并通过字幕面板一键 ASR→LLM 流程测试、相关 ReplayPage 测试、`scripts/tests/workflow-rules.test.mjs` 的 authority-docs 字幕契约断言、全量 `quality:local`。

## AI 字幕评估记录

- `npm run subtitle:postprocess:evaluate`: `representativeOutputSource=postprocessor-runner`，`representativePassRate=1`，`overallEvaluationDurationMs=1.712`，`averageFixtureValidationDurationMs=0.1941`，`maxFixtureValidationDurationMs=1.012`。该命令验证 fixture/runner 输出合同，不代表真实端到端模型耗时。
- `npm run subtitle:postprocess:runtime-benchmark`: `postprocessClickToResultReadyDurationMs=31.069`，`postProcessTimeoutBudgetMs=60000`，`playbackProbeResponsiveDuringPostprocess=true`，mock worker inference `6.448ms`。

## 自检

- [x] 未修改 `docs/progress.json` 或 `docs/progress.md`
- [x] 已运行 `npm run quality:local`，或说明无法运行的原因
- [x] 涉及 AI 字幕时，已记录一次 `npm run subtitle:postprocess:evaluate` 的“纠错并生成章节”效果验证结果，包含 `representativeOutputSource`、`overallEvaluationDurationMs`，并区分输出校验耗时与真实端到端耗时
- [x] 涉及 AI 字幕点击链路、LLM worker、模型加载或性能时，已记录一次 `npm run subtitle:postprocess:runtime-benchmark` 结果，包含 `postprocessClickToResultReadyDurationMs`、`postProcessTimeoutBudgetMs` 和 `playbackProbeResponsiveDuringPostprocess`
- [x] 已说明改动点和影响范围
- [x] 如果改动关键骨架，已补充契约测试并填写 GitNexus 影响分析摘要
- [ ] 已等待 repo-guard、codex 和 Copilot 评论，并完成必要审查
