### PR TITLE
支持录制与回放工作区拖拽调整空间

### DIFF
--- a/apps/web/src/features/player/ReplayPage.tsx
+++ b/apps/web/src/features/player/ReplayPage.tsx
@@ -21,7 +21,7 @@ import { createIframeRuntime } from "@/features/runtime-preview/iframeRuntime";
 import { createRecordingStore } from "@/features/library/recordingStore";
 import { createCloudRecordingRepository } from "@/features/cloud/cloudRecordingRepository";
 import { SubtitlePanel } from "@/features/subtitles";
-import { Toggle } from "@/shared/ui";
+import { ResizableWorkspace, Toggle } from "@/shared/ui";
 import type {
   PackageWarning,
   MediaTimelineSegment,
@@ -308,6 +308,39 @@ export function ReplayPage({ source = "local" }: ReplayPageProps) {
     );
   }
 
+  const replayStage = (
+    <div className="relative h-full min-h-0">
+      <CodeEditor
+        language={stableState.editor.language}
+        initialValue={stableState.editor.code}
+        value={stableState.editor.code}
+        fontSize={stableState.editor.fontSize}
+        theme={stableState.editor.theme}
+        readOnly
+        cursor={stableState.editor.cursor}
+        selection={stableState.editor.selection}
+        scrollTop={stableState.editor.scrollTop}
+        scrollLeft={stableState.editor.scrollLeft}
+      />
+      <ReplayVisualOverlays
+        state={overlayState}
+        showPointer={displayOptions.pointer}
+        showShortcut={displayOptions.shortcuts}
+      />
+      <RecordedMediaOverlay
+        videoRef={recordedMediaVideoRef}
+        media={currentMedia}
+        mediaBlob={mediaBlob}
+        mediaState={stableState.media}
+        schedulerState={schedulerState}
+        volume={volume}
+        muted={muted}
+        showCameraLayer={displayOptions.camera}
+        onStatusChange={syncSchedulerMediaStatus}
+      />
+    </div>
+  );
+
   return (
     <div className="flex h-full min-h-0 flex-col">
       {eventOnlyNotice ? (
@@ -344,51 +377,26 @@ export function ReplayPage({ source = "local" }: ReplayPageProps) {
           {shareFeedback.message}
         </div>
       ) : null}
-      <div
-        aria-label="回放工作区"
-        className={
-          displayOptions.runtime
-            ? "grid min-h-0 flex-1 grid-cols-1 md:grid-cols-[1fr_minmax(320px,420px)]"
-            : "grid min-h-0 flex-1 grid-cols-1"
-        }
-      >
-        <div className="relative min-h-0 border-r border-border">
-          <CodeEditor
-            language={stableState.editor.language}
-            initialValue={stableState.editor.code}
-            value={stableState.editor.code}
-            fontSize={stableState.editor.fontSize}
-            theme={stableState.editor.theme}
-            readOnly
-            cursor={stableState.editor.cursor}
-            selection={stableState.editor.selection}
-            scrollTop={stableState.editor.scrollTop}
-            scrollLeft={stableState.editor.scrollLeft}
-          />
-          <ReplayVisualOverlays
-            state={overlayState}
-            showPointer={displayOptions.pointer}
-            showShortcut={displayOptions.shortcuts}
-          />
-          <RecordedMediaOverlay
-            videoRef={recordedMediaVideoRef}
-            media={currentMedia}
-            mediaBlob={mediaBlob}
-            mediaState={stableState.media}
-            schedulerState={schedulerState}
-            volume={volume}
-            muted={muted}
-            showCameraLayer={displayOptions.camera}
-            onStatusChange={syncSchedulerMediaStatus}
-          />
+      {displayOptions.runtime ? (
+        <ResizableWorkspace
+          ariaLabel="回放工作区"
+          separatorLabel="调整回放工作区宽度"
+          storageKey="code-tape:workspace:replay:left-percent"
+          leftClassName="min-h-[24rem] border-b border-border md:min-h-0 md:border-b-0"
+          rightClassName="flex flex-col"
+          left={replayStage}
+          right={
+            <>
+              <PreviewPane runtime={runtime} previewHtml={stableState.runtime.previewHtml} className="min-h-0 flex-1" />
+              <RuntimeOutputPanel runtime={stableState.runtime} />
+            </>
+          }
+        />
+      ) : (
+        <div aria-label="回放工作区" className="grid min-h-0 flex-1 grid-cols-1">
+          {replayStage}
         </div>
-        {displayOptions.runtime ? (
-          <div className="flex min-h-0 flex-col">
-            <PreviewPane runtime={runtime} previewHtml={stableState.runtime.previewHtml} className="min-h-0 flex-1" />
-            <RuntimeOutputPanel runtime={stableState.runtime} />
-          </div>
-        ) : null}
-      </div>
+      )}
       {displayOptions.subtitles ? (
         <SubtitlePanel
           recordingId={pkg?.meta.id ?? null}
@@ -769,4 +777,3 @@ function formatError(err: unknown): string {
   if (typeof err === "string") return err;
   return "unknown error";
 }
-

--- a/apps/web/src/features/player/__tests__/ReplayPage.test.tsx
+++ b/apps/web/src/features/player/__tests__/ReplayPage.test.tsx
@@ -222,6 +222,7 @@ vi.mock("../ReplayControls", () => ({
 
 describe("ReplayPage", () => {
   beforeEach(() => {
+    window.localStorage.clear();
     replayPageMock.reset();
   });
 
@@ -490,6 +491,36 @@ describe("ReplayPage", () => {
     await waitFor(() => expect(replayPageMock.scheduler.load).toHaveBeenCalledWith(replayPageMock.packageData));
 
     expect(screen.getByLabelText("回放工作区")).toHaveClass("min-h-0");
+  });
+
+  it("lets users resize and persist the replay workspace from the keyboard", async () => {
+    const { ReplayPage } = await import("../ReplayPage");
+
+    render(<ReplayPage />);
+    await waitFor(() => expect(replayPageMock.scheduler.load).toHaveBeenCalledWith(replayPageMock.packageData));
+
+    const separator = screen.getByRole("separator", { name: "调整回放工作区宽度" });
+    expect(separator).toHaveAttribute("aria-valuemin", "52");
+    expect(separator).toHaveAttribute("aria-valuemax", "78");
+    expect(separator).toHaveAttribute("aria-valuenow", "68");
+
+    fireEvent.keyDown(separator, { key: "ArrowRight" });
+
+    expect(separator).toHaveAttribute("aria-valuenow", "72");
+    expect(window.localStorage.getItem("code-tape:workspace:replay:left-percent")).toBe("72");
+  });
+
+  it("hides the replay workspace separator when the runtime panel is hidden", async () => {
+    const { ReplayPage } = await import("../ReplayPage");
+
+    render(<ReplayPage />);
+    await waitFor(() => expect(replayPageMock.scheduler.load).toHaveBeenCalledWith(replayPageMock.packageData));
+
+    expect(screen.getByRole("separator", { name: "调整回放工作区宽度" })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "显示运行面板" }));
+
+    expect(screen.queryByRole("separator", { name: "调整回放工作区宽度" })).not.toBeInTheDocument();
   });
 
   it("renders transient pointer and shortcut overlays from scheduler ticks", async () => {

--- a/apps/web/src/features/recorder/RecorderPage.tsx
+++ b/apps/web/src/features/recorder/RecorderPage.tsx
@@ -23,7 +23,7 @@ import {
   createRuntimeProducer,
   createShortcutProducer,
 } from "@/features/capture";
-import { IconButton, useTheme } from "@/shared/ui";
+import { IconButton, ResizableWorkspace, useTheme } from "@/shared/ui";
 import type {
   CameraPositionPayload,
   DeviceInfo,
@@ -666,42 +666,51 @@ export function RecorderPage({ onEventBusReady }: RecorderPageProps = {}) {
         onCameraDeviceChange={handleCameraDeviceChange}
         onRequestMediaPermission={handleRequestMediaPermission}
       />
-      <div className="grid flex-1 grid-cols-1 md:grid-cols-[1fr_minmax(320px,420px)]">
-        <div className="relative border-r border-border">
-          <CodeEditor
-            ref={editorRef}
-            language={editorLanguage}
-            initialValue=""
-            fontSize={editorFontSize}
-            theme={theme.resolved}
-            readOnly={controllerState.status === "paused"}
-            onChange={scheduleAutoRun}
-            onCommand={(command) => {
-              if (command === "run") void handleRun();
-            }}
-            onBeforeFormatApply={() => stack.editorProducer.markNextChangeAsFormat()}
-          />
-          <CameraPreview
-            stream={mediaStream}
-            enabled={cameraEnabled}
-            position={cameraPosition}
-            draggable={controllerState.status !== "paused"}
-            onPositionChange={(next) => {
-              if (stack.controller.state.status === "paused") return;
-              setCameraPosition(next);
-              stack.mediaProducer.reportCameraPosition(next);
-            }}
-          />
-        </div>
-        <div className="flex min-h-0 flex-col">
-          <PreviewPane
-            runtime={stack.runtime}
-            className="min-h-0 flex-1"
-            onReset={() => setRuntimeState(INITIAL_RUNTIME_STATE)}
-          />
-          <RecorderRuntimeOutputPanel runtime={runtimeState} />
-        </div>
-      </div>
+      <ResizableWorkspace
+        ariaLabel="录制工作区"
+        separatorLabel="调整录制工作区宽度"
+        storageKey="code-tape:workspace:recorder:left-percent"
+        leftClassName="relative min-h-[24rem] border-b border-border md:min-h-0 md:border-b-0"
+        rightClassName="flex flex-col"
+        left={
+          <>
+            <CodeEditor
+              ref={editorRef}
+              language={editorLanguage}
+              initialValue=""
+              fontSize={editorFontSize}
+              theme={theme.resolved}
+              readOnly={controllerState.status === "paused"}
+              onChange={scheduleAutoRun}
+              onCommand={(command) => {
+                if (command === "run") void handleRun();
+              }}
+              onBeforeFormatApply={() => stack.editorProducer.markNextChangeAsFormat()}
+            />
+            <CameraPreview
+              stream={mediaStream}
+              enabled={cameraEnabled}
+              position={cameraPosition}
+              draggable={controllerState.status !== "paused"}
+              onPositionChange={(next) => {
+                if (stack.controller.state.status === "paused") return;
+                setCameraPosition(next);
+                stack.mediaProducer.reportCameraPosition(next);
+              }}
+            />
+          </>
+        }
+        right={
+          <>
+            <PreviewPane
+              runtime={stack.runtime}
+              className="min-h-0 flex-1"
+              onReset={() => setRuntimeState(INITIAL_RUNTIME_STATE)}
+            />
+            <RecorderRuntimeOutputPanel runtime={runtimeState} />
+          </>
+        }
+      />
     </div>
   );
 }

--- a/apps/web/src/features/recorder/__tests__/RecorderPage.test.tsx
+++ b/apps/web/src/features/recorder/__tests__/RecorderPage.test.tsx
@@ -373,6 +373,7 @@ async function flushAsyncWork(turns = 6): Promise<void> {
 
 describe("RecorderPage", () => {
   beforeEach(() => {
+    window.localStorage.clear();
     recorderPageMock.reset();
   });
 
@@ -442,6 +443,25 @@ describe("RecorderPage", () => {
     const output = await screen.findByRole("region", { name: "Runtime output" });
     expect(output).toHaveTextContent("success");
     expect(output).toHaveTextContent("1");
+  });
+
+  it("lets users resize and persist the recorder workspace from the keyboard", async () => {
+    const { RecorderPage } = await import("../RecorderPage");
+
+    render(<RecorderPage />);
+    await waitFor(() => expect(recorderPageMock.devices.enumerate).toHaveBeenCalledTimes(1));
+
+    const separator = screen.getByRole("separator", { name: "调整录制工作区宽度" });
+    expect(separator).toHaveAttribute("aria-valuemin", "52");
+    expect(separator).toHaveAttribute("aria-valuemax", "78");
+    expect(separator).toHaveAttribute("aria-valuenow", "68");
+
+    act(() => {
+      fireEvent.keyDown(separator, { key: "ArrowLeft" });
+    });
+
+    expect(separator).toHaveAttribute("aria-valuenow", "64");
+    expect(window.localStorage.getItem("code-tape:workspace:recorder:left-percent")).toBe("64");
   });
 
   it("runs code from the editor run command shortcut", async () => {

--- a/apps/web/src/shared/ui/ResizableWorkspace.tsx
+++ b/apps/web/src/shared/ui/ResizableWorkspace.tsx
@@ -1,0 +1,179 @@
+import {
+  useCallback,
+  useMemo,
+  useRef,
+  useState,
+  type CSSProperties,
+  type KeyboardEvent,
+  type PointerEvent,
+  type ReactNode,
+} from "react";
+import { cn } from "./utils/cn";
+
+const DEFAULT_LEFT_PERCENT = 68;
+const DEFAULT_MIN_LEFT_PERCENT = 52;
+const DEFAULT_MAX_LEFT_PERCENT = 78;
+const DEFAULT_STEP = 4;
+
+export type ResizableWorkspaceProps = {
+  ariaLabel: string;
+  separatorLabel: string;
+  storageKey: string;
+  left: ReactNode;
+  right: ReactNode;
+  className?: string;
+  leftClassName?: string;
+  rightClassName?: string;
+  defaultLeftPercent?: number;
+  minLeftPercent?: number;
+  maxLeftPercent?: number;
+  step?: number;
+};
+
+export function ResizableWorkspace({
+  ariaLabel,
+  separatorLabel,
+  storageKey,
+  left,
+  right,
+  className,
+  leftClassName,
+  rightClassName,
+  defaultLeftPercent = DEFAULT_LEFT_PERCENT,
+  minLeftPercent = DEFAULT_MIN_LEFT_PERCENT,
+  maxLeftPercent = DEFAULT_MAX_LEFT_PERCENT,
+  step = DEFAULT_STEP,
+}: ResizableWorkspaceProps) {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const draggingRef = useRef(false);
+  const [leftPercent, setLeftPercent] = useState(() =>
+    readStoredPercent(storageKey, defaultLeftPercent, minLeftPercent, maxLeftPercent, step),
+  );
+  const layoutStyle = useMemo(
+    () => ({ "--workspace-left": `${leftPercent}%` }) as CSSProperties,
+    [leftPercent],
+  );
+
+  const commitPercent = useCallback(
+    (nextPercent: number) => {
+      const clamped = clampToStep(nextPercent, minLeftPercent, maxLeftPercent, step);
+      setLeftPercent(clamped);
+      persistPercent(storageKey, clamped);
+    },
+    [maxLeftPercent, minLeftPercent, step, storageKey],
+  );
+
+  const commitPointerPosition = useCallback(
+    (clientX: number) => {
+      if (!Number.isFinite(clientX)) return;
+      const rect = containerRef.current?.getBoundingClientRect();
+      if (!rect || rect.width <= 0) return;
+      commitPercent(((clientX - rect.left) / rect.width) * 100);
+    },
+    [commitPercent],
+  );
+
+  const handlePointerDown = (event: PointerEvent<HTMLDivElement>) => {
+    event.preventDefault();
+    draggingRef.current = true;
+    event.currentTarget.setPointerCapture?.(event.pointerId);
+    commitPointerPosition(event.clientX);
+  };
+
+  const handlePointerMove = (event: PointerEvent<HTMLDivElement>) => {
+    if (!draggingRef.current) return;
+    commitPointerPosition(event.clientX);
+  };
+
+  const handlePointerUp = (event: PointerEvent<HTMLDivElement>) => {
+    draggingRef.current = false;
+    event.currentTarget.releasePointerCapture?.(event.pointerId);
+  };
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+    const keyActions: Record<string, number> = {
+      ArrowLeft: leftPercent - step,
+      ArrowDown: leftPercent - step,
+      ArrowRight: leftPercent + step,
+      ArrowUp: leftPercent + step,
+      Home: minLeftPercent,
+      End: maxLeftPercent,
+    };
+    const nextPercent = keyActions[event.key];
+    if (nextPercent === undefined) return;
+    event.preventDefault();
+    commitPercent(nextPercent);
+  };
+
+  return (
+    <div
+      ref={containerRef}
+      aria-label={ariaLabel}
+      className={cn("flex min-h-0 flex-1 flex-col md:flex-row", className)}
+      style={layoutStyle}
+    >
+      <div
+        className={cn(
+          "min-h-0 md:min-w-0 md:basis-[var(--workspace-left)] md:shrink-0 md:grow-0",
+          leftClassName,
+        )}
+      >
+        {left}
+      </div>
+      <div
+        role="separator"
+        aria-label={separatorLabel}
+        aria-orientation="vertical"
+        aria-valuemin={minLeftPercent}
+        aria-valuemax={maxLeftPercent}
+        aria-valuenow={leftPercent}
+        aria-valuetext={`${leftPercent}%`}
+        tabIndex={0}
+        className={cn(
+          "group hidden w-3 shrink-0 cursor-col-resize touch-none items-stretch justify-center outline-none md:flex",
+          "focus-visible:ring-2 focus-visible:ring-focus focus-visible:ring-offset-2 focus-visible:ring-offset-background",
+        )}
+        onPointerDown={handlePointerDown}
+        onPointerMove={handlePointerMove}
+        onPointerUp={handlePointerUp}
+        onPointerCancel={handlePointerUp}
+        onKeyDown={handleKeyDown}
+      >
+        <span className="my-3 w-px rounded-full bg-border transition-colors group-hover:bg-primary group-focus-visible:bg-primary" />
+      </div>
+      <div className={cn("min-h-0 md:min-w-0 md:flex-1", rightClassName)}>{right}</div>
+    </div>
+  );
+}
+
+function readStoredPercent(
+  storageKey: string,
+  fallback: number,
+  min: number,
+  max: number,
+  step: number,
+): number {
+  if (typeof window === "undefined") return clampToStep(fallback, min, max, step);
+  try {
+    const stored = window.localStorage.getItem(storageKey);
+    if (!stored) return clampToStep(fallback, min, max, step);
+    const parsed = Number(stored);
+    return Number.isFinite(parsed) ? clampToStep(parsed, min, max, step) : clampToStep(fallback, min, max, step);
+  } catch {
+    return clampToStep(fallback, min, max, step);
+  }
+}
+
+function persistPercent(storageKey: string, value: number) {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(storageKey, String(value));
+  } catch {
+    // Ignore storage failures in private/sandboxed contexts; resizing still works for the session.
+  }
+}
+
+function clampToStep(value: number, min: number, max: number, step: number): number {
+  const stepped = Math.round(value / step) * step;
+  return Math.min(max, Math.max(min, stepped));
+}

--- a/apps/web/src/shared/ui/__tests__/ResizableWorkspace.test.tsx
+++ b/apps/web/src/shared/ui/__tests__/ResizableWorkspace.test.tsx
@@ -43,6 +43,57 @@ describe("ResizableWorkspace", () => {
     expect(separator).toHaveAttribute("aria-valuenow", "76");
     expect(window.localStorage.getItem("code-tape:test-workspace:left-percent")).toBe("76");
   });
+
+  it("keeps the separator desktop-only while the base layout stays stacked", () => {
+    render(
+      <ResizableWorkspace
+        ariaLabel="窄屏测试工作区"
+        separatorLabel="调整窄屏测试工作区宽度"
+        storageKey="code-tape:narrow-workspace:left-percent"
+        left={<div>Left</div>}
+        right={<div>Right</div>}
+      />,
+    );
+
+    expect(screen.getByLabelText("窄屏测试工作区")).toHaveClass("flex-col", "md:flex-row");
+    expect(screen.getByRole("separator", { name: "调整窄屏测试工作区宽度" })).toHaveClass(
+      "hidden",
+      "md:flex",
+    );
+  });
+
+  it("falls back from invalid persisted values and clamps out-of-range values", () => {
+    window.localStorage.setItem("code-tape:invalid-workspace:left-percent", "not-a-number");
+    const { unmount } = render(
+      <ResizableWorkspace
+        ariaLabel="损坏偏好工作区"
+        separatorLabel="调整损坏偏好工作区宽度"
+        storageKey="code-tape:invalid-workspace:left-percent"
+        left={<div>Left</div>}
+        right={<div>Right</div>}
+      />,
+    );
+    expect(screen.getByRole("separator", { name: "调整损坏偏好工作区宽度" })).toHaveAttribute(
+      "aria-valuenow",
+      "68",
+    );
+    unmount();
+
+    window.localStorage.setItem("code-tape:clamped-workspace:left-percent", "99");
+    render(
+      <ResizableWorkspace
+        ariaLabel="越界偏好工作区"
+        separatorLabel="调整越界偏好工作区宽度"
+        storageKey="code-tape:clamped-workspace:left-percent"
+        left={<div>Left</div>}
+        right={<div>Right</div>}
+      />,
+    );
+    expect(screen.getByRole("separator", { name: "调整越界偏好工作区宽度" })).toHaveAttribute(
+      "aria-valuenow",
+      "78",
+    );
+  });
 });
 
 class TestPointerEvent extends MouseEvent {

--- a/apps/web/src/shared/ui/__tests__/ResizableWorkspace.test.tsx
+++ b/apps/web/src/shared/ui/__tests__/ResizableWorkspace.test.tsx
@@ -1,0 +1,55 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ResizableWorkspace } from "../ResizableWorkspace";
+
+describe("ResizableWorkspace", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    vi.stubGlobal("PointerEvent", TestPointerEvent);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("updates and persists the split when the separator is dragged", () => {
+    render(
+      <ResizableWorkspace
+        ariaLabel="测试工作区"
+        separatorLabel="调整测试工作区宽度"
+        storageKey="code-tape:test-workspace:left-percent"
+        left={<div>Left</div>}
+        right={<div>Right</div>}
+      />,
+    );
+    const workspace = screen.getByLabelText("测试工作区");
+    vi.spyOn(workspace, "getBoundingClientRect").mockReturnValue({
+      x: 0,
+      y: 0,
+      left: 0,
+      top: 0,
+      right: 1000,
+      bottom: 600,
+      width: 1000,
+      height: 600,
+      toJSON: () => ({}),
+    });
+
+    const separator = screen.getByRole("separator", { name: "调整测试工作区宽度" });
+    fireEvent(separator, new PointerEvent("pointerdown", { bubbles: true, clientX: 680, pointerId: 1 }));
+    fireEvent(separator, new PointerEvent("pointermove", { bubbles: true, clientX: 760, pointerId: 1 }));
+    fireEvent(separator, new PointerEvent("pointerup", { bubbles: true, pointerId: 1 }));
+
+    expect(separator).toHaveAttribute("aria-valuenow", "76");
+    expect(window.localStorage.getItem("code-tape:test-workspace:left-percent")).toBe("76");
+  });
+});
+
+class TestPointerEvent extends MouseEvent {
+  pointerId: number;
+
+  constructor(type: string, init: PointerEventInit = {}) {
+    super(type, init);
+    this.pointerId = init.pointerId ?? 1;
+  }
+}

--- a/apps/web/src/shared/ui/index.ts
+++ b/apps/web/src/shared/ui/index.ts
@@ -8,4 +8,5 @@ export { Slider, type SliderProps } from "./Slider";
 export { Toggle, type ToggleProps } from "./Toggle";
 export { Tooltip, TooltipProvider, type TooltipProps } from "./Tooltip";
 export { Popover, type PopoverProps } from "./Popover";
+export { ResizableWorkspace, type ResizableWorkspaceProps } from "./ResizableWorkspace";
 export { cn } from "./utils/cn";


### PR DESCRIPTION
## 关联

Refs #2（总控 issue，不在本 PR 中关闭）
Closes #221

## 改动点

- 新增共享 `ResizableWorkspace`，支持桌面端拖拽分隔条、键盘方向键/Home/End 调整、ARIA 数值反馈和 `localStorage` 持久化。
- 录制页和回放页接入可调整左右工作区；窄屏保持上下堆叠并隐藏分隔条。
- 回放页隐藏运行面板时恢复单栏工作区，不暴露无效分隔条。

## 影响范围

- 影响录制页、回放页的工作区布局和共享 UI 组件导出。
- 不修改录制包 schema、capture 事件、回放调度、媒体时钟、仓库/API/cloud 合约。

## GitNexus 影响分析摘要

- 风险等级: medium
- 关键骨架变更: 无；contract check 提示本 diff 未修改 critical contract surface。
- GitNexus 影响面: `RecorderPage`、`ReplayPage` 展示流；受影响流程为 ReplayPage 到 RecordedMediaSegment / CreateMediaClockAdapter 的渲染路径。
- 验证结果: `npx --yes gitnexus@1.6.5 detect_changes --repo code-tape` 已运行；`GITNEXUS_IMPACT_SUMMARY=... npm run contract:check` 通过。

## 自检

- [x] 未修改 `docs/progress.json` 或 `docs/progress.md`
- [x] 已运行 `npm run quality:local`，或说明无法运行的原因
- [x] 涉及 AI 字幕时，已记录一次 `npm run subtitle:postprocess:evaluate` 的“纠错并生成章节”效果验证结果，包含 `representativeOutputSource`、`overallEvaluationDurationMs`，并区分输出校验耗时与真实端到端耗时（本 PR 不涉及 AI 字幕）
- [x] 涉及 AI 字幕点击链路、LLM worker、模型加载或性能时，已记录一次 `npm run subtitle:postprocess:runtime-benchmark` 结果，包含 `postprocessClickToResultReadyDurationMs`、`postProcessTimeoutBudgetMs` 和 `playbackProbeResponsiveDuringPostprocess`（本 PR 不涉及 AI 字幕）
- [x] 已说明改动点和影响范围
- [x] 如果改动关键骨架，已补充契约测试并填写 GitNexus 影响分析摘要（未改关键骨架）
- [ ] 已等待 repo-guard、codex 和 Copilot 评论，并完成必要审查

## 本地验证

- `npm run test -w apps/web -- src/shared/ui/__tests__/ResizableWorkspace.test.tsx src/features/recorder/__tests__/RecorderPage.test.tsx src/features/player/__tests__/ReplayPage.test.tsx`
- `npm run lint:web`
- `npm run test:web`
- `npm run build -w apps/web`
- `GITNEXUS_IMPACT_SUMMARY=... npm run contract:check`
- `npm run quality:precommit`
- push hook: `npm run quality:local`（包含 6 条 Playwright e2e）
- Browser smoke: `npm run dev` 下录制页桌面分隔条可见，键盘调整 ARIA 数值；窄屏分隔条隐藏。