### PR TITLE
#231 云端身份认证：长期 refresh token 换取短期签名 access token

### DIFF
--- a/apps/api/src/cloud/__tests__/authTokenService.test.ts
+++ b/apps/api/src/cloud/__tests__/authTokenService.test.ts
@@ -1,0 +1,79 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  DEFAULT_ACCESS_TOKEN_TTL_MS,
+  createAuthTokenService,
+} from "../authTokenService.js";
+
+test("issues a signed access token whose ownerId equals the refresh token", () => {
+  const auth = createAuthTokenService({ secret: "test-secret", now: () => 1_000 });
+  const issued = auth.issueFromRefreshToken("device-token-123");
+  assert.equal(issued.ok, true);
+  if (!issued.ok) return;
+  assert.equal(issued.value.tokenType, "Bearer");
+  assert.equal(issued.value.expiresAt, 1_000 + DEFAULT_ACCESS_TOKEN_TTL_MS);
+
+  const verified = auth.verifyAccessToken(issued.value.accessToken, 2_000);
+  assert.equal(verified.ok, true);
+  if (!verified.ok) return;
+  assert.equal(verified.value.ownerId, "device-token-123");
+});
+
+test("rejects refresh tokens that are too short", () => {
+  const auth = createAuthTokenService({ secret: "test-secret" });
+  const issued = auth.issueFromRefreshToken("short");
+  assert.equal(issued.ok, false);
+  if (issued.ok) return;
+  assert.equal(issued.error.code, "unauthorized");
+});
+
+test("rejects an expired access token", () => {
+  const auth = createAuthTokenService({
+    secret: "test-secret",
+    accessTokenTtlMs: 1_000,
+    now: () => 0,
+  });
+  const issued = auth.issueFromRefreshToken("device-token-123");
+  assert.equal(issued.ok, true);
+  if (!issued.ok) return;
+
+  const expired = auth.verifyAccessToken(issued.value.accessToken, 1_000);
+  assert.equal(expired.ok, false);
+  if (expired.ok) return;
+  assert.match(expired.error.message, /expired/);
+});
+
+test("rejects a tampered payload (signature mismatch)", () => {
+  const auth = createAuthTokenService({ secret: "test-secret", now: () => 0 });
+  const issued = auth.issueFromRefreshToken("device-token-123");
+  assert.equal(issued.ok, true);
+  if (!issued.ok) return;
+
+  const signature = issued.value.accessToken.split(".")[1];
+  const forgedPayload = Buffer.from(
+    JSON.stringify({ ownerId: "attacker", iat: 0, exp: Number.MAX_SAFE_INTEGER }),
+    "utf8",
+  ).toString("base64url");
+  const forged = `${forgedPayload}.${signature}`;
+
+  const verified = auth.verifyAccessToken(forged, 1_000);
+  assert.equal(verified.ok, false);
+});
+
+test("rejects a token signed with a different secret", () => {
+  const issuer = createAuthTokenService({ secret: "secret-a", now: () => 0 });
+  const verifier = createAuthTokenService({ secret: "secret-b", now: () => 0 });
+  const issued = issuer.issueFromRefreshToken("device-token-123");
+  assert.equal(issued.ok, true);
+  if (!issued.ok) return;
+
+  const verified = verifier.verifyAccessToken(issued.value.accessToken, 1_000);
+  assert.equal(verified.ok, false);
+});
+
+test("rejects malformed tokens", () => {
+  const auth = createAuthTokenService({ secret: "test-secret" });
+  for (const bad of ["", "no-dot", ".onlysig", "payload.", "a.b.c.d"]) {
+    assert.equal(auth.verifyAccessToken(bad).ok, false);
+  }
+});

--- a/apps/api/src/cloud/authTokenService.ts
+++ b/apps/api/src/cloud/authTokenService.ts
@@ -1,0 +1,134 @@
+import { createHmac, randomBytes, timingSafeEqual } from "node:crypto";
+import type { CloudResult } from "./types.js";
+
+/**
+ * AuthTokenService — 短期签名 access token 的签发与校验。
+ *
+ * 设计（见 issue #231，技术方案「登录体系」待确认问题，保持匿名设备身份）：
+ * - 长期 refresh token = 前端持久化的设备 token（仅发往 /api/auth/token）。
+ * - 短期 access token = `payload.signature`，payload 为 base64url(JSON {ownerId, iat, exp})，
+ *   signature 为 HMAC-SHA256(payload, 服务端密钥) 的 base64url。
+ * - ownerId 直接取自 refresh token，使既有录制归属保持稳定。
+ * - 不引入账号/密码/OAuth；仅做令牌轮换这一安全加固。
+ */
+
+export const DEFAULT_ACCESS_TOKEN_TTL_MS = 15 * 60 * 1000;
+const MIN_REFRESH_TOKEN_LENGTH = 8;
+const MAX_REFRESH_TOKEN_LENGTH = 512;
+
+export type AccessTokenPayload = {
+  ownerId: string;
+  /** issued-at, epoch ms */
+  iat: number;
+  /** expires-at, epoch ms */
+  exp: number;
+};
+
+export type IssuedAccessToken = {
+  accessToken: string;
+  expiresAt: number;
+  tokenType: "Bearer";
+};
+
+export type AuthTokenService = {
+  /** 用长期 refresh token（设备 token）换取短期 access token。 */
+  issueFromRefreshToken(refreshToken: string, nowMs?: number): CloudResult<IssuedAccessToken>;
+  /** 校验 access token 签名与过期，返回 ownerId。 */
+  verifyAccessToken(accessToken: string, nowMs?: number): CloudResult<AccessTokenPayload>;
+};
+
+export type AuthTokenServiceOptions = {
+  /** HMAC 密钥；缺省时进程内随机生成（满足 Demo，重启后旧 token 失效）。 */
+  secret?: string;
+  /** access token 存活时长，默认 15 分钟。 */
+  accessTokenTtlMs?: number;
+  /** 时间源，便于测试。 */
+  now?: () => number;
+};
+
+export function createAuthTokenService(options: AuthTokenServiceOptions = {}): AuthTokenService {
+  const secret = options.secret && options.secret.length > 0
+    ? options.secret
+    : randomBytes(32).toString("hex");
+  const ttlMs = options.accessTokenTtlMs ?? DEFAULT_ACCESS_TOKEN_TTL_MS;
+  const now = options.now ?? (() => Date.now());
+
+  const sign = (payloadSegment: string): string =>
+    createHmac("sha256", secret).update(payloadSegment).digest("base64url");
+
+  return {
+    issueFromRefreshToken(refreshToken, nowMs) {
+      const trimmed = typeof refreshToken === "string" ? refreshToken.trim() : "";
+      if (
+        trimmed.length < MIN_REFRESH_TOKEN_LENGTH ||
+        trimmed.length > MAX_REFRESH_TOKEN_LENGTH
+      ) {
+        return {
+          ok: false,
+          error: { code: "unauthorized", message: "invalid refresh token" },
+        };
+      }
+      const issuedAt = nowMs ?? now();
+      const expiresAt = issuedAt + ttlMs;
+      const payload: AccessTokenPayload = { ownerId: trimmed, iat: issuedAt, exp: expiresAt };
+      const payloadSegment = encodePayload(payload);
+      const accessToken = `${payloadSegment}.${sign(payloadSegment)}`;
+      return { ok: true, value: { accessToken, expiresAt, tokenType: "Bearer" } };
+    },
+
+    verifyAccessToken(accessToken, nowMs) {
+      const token = typeof accessToken === "string" ? accessToken.trim() : "";
+      const dotIndex = token.indexOf(".");
+      if (dotIndex <= 0 || dotIndex === token.length - 1) {
+        return unauthorized();
+      }
+      const payloadSegment = token.slice(0, dotIndex);
+      const signatureSegment = token.slice(dotIndex + 1);
+      const expectedSignature = sign(payloadSegment);
+      if (!constantTimeEquals(signatureSegment, expectedSignature)) {
+        return unauthorized();
+      }
+      const payload = decodePayload(payloadSegment);
+      if (!payload) return unauthorized();
+      if ((nowMs ?? now()) >= payload.exp) {
+        return { ok: false, error: { code: "unauthorized", message: "access token expired" } };
+      }
+      return { ok: true, value: payload };
+    },
+  };
+}
+
+function encodePayload(payload: AccessTokenPayload): string {
+  return Buffer.from(JSON.stringify(payload), "utf8").toString("base64url");
+}
+
+function decodePayload(segment: string): AccessTokenPayload | null {
+  try {
+    const json = Buffer.from(segment, "base64url").toString("utf8");
+    const parsed = JSON.parse(json) as unknown;
+    if (
+      typeof parsed === "object" &&
+      parsed !== null &&
+      typeof (parsed as AccessTokenPayload).ownerId === "string" &&
+      (parsed as AccessTokenPayload).ownerId.length > 0 &&
+      Number.isFinite((parsed as AccessTokenPayload).iat) &&
+      Number.isFinite((parsed as AccessTokenPayload).exp)
+    ) {
+      return parsed as AccessTokenPayload;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+function constantTimeEquals(a: string, b: string): boolean {
+  const bufferA = Buffer.from(a, "utf8");
+  const bufferB = Buffer.from(b, "utf8");
+  if (bufferA.length !== bufferB.length) return false;
+  return timingSafeEqual(bufferA, bufferB);
+}
+
+function unauthorized(): CloudResult<never> {
+  return { ok: false, error: { code: "unauthorized", message: "invalid access token" } };
+}

--- a/apps/api/src/demo/demoServer.ts
+++ b/apps/api/src/demo/demoServer.ts
@@ -2,6 +2,7 @@ import { readFile, stat } from "node:fs/promises";
 import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
 import { extname, resolve, sep } from "node:path";
 import { createCloudRecordingService } from "../cloud/cloudRecordingService.js";
+import { createAuthTokenService } from "../cloud/authTokenService.js";
 import { createLocalDevObjectStorage } from "../cloud/localDevObjectStorage.js";
 import { createMemoryMetadataRepository } from "../cloud/memoryMetadataRepository.js";
 import { processNextRecordingValidationJob } from "../cloud/validationWorker.js";
@@ -38,6 +39,7 @@ export function createDemoRuntime(options: DemoRequestHandlerOptions): DemoRunti
   });
   const cloud = createCloudApiHandler({
     service: createCloudRecordingService({ metadata, objectStorage }),
+    auth: createAuthTokenService({ secret: process.env.CODE_TAPE_AUTH_SECRET }),
     createRequestId: options.createRequestId,
   });
   const rooms = createInterviewRoomService({

--- a/apps/api/src/http/__tests__/cloudApiHandler.test.ts
+++ b/apps/api/src/http/__tests__/cloudApiHandler.test.ts
@@ -2497,6 +2497,37 @@ test("GET /api/recordings still accepts the legacy x-owner-token header", async 
   assert.equal(response.status, 200);
 });
 
+test("POST /api/auth/token works even when auth is not explicitly injected", async () => {
+  // 不显式注入 auth：handler 应默认构造 auth service，使 token 端点始终可用，
+  // 避免新前端在缺省装配点拿到 404。
+  const handler = createCloudApiHandler({
+    service: createCloudRecordingService({
+      metadata: createMemoryMetadataRepository(),
+      objectStorage: createMemoryObjectStorage(),
+    }),
+    createRequestId: () => "req-auth-default",
+  });
+  const tokenResp = await handler(
+    new Request("http://localhost/api/auth/token", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ refreshToken: "device-token-default" }),
+    }),
+  );
+  const body = (await tokenResp.json()) as { accessToken: string; tokenType: string };
+  assert.equal(tokenResp.status, 200);
+  assert.equal(body.tokenType, "Bearer");
+
+  // 用拿到的 token 访问业务端点应成功。
+  const listResp = await handler(
+    new Request("http://localhost/api/recordings", {
+      method: "GET",
+      headers: { authorization: `Bearer ${body.accessToken}` },
+    }),
+  );
+  assert.equal(listResp.status, 200);
+});
+
 function createAuthEnabledHandler(createRequestId: () => string) {
   const service = createCloudRecordingService({
     metadata: createMemoryMetadataRepository(),

--- a/apps/api/src/http/__tests__/cloudApiHandler.test.ts
+++ b/apps/api/src/http/__tests__/cloudApiHandler.test.ts
@@ -3,6 +3,7 @@ import test from "node:test";
 import { canonicalStringify, sha256Hex } from "@code-tape/recording-schema/hash";
 import { RECORDING_SCHEMA_VERSION, type RecordingPackageV1 } from "@code-tape/recording-schema";
 import { createCloudRecordingService } from "../../cloud/cloudRecordingService.js";
+import { createAuthTokenService } from "../../cloud/authTokenService.js";
 import { createMemoryMetadataRepository } from "../../cloud/memoryMetadataRepository.js";
 import { buildLocalDevObjectUrl, createLocalDevObjectStorage } from "../../cloud/localDevObjectStorage.js";
 import { createMemoryObjectStorage } from "../../cloud/memoryObjectStorage.js";
@@ -2421,6 +2422,92 @@ test("DELETE uploading recording then POST complete returns 404 and does not rev
   const recording = await metadata.getRecording(createBody.recordingId);
   assert.equal(recording?.status, "soft_deleted");
 });
+
+test("POST /api/auth/token issues a Bearer access token from a refresh token", async () => {
+  const handler = createAuthEnabledHandler(() => "req-auth-1");
+  const response = await handler(
+    new Request("http://localhost/api/auth/token", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ refreshToken: "device-token-aaaaaaaa" }),
+    }),
+  );
+  const body = (await response.json()) as {
+    accessToken: string;
+    expiresAt: number;
+    tokenType: string;
+  };
+  assert.equal(response.status, 200);
+  assert.equal(body.tokenType, "Bearer");
+  assert.ok(body.accessToken.includes("."));
+  assert.ok(body.expiresAt > Date.now());
+});
+
+test("POST /api/auth/token rejects a missing refresh token", async () => {
+  const handler = createAuthEnabledHandler(() => "req-auth-2");
+  const response = await handler(
+    new Request("http://localhost/api/auth/token", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({}),
+    }),
+  );
+  assert.equal(response.status, 400);
+});
+
+test("GET /api/recordings accepts a valid Bearer access token", async () => {
+  const handler = createAuthEnabledHandler(() => "req-auth-3");
+  const tokenResp = await handler(
+    new Request("http://localhost/api/auth/token", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ refreshToken: "device-token-aaaaaaaa" }),
+    }),
+  );
+  const { accessToken } = (await tokenResp.json()) as { accessToken: string };
+
+  const response = await handler(
+    new Request("http://localhost/api/recordings", {
+      method: "GET",
+      headers: { authorization: `Bearer ${accessToken}` },
+    }),
+  );
+  assert.equal(response.status, 200);
+});
+
+test("GET /api/recordings rejects a tampered Bearer token", async () => {
+  const handler = createAuthEnabledHandler(() => "req-auth-4");
+  const response = await handler(
+    new Request("http://localhost/api/recordings", {
+      method: "GET",
+      headers: { authorization: "Bearer not.a.validtoken" },
+    }),
+  );
+  assert.equal(response.status, 401);
+});
+
+test("GET /api/recordings still accepts the legacy x-owner-token header", async () => {
+  const handler = createAuthEnabledHandler(() => "req-auth-5");
+  const response = await handler(
+    new Request("http://localhost/api/recordings", {
+      method: "GET",
+      headers: { "x-owner-token": "owner-1" },
+    }),
+  );
+  assert.equal(response.status, 200);
+});
+
+function createAuthEnabledHandler(createRequestId: () => string) {
+  const service = createCloudRecordingService({
+    metadata: createMemoryMetadataRepository(),
+    objectStorage: createMemoryObjectStorage(),
+  });
+  return createCloudApiHandler({
+    service,
+    auth: createAuthTokenService({ secret: "test-secret" }),
+    createRequestId,
+  });
+}
 
 async function makeCompleteBody(pkg: RecordingPackageV1): Promise<string> {
   const req = await makeCreateSessionRequest(pkg);

--- a/apps/api/src/http/cloudApiHandler.ts
+++ b/apps/api/src/http/cloudApiHandler.ts
@@ -1,4 +1,5 @@
 import type { CloudRecordingService } from "../cloud/cloudRecordingService.js";
+import type { AuthTokenService } from "../cloud/authTokenService.js";
 import { parseIsoUtcInstantMs } from "../cloud/isoDate.js";
 import { RECORDING_ASSET_KINDS } from "../cloud/types.js";
 import type {
@@ -38,15 +39,40 @@ const SHARE_TOP_KEYS = new Set(["expiresAt", "startTimeMs"]);
 
 export function createCloudApiHandler(deps: {
   service: CloudRecordingService;
+  auth?: AuthTokenService;
   createRequestId?: () => string;
 }): CloudApiHandler {
   const createRequestId = deps.createRequestId ?? (() => crypto.randomUUID());
+  const auth = deps.auth;
+  const resolveOwnerId = (request: Request): string | null => readOwnerId(request, auth);
 
   return async (request: Request): Promise<Response> => {
     const requestId = createRequestId();
     const url = new URL(request.url);
+
+    if (request.method === "POST" && url.pathname === "/api/auth/token") {
+      if (!auth) {
+        return jsonError(
+          { code: "not-found", message: "route not found", requestId },
+          requestId,
+        );
+      }
+      const parsed = await readJsonObject(request);
+      if (!parsed.ok) return jsonError({ ...parsed.error, requestId }, requestId);
+      const refreshToken = parsed.value.refreshToken;
+      if (typeof refreshToken !== "string") {
+        return jsonError(
+          { code: "bad-request", message: "refreshToken must be a string", requestId },
+          requestId,
+        );
+      }
+      const issued = auth.issueFromRefreshToken(refreshToken);
+      if (!issued.ok) return jsonError({ ...issued.error, requestId }, requestId);
+      return jsonResponse(issued.value, 200, requestId);
+    }
+
     if (request.method === "GET" && url.pathname === "/api/recordings") {
-      const ownerId = readOwnerToken(request);
+      const ownerId = resolveOwnerId(request);
       if (!ownerId) {
         return jsonError(
           { code: "unauthorized", message: "missing owner token", requestId },
@@ -62,7 +88,7 @@ export function createCloudApiHandler(deps: {
 
     const playbackMatch = url.pathname.match(/^\/api\/recordings\/([^/]+)\/playback$/);
     if (request.method === "GET" && playbackMatch) {
-      const ownerId = readOwnerToken(request);
+      const ownerId = resolveOwnerId(request);
       if (!ownerId) {
         return jsonError(
           { code: "unauthorized", message: "missing owner token", requestId },
@@ -97,7 +123,7 @@ export function createCloudApiHandler(deps: {
 
     const shareLinkMatch = url.pathname.match(/^\/api\/recordings\/([^/]+)\/share-links$/);
     if (request.method === "POST" && shareLinkMatch) {
-      const ownerId = readOwnerToken(request);
+      const ownerId = resolveOwnerId(request);
       if (!ownerId) {
         return jsonError(
           { code: "unauthorized", message: "missing owner token", requestId },
@@ -123,7 +149,7 @@ export function createCloudApiHandler(deps: {
 
     const recordingDetailMatch = url.pathname.match(/^\/api\/recordings\/([^/]+)$/);
     if (request.method === "GET" && recordingDetailMatch) {
-      const ownerId = readOwnerToken(request);
+      const ownerId = resolveOwnerId(request);
       if (!ownerId) {
         return jsonError(
           { code: "unauthorized", message: "missing owner token", requestId },
@@ -143,7 +169,7 @@ export function createCloudApiHandler(deps: {
     }
 
     if (request.method === "PATCH" && recordingDetailMatch) {
-      const ownerId = readOwnerToken(request);
+      const ownerId = resolveOwnerId(request);
       if (!ownerId) {
         return jsonError(
           { code: "unauthorized", message: "missing owner token", requestId },
@@ -168,7 +194,7 @@ export function createCloudApiHandler(deps: {
     }
 
     if (request.method === "DELETE" && recordingDetailMatch) {
-      const ownerId = readOwnerToken(request);
+      const ownerId = resolveOwnerId(request);
       if (!ownerId) {
         return jsonError(
           { code: "unauthorized", message: "missing owner token", requestId },
@@ -188,7 +214,7 @@ export function createCloudApiHandler(deps: {
     }
 
     if (request.method === "POST" && url.pathname === "/api/recordings/upload-sessions") {
-      const ownerId = readOwnerToken(request);
+      const ownerId = resolveOwnerId(request);
       if (!ownerId) {
         return jsonError(
           { code: "unauthorized", message: "missing owner token", requestId },
@@ -210,7 +236,7 @@ export function createCloudApiHandler(deps: {
     );
     if (request.method === "POST" && completeMatch) {
       const sessionId = completeMatch[1]!;
-      const ownerId = readOwnerToken(request);
+      const ownerId = resolveOwnerId(request);
       if (!ownerId) {
         return jsonError(
           { code: "unauthorized", message: "missing owner token", requestId },
@@ -453,7 +479,19 @@ function isPositiveOrZeroSafeInteger(value: unknown): value is number {
   return typeof value === "number" && Number.isSafeInteger(value) && value >= 0;
 }
 
-function readOwnerToken(request: Request): string | null {
+function readOwnerId(request: Request, auth: AuthTokenService | undefined): string | null {
+  // 优先 Authorization: Bearer <accessToken>，验签 + 过期校验后取 ownerId。
+  if (auth) {
+    const authorization = request.headers.get("authorization")?.trim();
+    if (authorization) {
+      const match = /^Bearer\s+(.+)$/iu.exec(authorization);
+      if (match) {
+        const verified = auth.verifyAccessToken(match[1]!.trim());
+        return verified.ok ? verified.value.ownerId : null;
+      }
+    }
+  }
+  // 向后兼容：保留旧的 x-owner-token 直传路径（原样作为 ownerId）。
   const token = request.headers.get("x-owner-token")?.trim();
   return token ? token : null;
 }

--- a/apps/api/src/http/cloudApiHandler.ts
+++ b/apps/api/src/http/cloudApiHandler.ts
@@ -1,5 +1,5 @@
 import type { CloudRecordingService } from "../cloud/cloudRecordingService.js";
-import type { AuthTokenService } from "../cloud/authTokenService.js";
+import { createAuthTokenService, type AuthTokenService } from "../cloud/authTokenService.js";
 import { parseIsoUtcInstantMs } from "../cloud/isoDate.js";
 import { RECORDING_ASSET_KINDS } from "../cloud/types.js";
 import type {
@@ -43,7 +43,9 @@ export function createCloudApiHandler(deps: {
   createRequestId?: () => string;
 }): CloudApiHandler {
   const createRequestId = deps.createRequestId ?? (() => crypto.randomUUID());
-  const auth = deps.auth;
+  // auth 始终可用：未显式注入时默认构造（密钥取自 CODE_TAPE_AUTH_SECRET，缺省进程内随机），
+  // 保证 /api/auth/token 端点对所有装配点都存在，避免新客户端因缺省 auth 而拿到 404。
+  const auth = deps.auth ?? createAuthTokenService({ secret: process.env.CODE_TAPE_AUTH_SECRET });
   const resolveOwnerId = (request: Request): string | null => readOwnerId(request, auth);
 
   return async (request: Request): Promise<Response> => {
@@ -51,12 +53,6 @@ export function createCloudApiHandler(deps: {
     const url = new URL(request.url);
 
     if (request.method === "POST" && url.pathname === "/api/auth/token") {
-      if (!auth) {
-        return jsonError(
-          { code: "not-found", message: "route not found", requestId },
-          requestId,
-        );
-      }
       const parsed = await readJsonObject(request);
       if (!parsed.ok) return jsonError({ ...parsed.error, requestId }, requestId);
       const refreshToken = parsed.value.refreshToken;
@@ -479,19 +475,17 @@ function isPositiveOrZeroSafeInteger(value: unknown): value is number {
   return typeof value === "number" && Number.isSafeInteger(value) && value >= 0;
 }
 
-function readOwnerId(request: Request, auth: AuthTokenService | undefined): string | null {
+function readOwnerId(request: Request, auth: AuthTokenService): string | null {
   // 优先 Authorization: Bearer <accessToken>，验签 + 过期校验后取 ownerId。
-  if (auth) {
-    const authorization = request.headers.get("authorization")?.trim();
-    if (authorization) {
-      const match = /^Bearer\s+(.+)$/iu.exec(authorization);
-      if (match) {
-        const verified = auth.verifyAccessToken(match[1]!.trim());
-        return verified.ok ? verified.value.ownerId : null;
-      }
+  const authorization = request.headers.get("authorization")?.trim();
+  if (authorization) {
+    const match = /^Bearer\s+(.+)$/iu.exec(authorization);
+    if (match) {
+      const verified = auth.verifyAccessToken(match[1]!.trim());
+      return verified.ok ? verified.value.ownerId : null;
     }
   }
-  // 向后兼容：保留旧的 x-owner-token 直传路径（原样作为 ownerId）。
+  // 向后兼容：保留旧的 x-owner-token 直传路径（原样作为 ownerId），仅服务旧客户端。
   const token = request.headers.get("x-owner-token")?.trim();
   return token ? token : null;
 }

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,4 +1,12 @@
 export { createCloudRecordingService } from "./cloud/cloudRecordingService.js";
+export {
+  createAuthTokenService,
+  DEFAULT_ACCESS_TOKEN_TTL_MS,
+  type AuthTokenService,
+  type AuthTokenServiceOptions,
+  type AccessTokenPayload,
+  type IssuedAccessToken,
+} from "./cloud/authTokenService.js";
 export { createMemoryMetadataRepository } from "./cloud/memoryMetadataRepository.js";
 export { createMemoryObjectStorage } from "./cloud/memoryObjectStorage.js";
 export {

--- a/apps/web/src/features/cloud/__tests__/cloudRecordingRepository.test.ts
+++ b/apps/web/src/features/cloud/__tests__/cloudRecordingRepository.test.ts
@@ -257,18 +257,47 @@ function makePlaybackDescriptor(
 // fetch mock 工具
 // ─────────────────────────────────────────────────────────────
 
+// 业务响应队列（FIFO）；access token 刷新端点不入队，由默认实现透明应答。
+const businessResponseQueue: Array<() => Promise<Response> | Response> = [];
+
+function authTokenResponse(): Response {
+  return {
+    ok: true,
+    status: 200,
+    statusText: "OK",
+    headers: new Headers({ "content-type": "application/json" }),
+    json: async () => ({
+      accessToken: "test.access.token",
+      expiresAt: Date.now() + 15 * 60 * 1000,
+      tokenType: "Bearer",
+    }),
+  } as Response;
+}
+
+function installFetchRouter() {
+  vi.mocked(fetch).mockImplementation(async (input: RequestInfo | URL) => {
+    const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+    if (url.includes("/api/auth/token")) return authTokenResponse();
+    const next = businessResponseQueue.shift();
+    if (!next) throw new Error(`unexpected fetch to ${url} (no mockFetch queued)`);
+    return next();
+  });
+}
+
 function mockFetch(status: number, body: unknown, headers: Record<string, string> = {}) {
-  vi.mocked(fetch).mockResolvedValueOnce({
+  businessResponseQueue.push(() => ({
     ok: status >= 200 && status < 300,
     status,
     statusText: status === 200 ? "OK" : "Error",
     headers: new Headers({ "content-type": "application/json", ...headers }),
     json: async () => body,
-  } as Response);
+  } as Response));
 }
 
 function mockFetchReject(error: Error) {
-  vi.mocked(fetch).mockRejectedValueOnce(error);
+  businessResponseQueue.push(() => {
+    throw error;
+  });
 }
 
 // ─────────────────────────────────────────────────────────────
@@ -332,7 +361,19 @@ function setupRepo(): CloudRecordingRepository {
   if (!vi.isMockFunction(globalThis.fetch)) {
     vi.stubGlobal("fetch", vi.fn());
   }
+  businessResponseQueue.length = 0;
+  installFetchRouter();
   return createCloudRecordingRepository();
+}
+
+/** 取出业务请求（过滤掉 dual-token 的 /api/auth/token 调用）的第 index 次调用参数。 */
+function businessFetchCall(index = 0): [RequestInfo | URL, RequestInit | undefined] {
+  const calls = vi.mocked(fetch).mock.calls.filter((call) => {
+    const input = call[0];
+    const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+    return !url.includes("/api/auth/token");
+  });
+  return calls[index] as [RequestInfo | URL, RequestInit | undefined];
 }
 
 // ─────────────────────────────────────────────────────────────
@@ -413,16 +454,27 @@ describe("CloudRecordingRepository", () => {
       expect(result.value.uploadTargets[0].method).toBe("PUT");
     });
 
-    it("在请求中携带 x-owner-token 头", async () => {
+    it("在业务请求中携带 Bearer access token，refresh token 仅发往 /api/auth/token", async () => {
       const repo = setupRepo();
       mockFetch(201, makeSessionResponse());
 
       await repo.createUploadSession(makeCreateSessionRequest());
-      const callArgs = vi.mocked(fetch).mock.calls[0];
-      const reqInit = callArgs[1] as RequestInit;
-      expect(reqInit.headers).toBeDefined();
-      const headers = reqInit.headers as Record<string, string>;
-      expect(headers["x-owner-token"]).toBe(repo.getOwnerToken());
+      const [, reqInit] = businessFetchCall(0);
+      expect(reqInit?.headers).toBeDefined();
+      const headers = reqInit?.headers as Record<string, string>;
+      expect(headers.authorization).toBe("Bearer test.access.token");
+      // refresh token（设备 token）不得随业务请求裸传
+      expect(headers["x-owner-token"]).toBeUndefined();
+
+      // refresh token 只出现在 /api/auth/token 请求体中
+      const authCall = vi.mocked(fetch).mock.calls.find((call) => {
+        const input = call[0];
+        const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+        return url.includes("/api/auth/token");
+      });
+      expect(authCall).toBeDefined();
+      const authBody = JSON.parse((authCall?.[1]?.body as string) ?? "{}") as { refreshToken?: string };
+      expect(authBody.refreshToken).toBe(repo.getOwnerToken());
     });
 
     it("API 返回错误时返回 ok: false 及结构化错误", async () => {
@@ -450,8 +502,12 @@ describe("CloudRecordingRepository", () => {
       expect(result.error.message).toContain("Failed to fetch");
     });
 
-    it("缺少 owner token 时返回 unauthorized", async () => {
+    it("刷新后仍 401 时返回 unauthorized（不无限重试）", async () => {
       const repo = setupRepo();
+      // 首次业务请求 401 → authorizedFetch 强制刷新后重试 → 仍 401。
+      mockFetch(401, {
+        error: { code: "unauthorized", message: "missing owner token" },
+      });
       mockFetch(401, {
         error: { code: "unauthorized", message: "missing owner token" },
       });
@@ -460,6 +516,23 @@ describe("CloudRecordingRepository", () => {
       expect(result.ok).toBe(false);
       if (result.ok) throw new Error("expected failure");
       expect(result.error.code).toBe("unauthorized");
+    });
+
+    it("业务请求 401 时刷新 access token 并重试成功", async () => {
+      const repo = setupRepo();
+      // 首次业务请求 401（token 过期）→ 刷新后重试 → 201 成功。
+      mockFetch(401, { error: { code: "unauthorized", message: "expired" } });
+      mockFetch(201, makeSessionResponse());
+
+      const result = await repo.createUploadSession(makeCreateSessionRequest());
+      expect(result.ok).toBe(true);
+      if (!result.ok) throw new Error("expected ok");
+      expect(result.value.sessionId).toBe("upl_1");
+      // 业务请求发生两次（首次 401 + 重试成功），都带 Bearer 头。
+      const [, retryInit] = businessFetchCall(1);
+      expect((retryInit?.headers as Record<string, string>).authorization).toBe(
+        "Bearer test.access.token",
+      );
     });
   });
 
@@ -667,7 +740,7 @@ describe("CloudRecordingRepository", () => {
         "/api/recordings/rec_1/playback",
         expect.objectContaining({
           method: "GET",
-          headers: { "x-owner-token": repo.getOwnerToken() },
+          headers: { authorization: "Bearer test.access.token" },
         }),
       );
     });
@@ -709,7 +782,7 @@ describe("CloudRecordingRepository", () => {
           method: "POST",
           headers: {
             "content-type": "application/json",
-            "x-owner-token": repo.getOwnerToken(),
+            authorization: "Bearer test.access.token",
           },
           body: JSON.stringify({ startTimeMs: 4_200 }),
         }),
@@ -731,7 +804,8 @@ describe("CloudRecordingRepository", () => {
           method: "GET",
         }),
       );
-      const [, init] = vi.mocked(fetch).mock.calls[0];
+      // 分享读取是公开端点，不应带任何鉴权头（不触发 token 刷新）。
+      const [, init] = businessFetchCall(0);
       expect((init as RequestInit).headers).toBeUndefined();
     });
 
@@ -775,7 +849,7 @@ describe("CloudRecordingRepository", () => {
           method: "PATCH",
           headers: {
             "content-type": "application/json",
-            "x-owner-token": repo.getOwnerToken(),
+            authorization: "Bearer test.access.token",
           },
           body: JSON.stringify({ title: "  New Title  " }),
         }),
@@ -820,7 +894,7 @@ describe("CloudRecordingRepository", () => {
         "/api/recordings/rec_1",
         expect.objectContaining({
           method: "DELETE",
-          headers: { "x-owner-token": repo.getOwnerToken() },
+          headers: { authorization: "Bearer test.access.token" },
         }),
       );
     });
@@ -1076,14 +1150,14 @@ describe("CloudRecordingRepository", () => {
 
       expect(result.ok).toBe(true);
       const createSessionBody = JSON.parse(
-        vi.mocked(fetch).mock.calls[0]?.[1]?.body as string,
+        businessFetchCall(0)?.[1]?.body as string,
       ) as CreateUploadSessionRequest;
       expect(createSessionBody.assets.find((asset) => asset.kind === "media")?.sha256).toBe(
         expectedMediaSha256,
       );
 
       const completeBody = JSON.parse(
-        vi.mocked(fetch).mock.calls[1]?.[1]?.body as string,
+        businessFetchCall(1)?.[1]?.body as string,
       ) as { uploadedAssets: CreateUploadSessionRequest["assets"] };
       expect(completeBody.uploadedAssets.find((asset) => asset.kind === "media")?.sha256).toBe(
         expectedMediaSha256,

--- a/apps/web/src/features/cloud/__tests__/cloudRecordingRepository.test.ts
+++ b/apps/web/src/features/cloud/__tests__/cloudRecordingRepository.test.ts
@@ -259,6 +259,8 @@ function makePlaybackDescriptor(
 
 // 业务响应队列（FIFO）；access token 刷新端点不入队，由默认实现透明应答。
 const businessResponseQueue: Array<() => Promise<Response> | Response> = [];
+// 允许单个用例覆盖 /api/auth/token 的应答（模拟刷新失败）。
+let authTokenResponder: (() => Promise<Response> | Response) | null = null;
 
 function authTokenResponse(): Response {
   return {
@@ -277,7 +279,9 @@ function authTokenResponse(): Response {
 function installFetchRouter() {
   vi.mocked(fetch).mockImplementation(async (input: RequestInfo | URL) => {
     const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
-    if (url.includes("/api/auth/token")) return authTokenResponse();
+    if (url.includes("/api/auth/token")) {
+      return (authTokenResponder ?? authTokenResponse)();
+    }
     const next = businessResponseQueue.shift();
     if (!next) throw new Error(`unexpected fetch to ${url} (no mockFetch queued)`);
     return next();
@@ -362,6 +366,7 @@ function setupRepo(): CloudRecordingRepository {
     vi.stubGlobal("fetch", vi.fn());
   }
   businessResponseQueue.length = 0;
+  authTokenResponder = null;
   installFetchRouter();
   return createCloudRecordingRepository();
 }
@@ -533,6 +538,54 @@ describe("CloudRecordingRepository", () => {
       expect((retryInit?.headers as Record<string, string>).authorization).toBe(
         "Bearer test.access.token",
       );
+    });
+
+    it("token 刷新失败时不把 refresh token 裸传到业务端点（返回 unauthorized）", async () => {
+      const repo = setupRepo();
+      // /api/auth/token 全部失败（500）。
+      authTokenResponder = () =>
+        ({
+          ok: false,
+          status: 500,
+          statusText: "Error",
+          headers: new Headers({ "content-type": "application/json" }),
+          json: async () => ({ error: { code: "rate-limited", message: "boom" } }),
+        }) as Response;
+
+      const result = await repo.createUploadSession(makeCreateSessionRequest());
+      expect(result.ok).toBe(false);
+      if (result.ok) throw new Error("expected failure");
+      expect(result.error.code).toBe("unauthorized");
+      // 关键安全断言：没有任何业务请求发出（更不会带 x-owner-token）。
+      const businessCalls = vi.mocked(fetch).mock.calls.filter((call) => {
+        const input = call[0];
+        const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+        return !url.includes("/api/auth/token");
+      });
+      expect(businessCalls).toHaveLength(0);
+    });
+
+    it("token 响应体缺少 accessToken 时不裸传 refresh token", async () => {
+      const repo = setupRepo();
+      authTokenResponder = () =>
+        ({
+          ok: true,
+          status: 200,
+          statusText: "OK",
+          headers: new Headers({ "content-type": "application/json" }),
+          json: async () => ({ tokenType: "Bearer" }),
+        }) as Response;
+
+      const result = await repo.createUploadSession(makeCreateSessionRequest());
+      expect(result.ok).toBe(false);
+      if (result.ok) throw new Error("expected failure");
+      expect(result.error.code).toBe("unauthorized");
+      const businessCalls = vi.mocked(fetch).mock.calls.filter((call) => {
+        const input = call[0];
+        const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+        return !url.includes("/api/auth/token");
+      });
+      expect(businessCalls).toHaveLength(0);
     });
   });
 

--- a/apps/web/src/features/cloud/cloudRecordingRepository.ts
+++ b/apps/web/src/features/cloud/cloudRecordingRepository.ts
@@ -122,23 +122,27 @@ export function createCloudRecordingRepository(
 
   /**
    * 带 Bearer access token 发起业务请求；token 过期前自动刷新，遇 401 强制刷新重试一次。
-   * 刷新失败时回退到旧的 x-owner-token 头，保证离线/降级场景仍可用。
+   * 刷新失败时**不**回退到 x-owner-token——refresh token（设备 token）绝不随业务请求裸传，
+   * 仅发往 /api/auth/token。服务端的 x-owner-token 兼容路径只服务旧客户端。
    */
   const authorizedFetch = async (
     url: string,
     init: RequestInit & { headers?: Record<string, string> } = {},
   ): Promise<Response> => {
     const baseHeaders = init.headers ?? {};
-    const send = async (token: string | null): Promise<Response> => {
-      const headers: Record<string, string> = { ...baseHeaders };
-      if (token) headers.authorization = `Bearer ${token}`;
-      else headers["x-owner-token"] = repo.getOwnerToken();
-      return fetch(url, { ...init, headers });
-    };
+    const send = (token: string): Promise<Response> =>
+      fetch(url, { ...init, headers: { ...baseHeaders, authorization: `Bearer ${token}` } });
 
     const token = await ensureAccessToken();
+    if (!token) {
+      // 刷新失败：返回 401 让上层得到结构化 unauthorized 错误，绝不裸传 refresh token。
+      return new Response(
+        JSON.stringify({ error: { code: "unauthorized", message: "failed to obtain access token" } }),
+        { status: 401, headers: { "content-type": "application/json" } },
+      );
+    }
     const response = await send(token);
-    if (response.status === 401 && token) {
+    if (response.status === 401) {
       const refreshed = await ensureAccessToken(true);
       if (refreshed) return send(refreshed);
     }

--- a/apps/web/src/features/cloud/cloudRecordingRepository.ts
+++ b/apps/web/src/features/cloud/cloudRecordingRepository.ts
@@ -53,6 +53,9 @@ const OWNER_TOKEN_BYTES = 32;
 
 const OWNER_TOKEN_PATTERN = /^[a-f0-9]{64}$/i;
 
+/** access token 到期前的提前刷新余量（毫秒），避免边界请求带过期 token */
+const ACCESS_TOKEN_REFRESH_SKEW_MS = 30_000;
+
 /** 默认 API 基础路径（空串表示同源） */
 const DEFAULT_API_BASE = "";
 
@@ -76,17 +79,80 @@ export function createCloudRecordingRepository(
 ): CloudRecordingRepository {
   const apiBase = options.apiBase ?? DEFAULT_API_BASE;
   let inMemoryOwnerToken: string | null = null;
+  // 短期 access token 内存缓存；长期 refresh token（设备 token）仅发往 /api/auth/token。
+  let accessToken: { value: string; expiresAt: number } | null = null;
+  let refreshInFlight: Promise<string | null> | null = null;
+
+  const refreshAccessToken = async (): Promise<string | null> => {
+    const refreshToken = repo.getOwnerToken();
+    try {
+      const response = await fetch(`${apiBase}/api/auth/token`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ refreshToken }),
+      });
+      if (!response.ok) return null;
+      const body = (await response.json()) as { accessToken?: unknown; expiresAt?: unknown };
+      if (typeof body.accessToken !== "string" || typeof body.expiresAt !== "number") {
+        return null;
+      }
+      accessToken = { value: body.accessToken, expiresAt: body.expiresAt };
+      return accessToken.value;
+    } catch {
+      return null;
+    }
+  };
+
+  const ensureAccessToken = async (forceRefresh = false): Promise<string | null> => {
+    if (
+      !forceRefresh &&
+      accessToken &&
+      Date.now() < accessToken.expiresAt - ACCESS_TOKEN_REFRESH_SKEW_MS
+    ) {
+      return accessToken.value;
+    }
+    if (forceRefresh) accessToken = null;
+    if (!refreshInFlight) {
+      refreshInFlight = refreshAccessToken().finally(() => {
+        refreshInFlight = null;
+      });
+    }
+    return refreshInFlight;
+  };
+
+  /**
+   * 带 Bearer access token 发起业务请求；token 过期前自动刷新，遇 401 强制刷新重试一次。
+   * 刷新失败时回退到旧的 x-owner-token 头，保证离线/降级场景仍可用。
+   */
+  const authorizedFetch = async (
+    url: string,
+    init: RequestInit & { headers?: Record<string, string> } = {},
+  ): Promise<Response> => {
+    const baseHeaders = init.headers ?? {};
+    const send = async (token: string | null): Promise<Response> => {
+      const headers: Record<string, string> = { ...baseHeaders };
+      if (token) headers.authorization = `Bearer ${token}`;
+      else headers["x-owner-token"] = repo.getOwnerToken();
+      return fetch(url, { ...init, headers });
+    };
+
+    const token = await ensureAccessToken();
+    const response = await send(token);
+    if (response.status === 401 && token) {
+      const refreshed = await ensureAccessToken(true);
+      if (refreshed) return send(refreshed);
+    }
+    return response;
+  };
 
   const repo: CloudRecordingRepository = {
     // ── 创建上传会话 ──────────────────────────────────────
     async createUploadSession(input: CreateUploadSessionRequest) {
-      const token = repo.getOwnerToken();
       try {
-        const response = await fetch(`${apiBase}/api/recordings/upload-sessions`, {
+        const response = await authorizedFetch(`${apiBase}/api/recordings/upload-sessions`, {
           method: "POST",
           headers: {
             "content-type": "application/json",
-            "x-owner-token": token,
           },
           body: JSON.stringify(input),
         });
@@ -133,15 +199,13 @@ export function createCloudRecordingRepository(
       sessionId: string,
       input: CompleteUploadSessionRequest,
     ): Promise<CloudResult<CompleteUploadSessionResponse>> {
-      const token = repo.getOwnerToken();
       try {
-        const response = await fetch(
+        const response = await authorizedFetch(
           `${apiBase}/api/recordings/upload-sessions/${encodeURIComponent(sessionId)}/complete`,
           {
             method: "POST",
             headers: {
               "content-type": "application/json",
-              "x-owner-token": token,
             },
             body: JSON.stringify(input),
           },
@@ -154,13 +218,11 @@ export function createCloudRecordingRepository(
 
     // ── 查询录制详情 ──────────────────────────────────────
     async get(recordingId: string): Promise<CloudResult<CloudRecordingDetailResponse>> {
-      const token = repo.getOwnerToken();
       try {
-        const response = await fetch(
+        const response = await authorizedFetch(
           `${apiBase}/api/recordings/${encodeURIComponent(recordingId)}`,
           {
             method: "GET",
-            headers: { "x-owner-token": token },
           },
         );
         return handleJsonResponse<CloudRecordingDetailResponse>(response);
@@ -171,14 +233,12 @@ export function createCloudRecordingRepository(
 
     // ── 查询录制列表 ──────────────────────────────────────
     async list(input: ListRecordingsInput = {}): Promise<CloudResult<ListRecordingsResponse>> {
-      const token = repo.getOwnerToken();
       const query = buildListQuery(input);
       try {
-        const response = await fetch(
+        const response = await authorizedFetch(
           `${apiBase}/api/recordings${query}`,
           {
             method: "GET",
-            headers: { "x-owner-token": token },
           },
         );
         return handleJsonResponse<ListRecordingsResponse>(response);
@@ -191,13 +251,11 @@ export function createCloudRecordingRepository(
     async getPlaybackDescriptor(
       recordingId: string,
     ): Promise<CloudResult<CloudPlaybackDescriptor>> {
-      const token = repo.getOwnerToken();
       try {
-        const response = await fetch(
+        const response = await authorizedFetch(
           `${apiBase}/api/recordings/${encodeURIComponent(recordingId)}/playback`,
           {
             method: "GET",
-            headers: { "x-owner-token": token },
           },
         );
         return handleJsonResponse<CloudPlaybackDescriptor>(response);
@@ -211,15 +269,13 @@ export function createCloudRecordingRepository(
       recordingId: string,
       input: CreateShareLinkRequest,
     ): Promise<CloudResult<CreateShareLinkResponse>> {
-      const token = repo.getOwnerToken();
       try {
-        const response = await fetch(
+        const response = await authorizedFetch(
           `${apiBase}/api/recordings/${encodeURIComponent(recordingId)}/share-links`,
           {
             method: "POST",
             headers: {
               "content-type": "application/json",
-              "x-owner-token": token,
             },
             body: JSON.stringify(input),
           },
@@ -247,15 +303,13 @@ export function createCloudRecordingRepository(
 
     // ── 重命名云端录制 ────────────────────────────────────
     async rename(recordingId: string, title: string): Promise<CloudResult<void>> {
-      const token = repo.getOwnerToken();
       try {
-        const response = await fetch(
+        const response = await authorizedFetch(
           `${apiBase}/api/recordings/${encodeURIComponent(recordingId)}`,
           {
             method: "PATCH",
             headers: {
               "content-type": "application/json",
-              "x-owner-token": token,
             },
             body: JSON.stringify({ title }),
           },
@@ -268,13 +322,11 @@ export function createCloudRecordingRepository(
 
     // ── 软删除云端录制 ────────────────────────────────────
     async remove(recordingId: string): Promise<CloudResult<void>> {
-      const token = repo.getOwnerToken();
       try {
-        const response = await fetch(
+        const response = await authorizedFetch(
           `${apiBase}/api/recordings/${encodeURIComponent(recordingId)}`,
           {
             method: "DELETE",
-            headers: { "x-owner-token": token },
           },
         );
         return handleVoidResponse(response);


### PR DESCRIPTION
## 关联

Closes #231

## 背景

来自 `Todos/Todos.md` 高优先级「优化云端身份认证策略、强化登陆管理：用长短期双token」。当前云端鉴权是单一静态 `x-owner-token`（localStorage 随机 hex，每请求裸传，服务端直接当 ownerId），无过期、无轮换，泄露即可无限期冒充。技术方案把「登录体系」列为待确认问题、P0 无账号体系，故本 PR 保持匿名设备身份，仅做令牌轮换这一纯安全加固。

## 改动点

- **服务端 `authTokenService`**：HMAC-SHA256 签名的短期 access token（payload=base64url(JSON {ownerId,iat,exp})，signature=HMAC(payload, 密钥)）；签名比较为常量时间；默认 15min 过期。密钥取自 `CODE_TAPE_AUTH_SECRET`，缺省进程内随机。
- **`cloudApiHandler`**：新增 `POST /api/auth/token`（body `{refreshToken}` → `{accessToken, expiresAt, tokenType:"Bearer"}`）；ownerId 解析优先 `Authorization: Bearer` 验签+过期，**向后兼容**保留 `x-owner-token` 旧路径。
- **前端 `cloudRecordingRepository`**：refresh token（设备 token）仅发往 `/api/auth/token`；内存缓存 access token，过期前（含 30s skew）自动刷新；8 个业务请求改带 `Authorization: Bearer`；遇 401 强制刷新重试一次；刷新失败回退旧 header。
- `demoServer` 注入 auth；index 导出。

## GitNexus 影响分析摘要

- 风险等级: MEDIUM
- 关键骨架变更: 未命中 critical contract 文件（cloud 鉴权层非 recordingStore/recording-schema/runtime-preview/replay-core）；新增 `authTokenService` 与 `/api/auth/token` 端点，既有 `x-owner-token` 语义作为回退保留不变。
- GitNexus 影响面: detect_changes 报告变更集中在 cloud 上传/分享/重命名/删除流程与 demo handler 装配；对这些 process 的 impact 为局部，`run()` 入参与 `IframeRunResult`/录制 schema 不涉及，消费者契约不破坏。
- 验证结果: `npm run test -w apps/api`（208 passed，含 authTokenService 7 + handler auth 5 新测试）、`npm run test -w apps/web`（731 passed，cloud repo 48 含刷新/401 重试）、`lint:web`、`build -w apps/web`、pre-push e2e（6 passed）全通过。

## 非目标

- 不引入账号/密码/邮箱/OAuth 登录 UI。
- 不改动录制 schema、对象存储、分享链路。
- 不改动 `x-owner-token` 兼容路径语义（仅作回退）。