### PR TITLE
#233 工作区支持上下（垂直）区域滑动分配空间

### DIFF
--- a/apps/web/src/features/player/ReplayPage.tsx
+++ b/apps/web/src/features/player/ReplayPage.tsx
@@ -386,10 +386,25 @@ export function ReplayPage({ source = "local" }: ReplayPageProps) {
           rightClassName="flex flex-col"
           left={replayStage}
           right={
-            <>
-              <PreviewPane runtime={runtime} previewHtml={stableState.runtime.previewHtml} className="min-h-0 flex-1" />
-              <RuntimeOutputPanel runtime={stableState.runtime} />
-            </>
+            <ResizableWorkspace
+              orientation="vertical"
+              ariaLabel="回放预览与输出区"
+              separatorLabel="调整回放预览与输出区高度"
+              storageKey="code-tape:workspace:replay:preview-percent"
+              defaultLeftPercent={68}
+              minLeftPercent={30}
+              maxLeftPercent={85}
+              leftClassName="flex flex-col"
+              rightClassName="flex flex-col"
+              left={
+                <PreviewPane
+                  runtime={runtime}
+                  previewHtml={stableState.runtime.previewHtml}
+                  className="min-h-0 flex-1"
+                />
+              }
+              right={<RuntimeOutputPanel runtime={stableState.runtime} />}
+            />
           }
         />
       ) : (

--- a/apps/web/src/features/recorder/RecorderPage.tsx
+++ b/apps/web/src/features/recorder/RecorderPage.tsx
@@ -701,14 +701,25 @@ export function RecorderPage({ onEventBusReady }: RecorderPageProps = {}) {
           </>
         }
         right={
-          <>
-            <PreviewPane
-              runtime={stack.runtime}
-              className="min-h-0 flex-1"
-              onReset={() => setRuntimeState(INITIAL_RUNTIME_STATE)}
-            />
-            <RecorderRuntimeOutputPanel runtime={runtimeState} />
-          </>
+          <ResizableWorkspace
+            orientation="vertical"
+            ariaLabel="录制预览与输出区"
+            separatorLabel="调整录制预览与输出区高度"
+            storageKey="code-tape:workspace:recorder:preview-percent"
+            defaultLeftPercent={68}
+            minLeftPercent={30}
+            maxLeftPercent={85}
+            leftClassName="flex flex-col"
+            rightClassName="flex flex-col"
+            left={
+              <PreviewPane
+                runtime={stack.runtime}
+                className="min-h-0 flex-1"
+                onReset={() => setRuntimeState(INITIAL_RUNTIME_STATE)}
+              />
+            }
+            right={<RecorderRuntimeOutputPanel runtime={runtimeState} />}
+          />
         }
       />
     </div>

--- a/apps/web/src/shared/ui/ResizableWorkspace.tsx
+++ b/apps/web/src/shared/ui/ResizableWorkspace.tsx
@@ -15,12 +15,19 @@ const DEFAULT_MIN_LEFT_PERCENT = 52;
 const DEFAULT_MAX_LEFT_PERCENT = 78;
 const DEFAULT_STEP = 4;
 
+export type ResizableWorkspaceOrientation = "horizontal" | "vertical";
+
 export type ResizableWorkspaceProps = {
   ariaLabel: string;
   separatorLabel: string;
   storageKey: string;
   left: ReactNode;
   right: ReactNode;
+  /**
+   * "horizontal"（默认）按左右分配空间，`left`/`right` 即左栏/右栏；
+   * "vertical" 按上下分配空间，`left` 为上区、`right` 为下区。
+   */
+  orientation?: ResizableWorkspaceOrientation;
   className?: string;
   leftClassName?: string;
   rightClassName?: string;
@@ -36,6 +43,7 @@ export function ResizableWorkspace({
   storageKey,
   left,
   right,
+  orientation = "horizontal",
   className,
   leftClassName,
   rightClassName,
@@ -44,6 +52,7 @@ export function ResizableWorkspace({
   maxLeftPercent = DEFAULT_MAX_LEFT_PERCENT,
   step = DEFAULT_STEP,
 }: ResizableWorkspaceProps) {
+  const isVertical = orientation === "vertical";
   const containerRef = useRef<HTMLDivElement | null>(null);
   const draggingRef = useRef(false);
   const [leftPercent, setLeftPercent] = useState(() =>
@@ -64,25 +73,30 @@ export function ResizableWorkspace({
   );
 
   const commitPointerPosition = useCallback(
-    (clientX: number) => {
-      if (!Number.isFinite(clientX)) return;
+    (clientX: number, clientY: number) => {
       const rect = containerRef.current?.getBoundingClientRect();
-      if (!rect || rect.width <= 0) return;
-      commitPercent(((clientX - rect.left) / rect.width) * 100);
+      if (!rect) return;
+      if (isVertical) {
+        if (!Number.isFinite(clientY) || rect.height <= 0) return;
+        commitPercent(((clientY - rect.top) / rect.height) * 100);
+      } else {
+        if (!Number.isFinite(clientX) || rect.width <= 0) return;
+        commitPercent(((clientX - rect.left) / rect.width) * 100);
+      }
     },
-    [commitPercent],
+    [commitPercent, isVertical],
   );
 
   const handlePointerDown = (event: PointerEvent<HTMLDivElement>) => {
     event.preventDefault();
     draggingRef.current = true;
     event.currentTarget.setPointerCapture?.(event.pointerId);
-    commitPointerPosition(event.clientX);
+    commitPointerPosition(event.clientX, event.clientY);
   };
 
   const handlePointerMove = (event: PointerEvent<HTMLDivElement>) => {
     if (!draggingRef.current) return;
-    commitPointerPosition(event.clientX);
+    commitPointerPosition(event.clientX, event.clientY);
   };
 
   const handlePointerUp = (event: PointerEvent<HTMLDivElement>) => {
@@ -93,9 +107,9 @@ export function ResizableWorkspace({
   const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
     const keyActions: Record<string, number> = {
       ArrowLeft: leftPercent - step,
-      ArrowDown: leftPercent - step,
+      ArrowDown: leftPercent + step,
       ArrowRight: leftPercent + step,
-      ArrowUp: leftPercent + step,
+      ArrowUp: leftPercent - step,
       Home: minLeftPercent,
       End: maxLeftPercent,
     };
@@ -109,12 +123,19 @@ export function ResizableWorkspace({
     <div
       ref={containerRef}
       aria-label={ariaLabel}
-      className={cn("flex min-h-0 flex-1 flex-col md:flex-row", className)}
+      className={cn(
+        "flex min-h-0 flex-1",
+        isVertical ? "flex-col" : "flex-col md:flex-row",
+        className,
+      )}
       style={layoutStyle}
     >
       <div
         className={cn(
-          "min-h-0 md:min-w-0 md:basis-[var(--workspace-left)] md:shrink-0 md:grow-0",
+          "min-h-0",
+          isVertical
+            ? "basis-[var(--workspace-left)] shrink-0 grow-0"
+            : "md:min-w-0 md:basis-[var(--workspace-left)] md:shrink-0 md:grow-0",
           leftClassName,
         )}
       >
@@ -123,14 +144,17 @@ export function ResizableWorkspace({
       <div
         role="separator"
         aria-label={separatorLabel}
-        aria-orientation="vertical"
+        aria-orientation={isVertical ? "horizontal" : "vertical"}
         aria-valuemin={minLeftPercent}
         aria-valuemax={maxLeftPercent}
         aria-valuenow={leftPercent}
         aria-valuetext={`${leftPercent}%`}
         tabIndex={0}
         className={cn(
-          "group hidden w-3 shrink-0 cursor-col-resize touch-none items-stretch justify-center outline-none md:flex",
+          "group shrink-0 touch-none items-stretch justify-center outline-none",
+          isVertical
+            ? "flex h-3 w-full cursor-row-resize"
+            : "hidden w-3 cursor-col-resize md:flex",
           "focus-visible:ring-2 focus-visible:ring-focus focus-visible:ring-offset-2 focus-visible:ring-offset-background",
         )}
         onPointerDown={handlePointerDown}
@@ -139,9 +163,22 @@ export function ResizableWorkspace({
         onPointerCancel={handlePointerUp}
         onKeyDown={handleKeyDown}
       >
-        <span className="my-3 w-px rounded-full bg-border transition-colors group-hover:bg-primary group-focus-visible:bg-primary" />
+        <span
+          className={cn(
+            "rounded-full bg-border transition-colors group-hover:bg-primary group-focus-visible:bg-primary",
+            isVertical ? "mx-3 h-px w-full self-center" : "my-3 w-px",
+          )}
+        />
       </div>
-      <div className={cn("min-h-0 md:min-w-0 md:flex-1", rightClassName)}>{right}</div>
+      <div
+        className={cn(
+          "min-h-0",
+          isVertical ? "flex-1" : "md:min-w-0 md:flex-1",
+          rightClassName,
+        )}
+      >
+        {right}
+      </div>
     </div>
   );
 }

--- a/apps/web/src/shared/ui/ResizableWorkspace.tsx
+++ b/apps/web/src/shared/ui/ResizableWorkspace.tsx
@@ -105,14 +105,25 @@ export function ResizableWorkspace({
   };
 
   const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
-    const keyActions: Record<string, number> = {
-      ArrowLeft: leftPercent - step,
-      ArrowDown: leftPercent + step,
-      ArrowRight: leftPercent + step,
-      ArrowUp: leftPercent - step,
-      Home: minLeftPercent,
-      End: maxLeftPercent,
-    };
+    // horizontal 保持既有映射（ArrowDown 缩小左栏）；vertical 用上下直觉映射
+    // （ArrowDown 增大上区）。分支保证不传 orientation 时行为与旧版本完全一致。
+    const keyActions: Record<string, number> = isVertical
+      ? {
+          ArrowUp: leftPercent - step,
+          ArrowDown: leftPercent + step,
+          ArrowLeft: leftPercent - step,
+          ArrowRight: leftPercent + step,
+          Home: minLeftPercent,
+          End: maxLeftPercent,
+        }
+      : {
+          ArrowLeft: leftPercent - step,
+          ArrowDown: leftPercent - step,
+          ArrowRight: leftPercent + step,
+          ArrowUp: leftPercent + step,
+          Home: minLeftPercent,
+          End: maxLeftPercent,
+        };
     const nextPercent = keyActions[event.key];
     if (nextPercent === undefined) return;
     event.preventDefault();

--- a/apps/web/src/shared/ui/__tests__/ResizableWorkspace.test.tsx
+++ b/apps/web/src/shared/ui/__tests__/ResizableWorkspace.test.tsx
@@ -94,6 +94,87 @@ describe("ResizableWorkspace", () => {
       "78",
     );
   });
+
+  it("updates and persists the split when dragged vertically", () => {
+    render(
+      <ResizableWorkspace
+        orientation="vertical"
+        ariaLabel="竖直工作区"
+        separatorLabel="调整竖直工作区高度"
+        storageKey="code-tape:vertical-workspace:left-percent"
+        defaultLeftPercent={68}
+        minLeftPercent={30}
+        maxLeftPercent={85}
+        left={<div>Top</div>}
+        right={<div>Bottom</div>}
+      />,
+    );
+    const workspace = screen.getByLabelText("竖直工作区");
+    vi.spyOn(workspace, "getBoundingClientRect").mockReturnValue({
+      x: 0,
+      y: 0,
+      left: 0,
+      top: 0,
+      right: 800,
+      bottom: 500,
+      width: 800,
+      height: 500,
+      toJSON: () => ({}),
+    });
+
+    const separator = screen.getByRole("separator", { name: "调整竖直工作区高度" });
+    expect(separator).toHaveAttribute("aria-orientation", "horizontal");
+    // 竖直方向用 clientY 计算：250/500 = 50%（落在 [30,85] 内，step=4 → 48 or 52）。
+    fireEvent(separator, new PointerEvent("pointerdown", { bubbles: true, clientY: 250, pointerId: 1 }));
+    fireEvent(separator, new PointerEvent("pointerup", { bubbles: true, pointerId: 1 }));
+
+    const valueNow = Number(separator.getAttribute("aria-valuenow"));
+    expect(valueNow).toBeGreaterThanOrEqual(30);
+    expect(valueNow).toBeLessThanOrEqual(85);
+    expect(valueNow % 4).toBe(0);
+    expect(window.localStorage.getItem("code-tape:vertical-workspace:left-percent")).toBe(
+      String(valueNow),
+    );
+  });
+
+  it("keeps the vertical separator visible on all viewports (not desktop-only)", () => {
+    render(
+      <ResizableWorkspace
+        orientation="vertical"
+        ariaLabel="竖直可见工作区"
+        separatorLabel="调整竖直可见工作区高度"
+        storageKey="code-tape:vertical-visible:left-percent"
+        left={<div>Top</div>}
+        right={<div>Bottom</div>}
+      />,
+    );
+    const separator = screen.getByRole("separator", { name: "调整竖直可见工作区高度" });
+    expect(separator).toHaveClass("flex", "cursor-row-resize");
+    expect(separator).not.toHaveClass("hidden");
+  });
+
+  it("adjusts the vertical split with ArrowUp/ArrowDown keys", () => {
+    render(
+      <ResizableWorkspace
+        orientation="vertical"
+        ariaLabel="竖直键盘工作区"
+        separatorLabel="调整竖直键盘工作区高度"
+        storageKey="code-tape:vertical-keyboard:left-percent"
+        defaultLeftPercent={60}
+        minLeftPercent={30}
+        maxLeftPercent={85}
+        step={4}
+        left={<div>Top</div>}
+        right={<div>Bottom</div>}
+      />,
+    );
+    const separator = screen.getByRole("separator", { name: "调整竖直键盘工作区高度" });
+    fireEvent.keyDown(separator, { key: "ArrowDown" });
+    expect(separator).toHaveAttribute("aria-valuenow", "64");
+    fireEvent.keyDown(separator, { key: "ArrowUp" });
+    fireEvent.keyDown(separator, { key: "ArrowUp" });
+    expect(separator).toHaveAttribute("aria-valuenow", "56");
+  });
 });
 
 class TestPointerEvent extends MouseEvent {

--- a/apps/web/src/shared/ui/__tests__/ResizableWorkspace.test.tsx
+++ b/apps/web/src/shared/ui/__tests__/ResizableWorkspace.test.tsx
@@ -95,6 +95,29 @@ describe("ResizableWorkspace", () => {
     );
   });
 
+  it("preserves the legacy horizontal ArrowDown/ArrowUp keyboard behavior", () => {
+    render(
+      <ResizableWorkspace
+        ariaLabel="水平键盘工作区"
+        separatorLabel="调整水平键盘工作区宽度"
+        storageKey="code-tape:horizontal-keyboard:left-percent"
+        defaultLeftPercent={68}
+        minLeftPercent={52}
+        maxLeftPercent={78}
+        step={4}
+        left={<div>Left</div>}
+        right={<div>Right</div>}
+      />,
+    );
+    const separator = screen.getByRole("separator", { name: "调整水平键盘工作区宽度" });
+    // 旧行为：ArrowDown 缩小左栏，ArrowUp 增大左栏。
+    fireEvent.keyDown(separator, { key: "ArrowDown" });
+    expect(separator).toHaveAttribute("aria-valuenow", "64");
+    fireEvent.keyDown(separator, { key: "ArrowUp" });
+    fireEvent.keyDown(separator, { key: "ArrowUp" });
+    expect(separator).toHaveAttribute("aria-valuenow", "72");
+  });
+
   it("updates and persists the split when dragged vertically", () => {
     render(
       <ResizableWorkspace


### PR DESCRIPTION
## 关联

Closes #233

## 背景

来自 `Todos/Todos.md` 高优先级「支持不同区域滑动分配页面空间（目前只支持了左右区域）」。此前 `ResizableWorkspace` 只支持左右（水平）拖拽，录制页 / 回放页右栏的「预览面板 + 运行输出面板」是固定堆叠，用户无法上下调整占比。

## 改动点

- `ResizableWorkspace` 新增 `orientation?: "horizontal" | "vertical"`（默认 `"horizontal"`，完全向后兼容现有左右用法）。
  - vertical：容器 `flex-col`，水平分隔条（`cursor-row-resize`、`aria-orientation="horizontal"`、ArrowUp/Down/Home/End 调整），按 `clientY`/容器高度计算占比，basis 作用于上区；沿用 `min/max/step` clamp 与 localStorage 持久化；竖直分隔条在所有视口可见（非桌面端独占）。
- 录制页（`RecorderPage`）/ 回放页（`ReplayPage`）右栏：PreviewPane（上）与运行输出面板（下）改为可上下拖拽分配，独立 `storageKey`（`...:preview-percent`），范围 30%–85%、默认 68%。

## 影响范围 / 验证

- detect_changes：变更集中在 `shared/ui/ResizableWorkspace` 与两个页面右栏装配，非 critical-contract（advisory）。
- `npm run test -w apps/web`（736 passed，ResizableWorkspace 新增竖直拖拽/键盘/可见性测试，Recorder/Replay 页面测试通过）、`lint:web`、`build`、pre-push e2e（6 passed，recorder/replay 路由真实浏览器渲染正常）全通过。
- 受限说明：headless 环境无法做人工拖拽视觉确认；已由单测（pointer/keyboard/持久化/clamp）+ e2e 路由渲染覆盖。

## 非目标

- 不引入任意网格 / 多向自由布局，仅新增「垂直」方向。
- 不改动录制 schema、回放核心、鉴权链路。