### PR TITLE
#235 编辑器支持 HTML/CSS 渲染运行与 Python 高亮

### DIFF
--- a/apps/web/src/features/capture/__tests__/runtimeProducer.test.ts
+++ b/apps/web/src/features/capture/__tests__/runtimeProducer.test.ts
@@ -14,6 +14,7 @@ import { createRuntimeProducer } from "../runtimeProducer";
 function setup(overrides: {
   compile?: PreviewCompiler["compile"];
   run?: IframeRuntime["run"];
+  renderDocument?: IframeRuntime["renderDocument"];
 } = {}) {
   const clock = createRecordingClock({ nowProvider: () => 1000 });
   const bus = createEventBus({ clock, wallTimeProvider: () => "T" });
@@ -35,18 +36,22 @@ function setup(overrides: {
         stderr: [],
       })),
   );
+  const renderDocument = vi.fn(
+    overrides.renderDocument ?? (async (html: string): Promise<string> => html),
+  );
   const compiler: PreviewCompiler = { compile };
   const runtime: IframeRuntime = {
     mount: vi.fn(),
     run,
     renderPreview: vi.fn(),
+    renderDocument,
     reset: vi.fn(),
     destroy: vi.fn(),
   };
   const producer = createRuntimeProducer({ bus, clock, compiler, runtime });
   clock.start();
   producer.start();
-  return { bus, compile, producer, run, runtime };
+  return { bus, compile, producer, run, renderDocument, runtime };
 }
 
 describe("createRuntimeProducer", () => {
@@ -86,6 +91,59 @@ describe("createRuntimeProducer", () => {
         },
       },
     ]);
+  });
+
+  it("emits run-start then run-output for an HTML render (no JS compile/exec)", async () => {
+    const { bus, compile, producer, run, renderDocument } = setup();
+
+    const result = await producer.trigger({
+      language: "html",
+      source: "<h1>hi</h1>",
+    });
+
+    expect(compile).not.toHaveBeenCalled();
+    expect(run).not.toHaveBeenCalled();
+    expect(renderDocument).toHaveBeenCalledWith("<h1>hi</h1>");
+    expect(result.status).toBe("complete");
+    if (result.status === "complete") {
+      expect(result.previewHtml).toBe("<h1>hi</h1>");
+      expect(result.stdout).toEqual([]);
+    }
+    const events = bus.drain().map((event) => ({ type: event.type, payload: event.payload }));
+    expect(events[0]).toEqual({
+      type: "run-start",
+      payload: { language: "html", runtime: "iframe", runId: result.runId },
+    });
+    expect(events[1]?.type).toBe("run-output");
+  });
+
+  it("wraps CSS in an HTML scaffold and renders it (no JS compile/exec)", async () => {
+    const { compile, producer, run, renderDocument } = setup();
+
+    const result = await producer.trigger({
+      language: "css",
+      source: "h1 { color: red; }",
+    });
+
+    expect(compile).not.toHaveBeenCalled();
+    expect(run).not.toHaveBeenCalled();
+    const renderedHtml = renderDocument.mock.calls[0]?.[0] as string;
+    expect(renderedHtml).toContain("<style>h1 { color: red; }</style>");
+    expect(result.status).toBe("complete");
+  });
+
+  it("emits run-error if HTML render throws", async () => {
+    const { bus, producer } = setup({
+      renderDocument: async () => {
+        throw new Error("render boom");
+      },
+    });
+
+    const result = await producer.trigger({ language: "html", source: "<h1>x</h1>" });
+
+    expect(result.status).toBe("error");
+    const types = bus.drain().map((event) => event.type);
+    expect(types).toEqual(["run-start", "run-error"]);
   });
 
   it("emits run-error with transpile phase when compilation fails", async () => {

--- a/apps/web/src/features/capture/runtimeProducer.ts
+++ b/apps/web/src/features/capture/runtimeProducer.ts
@@ -16,6 +16,25 @@ function errorInfo(err: unknown): { message: string; stack?: string } {
   return { message: String(err) };
 }
 
+/**
+ * 为 HTML/CSS「运行」构造注入 no-script sandbox 的静态文档。
+ * - HTML：源码本身即文档（renderDocument 内部会剥离 <script> 并套 CSP）。
+ * - CSS：包进最小 HTML 脚手架的 <style>，让用户看到样式作用在示例结构上。
+ */
+function buildRenderDocument(language: "html" | "css", source: string): string {
+  if (language === "html") return source;
+  return [
+    "<body>",
+    `<style>${source}</style>`,
+    '<main class="code-tape-css-preview">',
+    "<h1>CSS Preview</h1>",
+    "<p>这是用于预览样式效果的示例文本。This is sample text for previewing your styles.</p>",
+    '<button type="button">Button</button>',
+    "</main>",
+    "</body>",
+  ].join("");
+}
+
 export const createRuntimeProducer: CreateRuntimeProducer = (deps): RuntimeProducerHandle => {
   const { bus, compiler, runtime } = deps;
   let paused = false;
@@ -115,6 +134,29 @@ export const createRuntimeProducer: CreateRuntimeProducer = (deps): RuntimeProdu
             runId,
           },
         });
+
+        // HTML/CSS：渲染到只读（no-script）sandbox，不走 JS 编译/执行链路。
+        if (input.language === "html" || input.language === "css") {
+          let previewHtml: string;
+          try {
+            previewHtml = await runtime.renderDocument(buildRenderDocument(input.language, input.source));
+          } catch (err) {
+            return emitRuntimeThrownError(runId, err);
+          }
+          bus.emit({
+            type: "run-output",
+            source: "runtime",
+            track: "runtime",
+            payload: { runId, stdout: [], stderr: [], previewHtml, status: "success" },
+          });
+          return {
+            runId,
+            status: "complete",
+            previewHtml,
+            stdout: [],
+            stderr: [],
+          };
+        }
 
         let compiled: CompileResult;
         try {

--- a/apps/web/src/features/capture/types.ts
+++ b/apps/web/src/features/capture/types.ts
@@ -135,7 +135,7 @@ export type RuntimeProducerHandle = EventProducer & {
    * result so the page UI can render console output during the run.
    */
   trigger(input: {
-    language: "javascript" | "typescript";
+    language: "javascript" | "typescript" | "html" | "css";
     source: string;
   }): Promise<RuntimeProducerRunResult>;
 };

--- a/apps/web/src/features/editor/CodeEditor.tsx
+++ b/apps/web/src/features/editor/CodeEditor.tsx
@@ -131,6 +131,9 @@ async function loadMonaco() {
     await Promise.all([
       import("monaco-editor/esm/vs/basic-languages/javascript/javascript.contribution"),
       import("monaco-editor/esm/vs/basic-languages/typescript/typescript.contribution"),
+      import("monaco-editor/esm/vs/basic-languages/python/python.contribution"),
+      import("monaco-editor/esm/vs/basic-languages/html/html.contribution"),
+      import("monaco-editor/esm/vs/basic-languages/css/css.contribution"),
       import("monaco-editor/esm/vs/editor/contrib/comment/browser/comment"),
       import("monaco-editor/esm/vs/editor/contrib/format/browser/formatActions"),
       import("monaco-editor/esm/vs/editor/standalone/browser/quickAccess/standaloneGotoLineQuickAccess"),

--- a/apps/web/src/features/editor/__tests__/CodeEditor.test.tsx
+++ b/apps/web/src/features/editor/__tests__/CodeEditor.test.tsx
@@ -205,6 +205,9 @@ vi.mock("monaco-editor/esm/vs/editor/editor.api", () => ({
 }));
 vi.mock("monaco-editor/esm/vs/basic-languages/javascript/javascript.contribution", () => ({}));
 vi.mock("monaco-editor/esm/vs/basic-languages/typescript/typescript.contribution", () => ({}));
+vi.mock("monaco-editor/esm/vs/basic-languages/python/python.contribution", () => ({}));
+vi.mock("monaco-editor/esm/vs/basic-languages/html/html.contribution", () => ({}));
+vi.mock("monaco-editor/esm/vs/basic-languages/css/css.contribution", () => ({}));
 vi.mock("monaco-editor/esm/vs/editor/contrib/comment/browser/comment", () => ({}));
 vi.mock("monaco-editor/esm/vs/editor/contrib/format/browser/formatActions", () => ({}));
 vi.mock("monaco-editor/esm/vs/editor/standalone/browser/quickAccess/standaloneGotoLineQuickAccess", () => ({}));

--- a/apps/web/src/features/recorder/RecorderPage.tsx
+++ b/apps/web/src/features/recorder/RecorderPage.tsx
@@ -113,8 +113,21 @@ export function RecorderPage({ onEventBusReady }: RecorderPageProps = {}) {
     const devices = createMediaDevicesController();
     let currentEditorLanguage: RecordingLanguage = "javascript";
     let currentMediaCapability: MediaCapability = INITIAL_CONTROLLER_STATE.mediaCapability;
-    const getCurrentRuntimeLanguage = (): RunStartPayload["language"] =>
-      currentEditorLanguage === "typescript" ? "typescript" : "javascript";
+    const getCurrentRuntimeLanguage = (): RunStartPayload["language"] | null => {
+      switch (currentEditorLanguage) {
+        case "typescript":
+          return "typescript";
+        case "html":
+          return "html";
+        case "css":
+          return "css";
+        case "javascript":
+          return "javascript";
+        case "python":
+          // Python：只高亮 / 录制 / 回放，不执行（见 docs/技术方案.md 第六章）。
+          return null;
+      }
+    };
     const editorProducer = createEditorProducer({
       bus,
       clock,
@@ -557,13 +570,16 @@ export function RecorderPage({ onEventBusReady }: RecorderPageProps = {}) {
   const handleRun = async (options: { clearPendingAutoRun?: boolean } = {}) => {
     if (options.clearPendingAutoRun ?? true) clearAutoRunTimer();
     if (isRuntimeRunLocked()) return;
+    const runtimeLanguage = stack.getCurrentRuntimeLanguage();
+    // Python 不执行：跳过运行，保持高亮/录制/回放。
+    if (runtimeLanguage === null) return;
     const editor = editorRef.current?.getEditor();
     if (!editor) return;
     stack.editorProducer.flushPending();
     setRuntimeState({ status: "running", stdout: [], stderr: [], errorMessage: null });
     try {
       const result = await stack.runtimeProducer.trigger({
-        language: stack.getCurrentRuntimeLanguage(),
+        language: runtimeLanguage,
         source: editor.getValue(),
       });
       if (result.status === "complete") {
@@ -788,6 +804,9 @@ function RecorderSetupToolbar({
         options={[
           { value: "javascript", label: "JavaScript" },
           { value: "typescript", label: "TypeScript" },
+          { value: "html", label: "HTML" },
+          { value: "css", label: "CSS" },
+          { value: "python", label: "Python" },
         ]}
       />
       <LabeledSelect

--- a/apps/web/src/features/runtime-preview/__tests__/iframeRuntime.test.ts
+++ b/apps/web/src/features/runtime-preview/__tests__/iframeRuntime.test.ts
@@ -266,6 +266,27 @@ describe("IframeRuntime sandbox lifecycle", () => {
     host.remove();
   });
 
+  it("renders a document in a no-script sandbox and returns sanitized markup", async () => {
+    const host = document.createElement("div");
+    document.body.appendChild(host);
+    const runtime = createIframeRuntime();
+
+    await runtime.mount(host);
+    const returned = await runtime.renderDocument(
+      "<body><h1>hello</h1><script>window.x=1</script></body>",
+    );
+    const frame = host.querySelector("iframe");
+
+    expect(frame?.getAttribute("sandbox")).toBe("");
+    expect(frame?.srcdoc).toContain("script-src 'none'");
+    expect(frame?.srcdoc).toContain("<h1>hello</h1>");
+    expect(frame?.srcdoc).not.toMatch(/<script/i);
+    // 返回的标记用于回放持久化（保留原始 HTML，便于复现）。
+    expect(returned).toContain("<h1>hello</h1>");
+    runtime.destroy();
+    host.remove();
+  });
+
   it("keeps the mounted host usable after reset", async () => {
     const host = document.createElement("div");
     document.body.appendChild(host);

--- a/apps/web/src/features/runtime-preview/__tests__/iframeRuntime.test.ts
+++ b/apps/web/src/features/runtime-preview/__tests__/iframeRuntime.test.ts
@@ -281,8 +281,10 @@ describe("IframeRuntime sandbox lifecycle", () => {
     expect(frame?.srcdoc).toContain("script-src 'none'");
     expect(frame?.srcdoc).toContain("<h1>hello</h1>");
     expect(frame?.srcdoc).not.toMatch(/<script/i);
-    // 返回的标记用于回放持久化（保留原始 HTML，便于复现）。
+    // 返回值是净化后的标记（脚本已剥离），作为 previewHtml 持久化时不含脚本。
     expect(returned).toContain("<h1>hello</h1>");
+    expect(returned).not.toMatch(/<script/i);
+    expect(returned).not.toContain("window.x=1");
     runtime.destroy();
     host.remove();
   });

--- a/apps/web/src/features/runtime-preview/iframeRuntime.ts
+++ b/apps/web/src/features/runtime-preview/iframeRuntime.ts
@@ -275,11 +275,12 @@ export function createIframeRuntime(options: IframeRuntimeOptions = {}): IframeR
       await createIframe("", buildPreviewSrcDoc(previewHtml));
     },
     async renderDocument(html: string): Promise<string> {
-      const srcdoc = buildPreviewSrcDoc(html);
-      await createIframe("", srcdoc);
-      // Persist exactly what was written (post-sanitize) so replay restores the
-      // same no-script document; cap to the preview budget for recording size.
-      return limitString(html, RUNTIME_PREVIEW_HTML_MAX_CHARS);
+      const safe = sanitizePreviewHtml(html);
+      await createIframe("", buildPreviewSrcDoc(html));
+      // Return the SANITIZED markup actually rendered (scripts stripped), so the
+      // persisted previewHtml is script-free regardless of who re-renders it.
+      const sanitized = safe.headHtml ? `${safe.headHtml}${safe.bodyHtml}` : safe.bodyHtml;
+      return limitString(sanitized, RUNTIME_PREVIEW_HTML_MAX_CHARS);
     },
     reset() {
       teardown();

--- a/apps/web/src/features/runtime-preview/iframeRuntime.ts
+++ b/apps/web/src/features/runtime-preview/iframeRuntime.ts
@@ -274,6 +274,13 @@ export function createIframeRuntime(options: IframeRuntimeOptions = {}): IframeR
     async renderPreview(previewHtml: string): Promise<void> {
       await createIframe("", buildPreviewSrcDoc(previewHtml));
     },
+    async renderDocument(html: string): Promise<string> {
+      const srcdoc = buildPreviewSrcDoc(html);
+      await createIframe("", srcdoc);
+      // Persist exactly what was written (post-sanitize) so replay restores the
+      // same no-script document; cap to the preview budget for recording size.
+      return limitString(html, RUNTIME_PREVIEW_HTML_MAX_CHARS);
+    },
     reset() {
       teardown();
     },

--- a/apps/web/src/shared/recording-schema/__tests__/validators.test.ts
+++ b/apps/web/src/shared/recording-schema/__tests__/validators.test.ts
@@ -52,6 +52,23 @@ describe("validateRecordingPackageV1", () => {
     expect(result.ok).toBe(true);
   });
 
+  it.each(["javascript", "typescript", "python", "html", "css"] as const)(
+    "accepts initialLanguage %s",
+    (language) => {
+      const pkg = makePackage();
+      pkg.meta.initialLanguage = language;
+      const result = validateRecordingPackageV1(pkg);
+      expect(result.ok).toBe(true);
+    },
+  );
+
+  it("rejects an unknown initialLanguage", () => {
+    const pkg = makePackage();
+    (pkg.meta as { initialLanguage: string }).initialLanguage = "rust";
+    const result = validateRecordingPackageV1(pkg);
+    expect(result.ok).toBe(false);
+  });
+
   it("rejects non-object inputs", () => {
     const result = validateRecordingPackageV1("not a package");
     expect(result.ok).toBe(false);

--- a/packages/recording-schema/src/types.ts
+++ b/packages/recording-schema/src/types.ts
@@ -15,7 +15,7 @@ export type RecordingSchemaVersion = typeof RECORDING_SCHEMA_VERSION;
 // Meta / Manifest / Media / Indexes
 // ─────────────────────────────────────────────────────────────────────────────
 
-export type RecordingLanguage = "javascript" | "typescript" | "python";
+export type RecordingLanguage = "javascript" | "typescript" | "python" | "html" | "css";
 export type RecordingTheme = "light" | "dark";
 
 export type MediaCapability = {
@@ -177,7 +177,11 @@ export type CameraPositionPayload = { x: number; y: number };
 
 // — Runtime —
 
-export type RunStartPayload = { language: "javascript" | "typescript"; runtime: "iframe"; runId: string };
+export type RunStartPayload = {
+  language: "javascript" | "typescript" | "html" | "css";
+  runtime: "iframe";
+  runId: string;
+};
 
 export type RunOutputPayload = {
   runId: string;
@@ -597,6 +601,12 @@ export type IframeRuntime = {
   mount(host: HTMLElement): Promise<void>;
   run(input: IframeRunInput): Promise<IframeRunResult>;
   renderPreview(previewHtml: string): Promise<void>;
+  /**
+   * Render static HTML markup into a read-only (no-script) sandbox iframe and
+   * return the sanitized markup actually written, so the caller can persist it
+   * as the run's previewHtml for replay. Used for HTML/CSS "run" (no JS exec).
+   */
+  renderDocument(html: string): Promise<string>;
   reset(): void;
   destroy(): void;
 };

--- a/packages/recording-schema/src/validators.ts
+++ b/packages/recording-schema/src/validators.ts
@@ -38,7 +38,7 @@ const EVENT_SOURCES = new Set([
   "annotation",
 ]);
 const EVENT_TRACKS = new Set(["main", "media", "runtime", "ui"]);
-const LANGUAGES = new Set(["javascript", "typescript", "python"]);
+const LANGUAGES = new Set(["javascript", "typescript", "python", "html", "css"]);
 
 export function isKnownRecordingEventType(type: unknown): type is RecordingEventType {
   return typeof type === "string" && EVENT_TYPES.has(type as RecordingEventType);
@@ -114,8 +114,12 @@ function validateMeta(value: unknown, errors: SchemaValidationIssue[]): void {
   if (value.ownerId !== null && typeof value.ownerId !== "string") {
     pushIssue(errors, "meta.ownerId", "ownerId must be string or null");
   }
-  if (value.initialLanguage !== "javascript" && value.initialLanguage !== "typescript" && value.initialLanguage !== "python") {
-    pushIssue(errors, "meta.initialLanguage", "initialLanguage must be one of javascript|typescript|python");
+  if (typeof value.initialLanguage !== "string" || !LANGUAGES.has(value.initialLanguage)) {
+    pushIssue(
+      errors,
+      "meta.initialLanguage",
+      "initialLanguage must be one of javascript|typescript|python|html|css",
+    );
   }
   expectNumber(value.initialFontSize, "meta.initialFontSize", errors);
   if (value.initialTheme !== "light" && value.initialTheme !== "dark") {
@@ -233,7 +237,7 @@ function validateEventPayload(
       expectNumber(payload.y, `${path}.y`, errors);
       break;
     case "run-start":
-      expectOneOf(payload.language, ["javascript", "typescript"], `${path}.language`, errors);
+      expectOneOf(payload.language, ["javascript", "typescript", "html", "css"], `${path}.language`, errors);
       expectLiteral(payload.runtime, "iframe", `${path}.runtime`, errors);
       expectString(payload.runId, `${path}.runId`, errors);
       break;


### PR DESCRIPTION
## 关联

Closes #235

## 背景

来自 `Todos/Todos.md` 高优先级「支持 python, HTML 等语言」（用户补充 CSS）。此前选择器只给 JS/TS。`docs/PRD.md` P1 前端执行明确列 JS/TS/CSS/HTML；`docs/技术方案.md` 第六章运行表只列 JS/TS + Python(只高亮)，遗漏 HTML/CSS——本 PR 按 PRD 对齐补齐 HTML/CSS 渲染。

## 改动点

- **schema**：`RecordingLanguage` 增加 `html`/`css`；`validators` 的 `LANGUAGES`、`initialLanguage`、`run-start.language` 校验同步。
- **编辑器**：Monaco 加载 `python`/`html`/`css` basic-language contribution（高亮）。
- **选择器**：RecorderPage 语言下拉新增 HTML / CSS / Python。
- **运行分流**：JS/TS 编译执行不变；HTML/CSS 经新增 `IframeRuntime.renderDocument` 注入**只读 no-script sandbox**渲染（CSS 包进最小 HTML 脚手架 `<style>`），run-output 持久化渲染 HTML 供回放；Python 不执行（`getCurrentRuntimeLanguage` 返回 null、`handleRun` 跳过），仅高亮/录制/回放。

## GitNexus 影响分析摘要

- 风险等级: MEDIUM
- 关键骨架变更: 命中 critical contract `packages/recording-schema`（`RecordingLanguage`/`RunStartPayload`/validators 扩展，向后兼容——既有 js/ts/python 包仍校验通过）与 `runtime-preview`（新增 `renderDocument`，不改既有 run/renderPreview 契约）。
- GitNexus 影响面: detect_changes 报告变更集中在 schema validators、runtimeProducer.trigger、CodeEditor.loadMonaco、RecorderPage 运行装配；impact 显示受影响 process 为 Monaco 加载链（多加载 3 个 contribution）与 run trigger，无意外 fan-out。
- 验证结果: `npm run test -w apps/web`（747 passed，新增 HTML/CSS 渲染、Python 不执行、renderDocument、initialLanguage 多语言校验测试）、`npm run test -w apps/api`（209 passed）、`lint:web`、`build`、pre-push e2e（6 passed）全通过。

## 非目标

- 不在前端执行 Python（遵循技术方案）。
- HTML/CSS 渲染不开放 `allow-scripts`，沿用 no-script + CSP 既有安全边界。
- 不引入第三方依赖/打包/多文件工程。