### PR TITLE
#237 运行预览 iframe 跟随主题色，黑色主题不再显示白底

### DIFF
--- a/apps/web/src/features/capture/__tests__/runtimeProducer.test.ts
+++ b/apps/web/src/features/capture/__tests__/runtimeProducer.test.ts
@@ -45,6 +45,7 @@ function setup(overrides: {
     run,
     renderPreview: vi.fn(),
     renderDocument,
+    setTheme: vi.fn(),
     reset: vi.fn(),
     destroy: vi.fn(),
   };

--- a/apps/web/src/features/interview/RemoteInterviewWorkbenchPage.tsx
+++ b/apps/web/src/features/interview/RemoteInterviewWorkbenchPage.tsx
@@ -673,6 +673,7 @@ export function RemoteInterviewWorkbenchView({
             <PreviewPane
               runtime={previewRuntime}
               previewHtml={runtime.previewHtml}
+              theme={editor.theme}
               showReset={false}
               className="min-h-0 flex-1"
             />

--- a/apps/web/src/features/player/ReplayPage.tsx
+++ b/apps/web/src/features/player/ReplayPage.tsx
@@ -400,6 +400,7 @@ export function ReplayPage({ source = "local" }: ReplayPageProps) {
                 <PreviewPane
                   runtime={runtime}
                   previewHtml={stableState.runtime.previewHtml}
+                  theme={stableState.editor.theme}
                   className="min-h-0 flex-1"
                 />
               }

--- a/apps/web/src/features/recorder/RecorderPage.tsx
+++ b/apps/web/src/features/recorder/RecorderPage.tsx
@@ -730,6 +730,7 @@ export function RecorderPage({ onEventBusReady }: RecorderPageProps = {}) {
             left={
               <PreviewPane
                 runtime={stack.runtime}
+                theme={theme.resolved}
                 className="min-h-0 flex-1"
                 onReset={() => setRuntimeState(INITIAL_RUNTIME_STATE)}
               />

--- a/apps/web/src/features/runtime-preview/PreviewPane.tsx
+++ b/apps/web/src/features/runtime-preview/PreviewPane.tsx
@@ -10,6 +10,8 @@ export type PreviewPaneProps = {
    * to inject historical DOM instead of executing live code.
    */
   previewHtml?: string | null;
+  /** Resolved app theme; propagates into the sandbox iframe default styling. */
+  theme?: "light" | "dark";
   onReset?: () => void;
   /** Hide the reset control for read-only consumers (e.g. interviewer view). */
   showReset?: boolean;
@@ -29,7 +31,7 @@ export type PreviewPaneProps = {
  *   - 外部 padding=0；让 iframe 100%/100% 填满，避免运行时坐标偏移
  *   - 灰底 + checker pattern 作为「未运行」占位
  */
-export function PreviewPane({ runtime, previewHtml, onReset, showReset = true, className }: PreviewPaneProps) {
+export function PreviewPane({ runtime, previewHtml, theme, onReset, showReset = true, className }: PreviewPaneProps) {
   const hostRef = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
@@ -37,6 +39,10 @@ export function PreviewPane({ runtime, previewHtml, onReset, showReset = true, c
     void runtime.mount(hostRef.current);
     return () => runtime.destroy();
   }, [runtime]);
+
+  useEffect(() => {
+    if (theme) runtime.setTheme(theme);
+  }, [runtime, theme]);
 
   useEffect(() => {
     if (typeof previewHtml === "string") {

--- a/apps/web/src/features/runtime-preview/__tests__/PreviewPane.test.tsx
+++ b/apps/web/src/features/runtime-preview/__tests__/PreviewPane.test.tsx
@@ -8,6 +8,8 @@ function makeRuntime(): IframeRuntime {
     mount: vi.fn(async () => {}),
     run: vi.fn(),
     renderPreview: vi.fn(async () => {}),
+    renderDocument: vi.fn(async (html: string) => html),
+    setTheme: vi.fn(),
     reset: vi.fn(),
     destroy: vi.fn(),
   } as unknown as IframeRuntime;
@@ -36,5 +38,15 @@ describe("PreviewPane", () => {
     await waitFor(() => expect(runtime.mount).toHaveBeenCalled());
 
     expect(screen.queryByRole("button", { name: "重置预览" })).not.toBeInTheDocument();
+  });
+
+  it("propagates the theme prop to the runtime via setTheme", async () => {
+    const runtime = makeRuntime();
+    const { rerender } = render(<PreviewPane runtime={runtime} theme="dark" />);
+    await waitFor(() => expect(runtime.mount).toHaveBeenCalled());
+    expect(runtime.setTheme).toHaveBeenCalledWith("dark");
+
+    rerender(<PreviewPane runtime={runtime} theme="light" />);
+    expect(runtime.setTheme).toHaveBeenCalledWith("light");
   });
 });

--- a/apps/web/src/features/runtime-preview/__tests__/iframeRuntime.test.ts
+++ b/apps/web/src/features/runtime-preview/__tests__/iframeRuntime.test.ts
@@ -278,6 +278,21 @@ describe("IframeRuntime sandbox lifecycle", () => {
     host.remove();
   });
 
+  it("uses :where() for the theme default so user CSS wins regardless of source order", async () => {
+    const host = document.createElement("div");
+    document.body.appendChild(host);
+    const runtime = createIframeRuntime();
+
+    await runtime.mount(host);
+    const srcdoc = host.querySelector("iframe")?.srcdoc ?? "";
+    // Default selector must have zero specificity (`:where()` per CSS spec) so
+    // any user `body { ... }` rule wins regardless of source order.
+    expect(srcdoc).toContain(":where(html,body)");
+    expect(srcdoc).not.toMatch(/<style[^>]*>html,body\{/);
+    runtime.destroy();
+    host.remove();
+  });
+
   it("does not reset body margin in the theme default style", async () => {
     const host = document.createElement("div");
     document.body.appendChild(host);

--- a/apps/web/src/features/runtime-preview/__tests__/iframeRuntime.test.ts
+++ b/apps/web/src/features/runtime-preview/__tests__/iframeRuntime.test.ts
@@ -278,6 +278,45 @@ describe("IframeRuntime sandbox lifecycle", () => {
     host.remove();
   });
 
+  it("does not reset body margin in the theme default style", async () => {
+    const host = document.createElement("div");
+    document.body.appendChild(host);
+    const runtime = createIframeRuntime();
+
+    await runtime.mount(host);
+    const srcdoc = host.querySelector("iframe")?.srcdoc ?? "";
+    // Theme tag is identifiable, but it must not modify layout (no margin reset).
+    expect(srcdoc).toContain('id="ct-theme"');
+    expect(srcdoc).not.toMatch(/margin\s*:\s*0/);
+    runtime.destroy();
+    host.remove();
+  });
+
+  it("posts a set-theme message to the JS run iframe instead of recreating it", async () => {
+    const host = document.createElement("div");
+    document.body.appendChild(host);
+    const runtime = createIframeRuntime({ theme: "dark" });
+
+    await runtime.mount(host);
+    // Start a long-running JS run so the iframe stays mounted.
+    const run = runtime.run({ runId: "run-theme", compiledCode: "", timeoutMs: 200 });
+    const frame = host.querySelector("iframe");
+    expect(frame).toBeTruthy();
+    const postSpy = vi.spyOn(frame!.contentWindow!, "postMessage");
+
+    runtime.setTheme("light");
+    // setTheme should NOT replace the run iframe; it should postMessage instead.
+    expect(host.querySelector("iframe")).toBe(frame);
+    expect(postSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "set-theme", theme: "light" }),
+      "*",
+    );
+
+    await run;
+    runtime.destroy();
+    host.remove();
+  });
+
   it("renders replay preview in a no-script sandbox", async () => {
     const host = document.createElement("div");
     document.body.appendChild(host);

--- a/apps/web/src/features/runtime-preview/__tests__/iframeRuntime.test.ts
+++ b/apps/web/src/features/runtime-preview/__tests__/iframeRuntime.test.ts
@@ -215,6 +215,69 @@ describe("IframeRuntime sandbox lifecycle", () => {
     host.remove();
   });
 
+  it("injects a dark theme background into the empty preview srcdoc by default", async () => {
+    const host = document.createElement("div");
+    document.body.appendChild(host);
+    const runtime = createIframeRuntime();
+
+    await runtime.mount(host);
+    const frame = host.querySelector("iframe");
+
+    expect(frame?.srcdoc).toContain("color-scheme:dark");
+    expect(frame?.srcdoc).toContain("#1c1f26"); // dark default background
+    runtime.destroy();
+    host.remove();
+  });
+
+  it("injects a light theme background when initialized with theme: 'light'", async () => {
+    const host = document.createElement("div");
+    document.body.appendChild(host);
+    const runtime = createIframeRuntime({ theme: "light" });
+
+    await runtime.mount(host);
+    const frame = host.querySelector("iframe");
+
+    expect(frame?.srcdoc).toContain("color-scheme:light");
+    expect(frame?.srcdoc).toContain("#f5f5f4"); // light default background
+    runtime.destroy();
+    host.remove();
+  });
+
+  it("re-renders the current preview with the new theme on setTheme", async () => {
+    const host = document.createElement("div");
+    document.body.appendChild(host);
+    const runtime = createIframeRuntime({ theme: "dark" });
+
+    await runtime.mount(host);
+    expect(host.querySelector("iframe")?.srcdoc).toContain("color-scheme:dark");
+
+    runtime.setTheme("light");
+    // setTheme triggers an async re-render; wait a microtask.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(host.querySelector("iframe")?.srcdoc).toContain("color-scheme:light");
+
+    runtime.destroy();
+    host.remove();
+  });
+
+  it("preserves the rendered preview content across a theme change", async () => {
+    const host = document.createElement("div");
+    document.body.appendChild(host);
+    const runtime = createIframeRuntime({ theme: "dark" });
+
+    await runtime.mount(host);
+    await runtime.renderPreview("<body><h1>kept</h1></body>");
+    expect(host.querySelector("iframe")?.srcdoc).toContain("<h1>kept</h1>");
+
+    runtime.setTheme("light");
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    const srcdoc = host.querySelector("iframe")?.srcdoc ?? "";
+    expect(srcdoc).toContain("<h1>kept</h1>");
+    expect(srcdoc).toContain("color-scheme:light");
+    runtime.destroy();
+    host.remove();
+  });
+
   it("renders replay preview in a no-script sandbox", async () => {
     const host = document.createElement("div");
     document.body.appendChild(host);

--- a/apps/web/src/features/runtime-preview/__tests__/iframeRuntime.test.ts
+++ b/apps/web/src/features/runtime-preview/__tests__/iframeRuntime.test.ts
@@ -285,10 +285,27 @@ describe("IframeRuntime sandbox lifecycle", () => {
 
     await runtime.mount(host);
     const srcdoc = host.querySelector("iframe")?.srcdoc ?? "";
-    // Default selector must have zero specificity (`:where()` per CSS spec) so
-    // any user `body { ... }` rule wins regardless of source order.
-    expect(srcdoc).toContain(":where(html,body)");
-    expect(srcdoc).not.toMatch(/<style[^>]*>html,body\{/);
+    // Default selectors must have zero specificity (`:where()` per CSS spec)
+    // so any user `body { ... }` rule wins regardless of source order.
+    expect(srcdoc).toContain(":where(html)");
+    expect(srcdoc).toContain(":where(body)");
+    expect(srcdoc).not.toMatch(/<style[^>]*>html\{|<style[^>]*>body\{/);
+    runtime.destroy();
+    host.remove();
+  });
+
+  it("scopes background/color to body so user body bg propagates to the canvas", async () => {
+    const host = document.createElement("div");
+    document.body.appendChild(host);
+    const runtime = createIframeRuntime();
+
+    await runtime.mount(host);
+    const srcdoc = host.querySelector("iframe")?.srcdoc ?? "";
+    // CSS canvas painting only propagates body bg when html has no bg of its own.
+    // Theme defaults: color-scheme on html; background/color only on body.
+    expect(srcdoc).toMatch(/:where\(html\)\{color-scheme:(light|dark);\}/);
+    expect(srcdoc).not.toMatch(/:where\(html\)\{[^}]*background/);
+    expect(srcdoc).toMatch(/:where\(body\)\{background:[^;]+;color:[^;]+;\}/);
     runtime.destroy();
     host.remove();
   });

--- a/apps/web/src/features/runtime-preview/iframeBoot.ts
+++ b/apps/web/src/features/runtime-preview/iframeBoot.ts
@@ -71,24 +71,29 @@ export const IFRAME_BOOT_SCRIPT = `
   });
 
   // Allowed theme bodies (must match host themeStyleTag in iframeRuntime.ts).
-  // Hard-coded here so a hostile parent can't inject arbitrary CSS via setTheme.
-  var THEME_BODIES = {
-    light: "color-scheme:light;background:#f5f5f4;color:#24272d;",
-    dark: "color-scheme:dark;background:#1c1f26;color:#e7e9ee;",
+  // Split by element so a user-provided body background propagates to the
+  // canvas (per CSS canvas painting rule); values are hard-coded so a hostile
+  // parent can't inject arbitrary CSS via setTheme.
+  var THEME_HTML = { light: "color-scheme:light;", dark: "color-scheme:dark;" };
+  var THEME_BODY = {
+    light: "background:#f5f5f4;color:#24272d;",
+    dark: "background:#1c1f26;color:#e7e9ee;",
   };
 
   window.addEventListener("message", function (event) {
     var msg = event.data;
     if (!msg || msg.type !== "set-theme") return;
-    var body = THEME_BODIES[msg.theme];
-    if (!body) return;
+    var htmlBody = THEME_HTML[msg.theme];
+    var bodyBody = THEME_BODY[msg.theme];
+    if (!htmlBody || !bodyBody) return;
     var styleEl = document.getElementById("ct-theme");
     if (!styleEl) {
       styleEl = document.createElement("style");
       styleEl.id = "ct-theme";
       document.head.appendChild(styleEl);
     }
-    styleEl.textContent = ":where(html,body){" + body + "}";
+    styleEl.textContent =
+      ":where(html){" + htmlBody + "}:where(body){" + bodyBody + "}";
   });
 
   window.addEventListener("message", async function (event) {

--- a/apps/web/src/features/runtime-preview/iframeBoot.ts
+++ b/apps/web/src/features/runtime-preview/iframeBoot.ts
@@ -88,7 +88,7 @@ export const IFRAME_BOOT_SCRIPT = `
       styleEl.id = "ct-theme";
       document.head.appendChild(styleEl);
     }
-    styleEl.textContent = "html,body{" + body + "}";
+    styleEl.textContent = ":where(html,body){" + body + "}";
   });
 
   window.addEventListener("message", async function (event) {

--- a/apps/web/src/features/runtime-preview/iframeBoot.ts
+++ b/apps/web/src/features/runtime-preview/iframeBoot.ts
@@ -70,6 +70,27 @@ export const IFRAME_BOOT_SCRIPT = `
     post("error", { message: limit(reason.message || String(reason), CONSOLE_ARG_MAX_CHARS), stack: reason.stack ? limit(reason.stack, CONSOLE_ARG_MAX_CHARS) : undefined });
   });
 
+  // Allowed theme bodies (must match host themeStyleTag in iframeRuntime.ts).
+  // Hard-coded here so a hostile parent can't inject arbitrary CSS via setTheme.
+  var THEME_BODIES = {
+    light: "color-scheme:light;background:#f5f5f4;color:#24272d;",
+    dark: "color-scheme:dark;background:#1c1f26;color:#e7e9ee;",
+  };
+
+  window.addEventListener("message", function (event) {
+    var msg = event.data;
+    if (!msg || msg.type !== "set-theme") return;
+    var body = THEME_BODIES[msg.theme];
+    if (!body) return;
+    var styleEl = document.getElementById("ct-theme");
+    if (!styleEl) {
+      styleEl = document.createElement("style");
+      styleEl.id = "ct-theme";
+      document.head.appendChild(styleEl);
+    }
+    styleEl.textContent = "html,body{" + body + "}";
+  });
+
   window.addEventListener("message", async function (event) {
     const msg = event.data;
     if (!msg || msg.type !== "init") return;

--- a/apps/web/src/features/runtime-preview/iframeRuntime.ts
+++ b/apps/web/src/features/runtime-preview/iframeRuntime.ts
@@ -44,7 +44,10 @@ const THEME_DEFAULT_STYLE: Record<RuntimePreviewTheme, string> = {
 };
 
 function themeStyleTag(theme: RuntimePreviewTheme): string {
-  return `<style id="ct-theme">html,body{${THEME_DEFAULT_STYLE[theme]}}</style>`;
+  // `:where()` gives the default rule zero specificity, so any user
+  // background/color rule wins regardless of source order — keeps the issue
+  // non-goal "不强制覆盖用户 HTML/CSS 自定义样式" inviolable.
+  return `<style id="ct-theme">:where(html,body){${THEME_DEFAULT_STYLE[theme]}}</style>`;
 }
 
 type SanitizedPreviewHtml = {

--- a/apps/web/src/features/runtime-preview/iframeRuntime.ts
+++ b/apps/web/src/features/runtime-preview/iframeRuntime.ts
@@ -9,6 +9,8 @@ import { IFRAME_BOOT_SCRIPT } from "./iframeBoot";
 export type IframeRuntimeOptions = {
   /** Override sandbox attributes; only "allow-scripts" is on by default. */
   sandboxFlags?: string;
+  /** Initial preview theme; defaults to "dark". */
+  theme?: RuntimePreviewTheme;
 };
 
 const RUNTIME_SOURCE = "code-tape-runtime";
@@ -25,6 +27,23 @@ const RUNTIME_CSP =
   "default-src 'none'; script-src 'unsafe-inline'; style-src 'unsafe-inline'; img-src data: blob:; connect-src 'none';";
 const REPLAY_PREVIEW_CSP =
   "default-src 'none'; script-src 'none'; style-src 'unsafe-inline'; img-src data: blob:; connect-src 'none';";
+
+export type RuntimePreviewTheme = "light" | "dark";
+
+/**
+ * Theme-aware default styling injected into preview/runtime srcdoc so the empty
+ * and rendered sandbox follows the host theme (opaque-origin iframes can't
+ * inherit the host's CSS variables). Placed in <head> before user content so a
+ * user's own background/color rules still win.
+ */
+const THEME_DEFAULT_STYLE: Record<RuntimePreviewTheme, string> = {
+  light: "color-scheme:light;background:#f5f5f4;color:#24272d;",
+  dark: "color-scheme:dark;background:#1c1f26;color:#e7e9ee;",
+};
+
+function themeStyleTag(theme: RuntimePreviewTheme): string {
+  return `<style>html,body{margin:0;${THEME_DEFAULT_STYLE[theme]}}</style>`;
+}
 
 type SanitizedPreviewHtml = {
   headHtml: string;
@@ -54,13 +73,13 @@ export function acceptRuntimeMessage(
   return sanitizeRuntimeMessage(m as RuntimeMessage);
 }
 
-function buildSrcDoc(bootScript: string): string {
-  return `<!doctype html><html><head><meta charset="utf-8"><meta http-equiv="Content-Security-Policy" content="${RUNTIME_CSP}" /><title>code-tape runtime</title></head><body><script>${bootScript}</script></body></html>`;
+function buildSrcDoc(bootScript: string, theme: RuntimePreviewTheme): string {
+  return `<!doctype html><html><head><meta charset="utf-8"><meta http-equiv="Content-Security-Policy" content="${RUNTIME_CSP}" />${themeStyleTag(theme)}<title>code-tape runtime</title></head><body><script>${bootScript}</script></body></html>`;
 }
 
-function buildPreviewSrcDoc(previewHtml: string): string {
+function buildPreviewSrcDoc(previewHtml: string, theme: RuntimePreviewTheme): string {
   const safePreviewHtml = sanitizePreviewHtml(previewHtml);
-  return `<!doctype html><html><head><meta charset="utf-8"><meta http-equiv="Content-Security-Policy" content="${REPLAY_PREVIEW_CSP}" /><title>code-tape replay preview</title>${safePreviewHtml.headHtml}</head>${safePreviewHtml.bodyHtml}</html>`;
+  return `<!doctype html><html><head><meta charset="utf-8"><meta http-equiv="Content-Security-Policy" content="${REPLAY_PREVIEW_CSP}" />${themeStyleTag(theme)}<title>code-tape replay preview</title>${safePreviewHtml.headHtml}</head>${safePreviewHtml.bodyHtml}</html>`;
 }
 
 function isRuntimePayload(type: string, payload: object): boolean {
@@ -155,6 +174,10 @@ export function createIframeRuntime(options: IframeRuntimeOptions = {}): IframeR
   let iframe: HTMLIFrameElement | null = null;
   let host: HTMLElement | null = null;
   let messageHandler: ((event: MessageEvent) => void) | null = null;
+  let theme: RuntimePreviewTheme = options.theme ?? "dark";
+  // Track the current static preview so a theme change can re-render it with the
+  // new default background. Null while a JS run iframe is mounted.
+  let currentPreviewHtml: string | null = "<body></body>";
 
   const sandboxFlags = options.sandboxFlags ?? "allow-scripts";
 
@@ -185,10 +208,21 @@ export function createIframeRuntime(options: IframeRuntimeOptions = {}): IframeR
   return {
     async mount(target: HTMLElement) {
       host = target;
-      if (!iframe) await createIframe("", buildPreviewSrcDoc("<body></body>"));
+      if (!iframe) await createIframe("", buildPreviewSrcDoc("<body></body>", theme));
+    },
+    setTheme(nextTheme: RuntimePreviewTheme) {
+      if (nextTheme === theme) return;
+      theme = nextTheme;
+      // Re-render the current static preview so the empty / replay preview
+      // background tracks the host theme. Skip while a JS run iframe is mounted
+      // (currentPreviewHtml === null) — its theme is fixed for that run.
+      if (host && currentPreviewHtml !== null) {
+        void createIframe("", buildPreviewSrcDoc(currentPreviewHtml, theme));
+      }
     },
     async run(input: IframeRunInput): Promise<IframeRunResult> {
-      const frame = await createIframe(sandboxFlags, buildSrcDoc(IFRAME_BOOT_SCRIPT));
+      currentPreviewHtml = null;
+      const frame = await createIframe(sandboxFlags, buildSrcDoc(IFRAME_BOOT_SCRIPT, theme));
       const stdout: string[] = [];
       const stderr: string[] = [];
       let outputTruncated = false;
@@ -272,20 +306,24 @@ export function createIframeRuntime(options: IframeRuntimeOptions = {}): IframeR
       });
     },
     async renderPreview(previewHtml: string): Promise<void> {
-      await createIframe("", buildPreviewSrcDoc(previewHtml));
+      currentPreviewHtml = previewHtml;
+      await createIframe("", buildPreviewSrcDoc(previewHtml, theme));
     },
     async renderDocument(html: string): Promise<string> {
+      currentPreviewHtml = html;
       const safe = sanitizePreviewHtml(html);
-      await createIframe("", buildPreviewSrcDoc(html));
+      await createIframe("", buildPreviewSrcDoc(html, theme));
       // Return the SANITIZED markup actually rendered (scripts stripped), so the
       // persisted previewHtml is script-free regardless of who re-renders it.
       const sanitized = safe.headHtml ? `${safe.headHtml}${safe.bodyHtml}` : safe.bodyHtml;
       return limitString(sanitized, RUNTIME_PREVIEW_HTML_MAX_CHARS);
     },
     reset() {
+      currentPreviewHtml = "<body></body>";
       teardown();
     },
     destroy() {
+      currentPreviewHtml = null;
       teardown();
       host = null;
     },

--- a/apps/web/src/features/runtime-preview/iframeRuntime.ts
+++ b/apps/web/src/features/runtime-preview/iframeRuntime.ts
@@ -34,7 +34,9 @@ export type RuntimePreviewTheme = "light" | "dark";
  * Theme-aware default styling injected into preview/runtime srcdoc so the empty
  * and rendered sandbox follows the host theme (opaque-origin iframes can't
  * inherit the host's CSS variables). Placed in <head> before user content so a
- * user's own background/color rules still win.
+ * user's own background/color rules still win. Tagged with id="ct-theme" so
+ * the runtime boot script can swap it in-place on theme change without losing
+ * run state.
  */
 const THEME_DEFAULT_STYLE: Record<RuntimePreviewTheme, string> = {
   light: "color-scheme:light;background:#f5f5f4;color:#24272d;",
@@ -42,7 +44,7 @@ const THEME_DEFAULT_STYLE: Record<RuntimePreviewTheme, string> = {
 };
 
 function themeStyleTag(theme: RuntimePreviewTheme): string {
-  return `<style>html,body{margin:0;${THEME_DEFAULT_STYLE[theme]}}</style>`;
+  return `<style id="ct-theme">html,body{${THEME_DEFAULT_STYLE[theme]}}</style>`;
 }
 
 type SanitizedPreviewHtml = {
@@ -213,11 +215,14 @@ export function createIframeRuntime(options: IframeRuntimeOptions = {}): IframeR
     setTheme(nextTheme: RuntimePreviewTheme) {
       if (nextTheme === theme) return;
       theme = nextTheme;
-      // Re-render the current static preview so the empty / replay preview
-      // background tracks the host theme. Skip while a JS run iframe is mounted
-      // (currentPreviewHtml === null) — its theme is fixed for that run.
-      if (host && currentPreviewHtml !== null) {
+      // For a static preview, re-render with the new theme; for a JS run iframe
+      // (currentPreviewHtml === null), postMessage so the boot script swaps the
+      // injected #ct-theme style in place — preserves run state and DOM mutations.
+      if (!host) return;
+      if (currentPreviewHtml !== null) {
         void createIframe("", buildPreviewSrcDoc(currentPreviewHtml, theme));
+      } else if (iframe?.contentWindow) {
+        iframe.contentWindow.postMessage({ type: "set-theme", theme }, "*");
       }
     },
     async run(input: IframeRunInput): Promise<IframeRunResult> {

--- a/apps/web/src/features/runtime-preview/iframeRuntime.ts
+++ b/apps/web/src/features/runtime-preview/iframeRuntime.ts
@@ -37,17 +37,33 @@ export type RuntimePreviewTheme = "light" | "dark";
  * user's own background/color rules still win. Tagged with id="ct-theme" so
  * the runtime boot script can swap it in-place on theme change without losing
  * run state.
+ *
+ * Split: `color-scheme` lives on `html`, `background`/`color` on `body` only.
+ * Per CSS canvas-painting rules, when only `body` has a background, that
+ * background propagates to the canvas — so a user `body { background: ... }`
+ * fully replaces the iframe canvas paint. If we put a default on `html` too,
+ * propagation is suppressed and the user's body bg only paints the body box.
  */
-const THEME_DEFAULT_STYLE: Record<RuntimePreviewTheme, string> = {
-  light: "color-scheme:light;background:#f5f5f4;color:#24272d;",
-  dark: "color-scheme:dark;background:#1c1f26;color:#e7e9ee;",
+const THEME_HTML_STYLE: Record<RuntimePreviewTheme, string> = {
+  light: "color-scheme:light;",
+  dark: "color-scheme:dark;",
+};
+
+const THEME_BODY_STYLE: Record<RuntimePreviewTheme, string> = {
+  light: "background:#f5f5f4;color:#24272d;",
+  dark: "background:#1c1f26;color:#e7e9ee;",
 };
 
 function themeStyleTag(theme: RuntimePreviewTheme): string {
   // `:where()` gives the default rule zero specificity, so any user
   // background/color rule wins regardless of source order — keeps the issue
   // non-goal "不强制覆盖用户 HTML/CSS 自定义样式" inviolable.
-  return `<style id="ct-theme">:where(html,body){${THEME_DEFAULT_STYLE[theme]}}</style>`;
+  return (
+    `<style id="ct-theme">` +
+    `:where(html){${THEME_HTML_STYLE[theme]}}` +
+    `:where(body){${THEME_BODY_STYLE[theme]}}` +
+    `</style>`
+  );
 }
 
 type SanitizedPreviewHtml = {

--- a/packages/recording-schema/src/types.ts
+++ b/packages/recording-schema/src/types.ts
@@ -607,6 +607,12 @@ export type IframeRuntime = {
    * as the run's previewHtml for replay. Used for HTML/CSS "run" (no JS exec).
    */
   renderDocument(html: string): Promise<string>;
+  /**
+   * Update the preview/runtime theme. Re-renders the current static preview
+   * (mount default / renderPreview / renderDocument) so its background tracks
+   * the host theme; a JS run iframe keeps its boot-time theme until next run.
+   */
+  setTheme(theme: "light" | "dark"): void;
   reset(): void;
   destroy(): void;
 };

--- a/packages/recording-schema/src/types.ts
+++ b/packages/recording-schema/src/types.ts
@@ -610,7 +610,8 @@ export type IframeRuntime = {
   /**
    * Update the preview/runtime theme. Re-renders the current static preview
    * (mount default / renderPreview / renderDocument) so its background tracks
-   * the host theme; a JS run iframe keeps its boot-time theme until next run.
+   * the host theme; for an active JS run iframe, posts a message so the boot
+   * script swaps the injected theme style in place — preserves run state.
    */
   setTheme(theme: "light" | "dark"): void;
   reset(): void;


### PR DESCRIPTION
## 关联

Closes #237

## 背景

来自 `Todos/Todos.md` Bugs：黑色主题下切到录制后右侧预览区显示白底。根因：PreviewPane 宿主容器 `bg-surface` 跟随主题，但内部 opaque-origin sandbox iframe 是独立文档，无法继承宿主的 `--ct-color-*` 变量；srcdoc `<body>` 此前无任何背景样式，浏览器默认白底导致深色主题右侧白块。

## 改动点

- `IframeRuntime` 加初始 `theme` 选项（默认 `"dark"`）与 `setTheme(theme)`；`buildSrcDoc`/`buildPreviewSrcDoc` 在 `<head>` 注入主题感知默认 `<style>`（`color-scheme` + `body` 背景/前景，置于用户内容前以便用户样式可覆盖）。
- `setTheme` 重渲染**当前静态预览**（`mount` 默认 / 上次 `renderPreview` / `renderDocument`）以反映新主题；JS 运行 iframe 保留运行时刻的主题至下次运行（避免破坏运行中状态）。
- `PreviewPane` 加 `theme` prop，桥接给 `runtime.setTheme`。
- `RecorderPage` 传宿主 `theme.resolved`；`ReplayPage` / 面试官 workbench 传录制时 `editor.theme`，使回放视觉与录制主题一致。
- `IframeRuntime` 接口在 schema 同步加 `setTheme`。

## GitNexus 影响分析摘要

- 风险等级: MEDIUM
- 关键骨架变更: 命中 critical contract `packages/recording-schema`（`IframeRuntime` 加 `setTheme`，向后扩展）与 `runtime-preview`（`createIframeRuntime` 加初始 `theme` 与 `setTheme`，`buildSrcDoc`/`buildPreviewSrcDoc` 加 theme 形参）。既有 run/renderPreview/renderDocument 公开形参不变。
- GitNexus 影响面: detect_changes 集中在 `runtime-preview/iframeRuntime`、`PreviewPane`、Recorder/Replay/Interview 三处 PreviewPane 装配；impact 显示影响面为 mount/render 链与 PreviewPane 三个调用方，无意外 fan-out。
- 验证结果: `npm run test -w apps/web`（752 passed，新增 dark/light srcdoc bg、setTheme 重渲染、PreviewPane.theme→setTheme 桥接、保留 preview 内容跨主题切换、runtimeProducer mock 同步）、`lint:web`、`build`、pre-push e2e（6 passed）全通过。
- 不背离 `docs/技术方案.md` 沙箱契约（CSP `style-src 'unsafe-inline'` 已允许内联 `<style>`，sandbox flags 不变）。

## 非目标

- 不改 CSP / sandbox 安全边界。
- 不强制覆盖用户 HTML/CSS 自定义背景（默认样式可被用户样式覆盖）。