### PR TITLE
#239 修复候选人房间状态区长链接溢出

### DIFF
--- a/apps/web/src/features/editor/CodeEditor.tsx
+++ b/apps/web/src/features/editor/CodeEditor.tsx
@@ -48,6 +48,9 @@ let themesDefined = false;
 let workersConfigured = false;
 const COLLAPSED_SELECTION_PULSE_MS = 420;
 const FORMAT_ACTION_ID = "editor.action.formatDocument";
+const PHYSICAL_CODE_BY_KEY: Record<string, string> = {
+  "/": "slash",
+};
 
 type PrettierFormatter = {
   format(source: string, language: RecordingLanguage): Promise<string | null>;
@@ -496,7 +499,7 @@ function isFormatShortcut(event: Monaco.IKeyboardEvent): boolean {
 function matchesKey(event: Monaco.IKeyboardEvent, key: string): boolean {
   const expected = key.toLowerCase();
   const actualKey = event.browserEvent.key.toLowerCase();
-  const expectedCode = `key${expected}`;
+  const expectedCode = PHYSICAL_CODE_BY_KEY[expected] ?? `key${expected}`;
   return (
     actualKey === expected
     || event.code.toLowerCase() === expectedCode

--- a/apps/web/src/features/editor/__tests__/CodeEditor.test.tsx
+++ b/apps/web/src/features/editor/__tests__/CodeEditor.test.tsx
@@ -519,6 +519,29 @@ describe("CodeEditor", () => {
     expect(editor.trigger).toHaveBeenCalledWith("keyboard", "editor.action.formatDocument", null);
   });
 
+  it("comments from the physical slash key when the reported key is layout-specific", async () => {
+    const { CodeEditor } = await import("../CodeEditor");
+    render(
+      <CodeEditor
+        language="javascript"
+        initialValue="const commented = true;"
+        fontSize={14}
+        theme="dark"
+      />,
+    );
+    await waitFor(() => expect(monacoMock.editor.create).toHaveBeenCalledTimes(1));
+    const editor = monacoMock.editors[0];
+
+    pressEditorShortcut(editor, {
+      key: "÷",
+      code: "Slash",
+      browserEvent: { code: "Slash", key: "÷", isComposing: false, repeat: false },
+      metaKey: true,
+    });
+
+    expect(editor.trigger).toHaveBeenCalledWith("keyboard", "editor.action.commentLine", null);
+  });
+
   it("uses a JS formatter fallback when Monaco format action leaves the document unchanged", async () => {
     const { CodeEditor } = await import("../CodeEditor");
     render(

--- a/apps/web/src/features/interview/CandidateInterviewPage.tsx
+++ b/apps/web/src/features/interview/CandidateInterviewPage.tsx
@@ -948,11 +948,15 @@ function MediaStreamTile({
 }
 
 function Metric({ label, value }: { label: string; value: string }) {
+  const displayValue = label === "面试官" ? `面试官${value}` : value;
+
   return (
-    <div className="flex items-center justify-between gap-3 rounded-md bg-surface px-2 py-1.5">
-      <dt className="text-muted">{label}</dt>
-      <dd className="truncate font-mono text-foreground">
-        {label === "面试官" ? `面试官${value}` : value}
+    <div className="flex min-w-0 items-center justify-between gap-3 rounded-md bg-surface px-2 py-1.5">
+      <dt className="shrink-0 text-muted">{label}</dt>
+      <dd className="min-w-0 text-right font-mono text-foreground">
+        <span className="block truncate" title={displayValue}>
+          {displayValue}
+        </span>
       </dd>
     </div>
   );

--- a/apps/web/src/features/interview/__tests__/CandidateInterviewPage.test.tsx
+++ b/apps/web/src/features/interview/__tests__/CandidateInterviewPage.test.tsx
@@ -184,6 +184,42 @@ describe("CandidateInterviewPage", () => {
     ).toBeInTheDocument();
   });
 
+  it("keeps long room status values inside shrinkable metric rows", () => {
+    const longSignalingUrl = `/api/interviews/rooms/${"room-".repeat(40)}/signaling`;
+    const longRoomId = `room-${"candidate-".repeat(24)}`;
+    const longJoinCode = `JOIN${"1234567890".repeat(10)}`;
+
+    render(
+      <TooltipProvider>
+        <CandidateInterviewView
+          roomId={longRoomId}
+          roomState={{
+            status: "waiting-interviewer",
+            joinCode: longJoinCode,
+            interviewerOnline: false,
+            signalingUrl: longSignalingUrl,
+          }}
+          mediaState={makeMediaState()}
+          recordingWorkspace={<div>Recording area</div>}
+        />
+      </TooltipProvider>,
+    );
+
+    const signalingValue = screen.getByText(longSignalingUrl);
+    expect(signalingValue.closest("dd")).toHaveClass("min-w-0");
+    expect(signalingValue).toHaveClass("block", "truncate");
+    expect(signalingValue).toHaveAttribute("title", longSignalingUrl);
+
+    const interviewerUrl = screen.getByText(
+      `http://localhost:3000/interview/interviewer/${encodeURIComponent(
+        longRoomId,
+      )}?joinCode=${encodeURIComponent(longJoinCode)}`,
+    );
+    expect(interviewerUrl.closest("dd")).toHaveClass("min-w-0");
+    expect(interviewerUrl).toHaveClass("block", "truncate");
+    expect(interviewerUrl).toHaveAttribute("title", interviewerUrl.textContent);
+  });
+
   it("resets the copied state when the interviewer room link changes", async () => {
     const writeText = vi.fn().mockResolvedValue(undefined);
     vi.stubGlobal("navigator", {


### PR DESCRIPTION
## 关联

Closes #239
Refs #2（总控 issue，不在本 PR 中关闭）

## 改动点

- 修复候选人面试侧栏房间状态指标行的长链接布局：metric row 与 value 区域支持收缩，长信令地址/面试官链接单行省略，并通过 title 保留完整值。
- 补充长信令地址、长 roomId、长 joinCode 的候选人页回归测试，覆盖长文本不撑开 metric value 的展示契约。
- 修复质量门暴露的编辑器快捷键稳定性问题：物理 Slash 键在布局相关 key 值下仍能触发注释命令，并补充单测。

## 影响范围

- 候选人实时面试页右侧“房间状态”区块展示。
- CodeEditor 快捷键匹配逻辑，仅新增 / -> Slash 的物理按键映射，不改变现有 Enter、F、G 等快捷键路径。

## GitNexus 影响分析摘要

- 风险等级: medium
- 关键骨架变更: 否；GitNexus contract 判定本 diff 未改关键 contract surface，属于 advisory。
- GitNexus 影响面: detect_changes 显示 4 个变更文件、2 个相关 symbols，影响 1 条执行流：RemoteInterviewWorkbenchView -> MatchesKey（5 steps），触达 matchesKey。
- 验证结果: npm run quality:local 已通过；另用浏览器烟测候选人页在 1280x720 与 390x844 下无页面级横向溢出。

## 自检

- [x] 未修改 docs/progress.json 或 docs/progress.md
- [x] 已运行 npm run quality:local，或说明无法运行的原因
- [x] 已说明改动点和影响范围
- [x] 如果改动关键骨架，已补充契约测试并填写 GitNexus 影响分析摘要
- [ ] 已等待 repo-guard、codex 和 Copilot 评论，并完成必要审查
