### PR TITLE
#252 修复录制页窄屏响应式布局

### DIFF
--- a/apps/web/e2e/scaffold.spec.ts
+++ b/apps/web/e2e/scaffold.spec.ts
@@ -1,4 +1,9 @@
-import { expect, test } from "@playwright/test";
+import { expect, test, type Page } from "@playwright/test";
+
+const LONG_MICROPHONE_LABEL =
+  "Very long studio microphone device name used to verify responsive wrapping without horizontal overflow";
+const LONG_CAMERA_LABEL =
+  "Very long external camera device name used to verify responsive wrapping without horizontal overflow";
 
 test("recorder route renders Monaco with usable recorder controls", async ({ page }) => {
   const runtimeErrors: string[] = [];
@@ -27,8 +32,119 @@ test("recorder route renders Monaco with usable recorder controls", async ({ pag
   expect(runtimeErrors.filter((message) => /monaco|worker/i.test(message))).toEqual([]);
 });
 
+test("recorder route keeps controls and workspace usable at narrow desktop widths", async ({ page }) => {
+  await installLongMediaDevices(page);
+  await page.setViewportSize({ width: 768, height: 720 });
+  await page.goto("/record", { waitUntil: "domcontentloaded" });
+  await expect(page.locator("[data-code-editor] .monaco-editor")).toBeVisible();
+  await selectLongDeviceNames(page);
+
+  await expect(page.getByRole("button", { name: "开始录制" })).toBeVisible();
+  await expect(page.getByRole("button", { name: "暂停录制" })).toBeVisible();
+  await expect(page.getByRole("button", { name: "继续录制" })).toBeVisible();
+  await expect(page.getByRole("button", { name: "停止录制" })).toBeVisible();
+  await expect(page.getByRole("button", { name: "运行代码" })).toBeVisible();
+  await expect(page.getByLabel("麦克风设备")).toBeVisible();
+  await expect(page.getByLabel("摄像头设备")).toBeVisible();
+  await expectRecorderShellToFit(page);
+
+  const workspaceLayout = await page.locator("[data-recorder-host]").evaluate((host) => {
+    const editor = host.querySelector("[data-code-editor]");
+    const output = host.querySelector("[aria-label='录制预览与输出区']");
+    if (!(editor instanceof HTMLElement) || !(output instanceof HTMLElement)) {
+      return null;
+    }
+    const editorBox = editor.getBoundingClientRect();
+    const outputBox = output.getBoundingClientRect();
+    return {
+      editorBottom: Math.round(editorBox.bottom),
+      outputTop: Math.round(outputBox.top),
+      outputLeft: Math.round(outputBox.left),
+      outputWidth: Math.round(outputBox.width),
+      outputHeight: Math.round(outputBox.height),
+    };
+  });
+  expect(workspaceLayout).not.toBeNull();
+  expect(workspaceLayout!.outputTop).toBeGreaterThan(workspaceLayout!.editorBottom - 2);
+  expect(workspaceLayout!.outputLeft).toBe(0);
+  expect(workspaceLayout!.outputWidth).toBeGreaterThanOrEqual(720);
+  expect(workspaceLayout!.outputHeight).toBeGreaterThanOrEqual(200);
+
+  for (const width of [1024, 1280]) {
+    await page.setViewportSize({ width, height: 720 });
+    await page.goto("/record", { waitUntil: "domcontentloaded" });
+    await expect(page.locator("[data-code-editor] .monaco-editor")).toBeVisible();
+    await selectLongDeviceNames(page);
+    await expect(page.getByRole("button", { name: "申请设备权限" })).toBeVisible();
+    await expectRecorderShellToFit(page);
+  }
+});
+
 test("missing replay id shows an explicit load error", async ({ page }) => {
   await page.goto("/replay/missing-recording", { waitUntil: "domcontentloaded" });
   await expect(page.getByText(/加载失败/)).toBeVisible();
   await expect(page.getByText(/incomplete-package/)).toBeVisible();
 });
+
+async function installLongMediaDevices(page: Page) {
+  await page.addInitScript(
+    ([microphoneLabel, cameraLabel]) => {
+      const devices = [
+        {
+          deviceId: "mic-long",
+          groupId: "group-audio",
+          kind: "audioinput",
+          label: microphoneLabel,
+          toJSON: () => ({}),
+        },
+        {
+          deviceId: "camera-long",
+          groupId: "group-video",
+          kind: "videoinput",
+          label: cameraLabel,
+          toJSON: () => ({}),
+        },
+      ];
+      Object.defineProperty(navigator, "mediaDevices", {
+        configurable: true,
+        value: {
+          enumerateDevices: async () => devices,
+          getUserMedia: async () => {
+            const error = new Error("Media capture is not needed for this layout regression");
+            error.name = "NotAllowedError";
+            throw error;
+          },
+        },
+      });
+    },
+    [LONG_MICROPHONE_LABEL, LONG_CAMERA_LABEL],
+  );
+}
+
+async function selectLongDeviceNames(page: Page) {
+  const microphone = page.getByLabel("麦克风设备");
+  const camera = page.getByLabel("摄像头设备");
+  await expect(microphone).toContainText(LONG_MICROPHONE_LABEL);
+  await expect(camera).toContainText(LONG_CAMERA_LABEL);
+  await microphone.selectOption("mic-long");
+  await camera.selectOption("camera-long");
+}
+
+async function expectRecorderShellToFit(page: Page) {
+  const overflowing = await page.locator("[data-recorder-host]").evaluate((host) => {
+    const checks = [
+      { name: "document", element: document.documentElement },
+      { name: "body", element: document.body },
+      { name: "host", element: host },
+      { name: "controls", element: host.querySelector("[role='toolbar']") },
+      { name: "setup", element: host.querySelector("[data-recorder-setup]") },
+      { name: "workspace", element: host.querySelector("[aria-label='录制工作区']") },
+    ];
+    return checks.flatMap(({ name, element }) => {
+      if (!(element instanceof HTMLElement)) return [`${name}:missing`];
+      const overflow = element.scrollWidth - element.clientWidth;
+      return overflow > 1 ? [`${name}:${element.scrollWidth}>${element.clientWidth}`] : [];
+    });
+  });
+  expect(overflowing).toEqual([]);
+}

--- a/apps/web/src/features/editor/CodeEditor.tsx
+++ b/apps/web/src/features/editor/CodeEditor.tsx
@@ -22,6 +22,7 @@ export type CodeEditorProps = {
   selection?: ReplayStableState["editor"]["selection"];
   scrollTop?: number;
   scrollLeft?: number;
+  minHeight?: "default" | "compact";
   onMount?(editor: Monaco.editor.IStandaloneCodeEditor): void;
   onChange?(): void;
   onCommand?(command: CodeEditorCommand): void;
@@ -160,6 +161,7 @@ export const CodeEditor = forwardRef<CodeEditorHandle, CodeEditorProps>(function
     selection,
     scrollTop,
     scrollLeft,
+    minHeight = "default",
     onMount,
     onChange,
     onCommand,
@@ -190,6 +192,7 @@ export const CodeEditor = forwardRef<CodeEditorHandle, CodeEditorProps>(function
   const onCommandRef = useRef(onCommand);
   const onBeforeFormatApplyRef = useRef(onBeforeFormatApply);
   const [loadError, setLoadError] = useState<unknown>(null);
+  const minHeightClass = minHeight === "compact" ? "min-h-[288px]" : "min-h-[320px]";
 
   latestPropsRef.current = {
     language,
@@ -330,8 +333,8 @@ export const CodeEditor = forwardRef<CodeEditorHandle, CodeEditorProps>(function
   }, [scrollLeft]);
 
   return (
-    <div className="relative h-full min-h-[320px] w-full bg-surface" data-code-editor>
-      <div ref={hostRef} aria-label="Code editor" className="h-full min-h-[320px] w-full" />
+    <div className={`relative h-full ${minHeightClass} w-full bg-surface`} data-code-editor>
+      <div ref={hostRef} aria-label="Code editor" className={`h-full ${minHeightClass} w-full`} />
       {loadError ? (
         <div className="absolute inset-0 flex items-center justify-center bg-surface/90 p-4" role="alert">
           <div className="max-w-sm rounded-md border border-border bg-surface-raised px-4 py-3 shadow-elevation-2">

--- a/apps/web/src/features/recorder/RecorderPage.tsx
+++ b/apps/web/src/features/recorder/RecorderPage.tsx
@@ -686,8 +686,9 @@ export function RecorderPage({ onEventBusReady }: RecorderPageProps = {}) {
         ariaLabel="录制工作区"
         separatorLabel="调整录制工作区宽度"
         storageKey="code-tape:workspace:recorder:left-percent"
-        leftClassName="relative min-h-[24rem] border-b border-border md:min-h-0 md:border-b-0"
-        rightClassName="flex flex-col"
+        desktopBreakpoint="lg"
+        leftClassName="relative min-h-[18rem] border-b border-border lg:min-h-0 lg:border-b-0"
+        rightClassName="flex flex-1 flex-col"
         left={
           <>
             <CodeEditor
@@ -696,6 +697,7 @@ export function RecorderPage({ onEventBusReady }: RecorderPageProps = {}) {
               initialValue=""
               fontSize={editorFontSize}
               theme={theme.resolved}
+              minHeight="compact"
               readOnly={controllerState.status === "paused"}
               onChange={scheduleAutoRun}
               onCommand={(command) => {
@@ -796,7 +798,10 @@ function RecorderSetupToolbar({
   onRequestMediaPermission,
 }: RecorderSetupToolbarProps) {
   return (
-    <div className="flex min-h-11 flex-wrap items-center gap-3 border-b border-border bg-background px-3 py-2">
+    <div
+      className="flex min-h-11 flex-wrap items-center gap-3 border-b border-border bg-background px-3 py-2"
+      data-recorder-setup
+    >
       <LabeledSelect
         label="语言"
         value={language}
@@ -871,13 +876,13 @@ type LabeledSelectProps = {
 
 function LabeledSelect({ label, value, disabled, options, onChange }: LabeledSelectProps) {
   return (
-    <label className="flex items-center gap-2 text-xs text-muted">
+    <label className="flex max-w-full min-w-0 items-center gap-2 text-xs text-muted">
       <span className="shrink-0">{label}</span>
       <select
         aria-label={label}
         value={value}
         disabled={disabled}
-        className="h-8 min-w-[8rem] rounded-md border border-border bg-surface px-2 text-sm text-foreground outline-none transition-colors focus:ring-2 focus:ring-focus disabled:cursor-not-allowed disabled:opacity-50"
+        className="h-8 w-44 max-w-full rounded-md border border-border bg-surface px-2 text-sm text-foreground outline-none transition-colors focus:ring-2 focus:ring-focus disabled:cursor-not-allowed disabled:opacity-50"
         onChange={(event) => onChange(event.currentTarget.value)}
       >
         {options.map((option) => (

--- a/apps/web/src/shared/ui/ResizableWorkspace.tsx
+++ b/apps/web/src/shared/ui/ResizableWorkspace.tsx
@@ -16,6 +16,7 @@ const DEFAULT_MAX_LEFT_PERCENT = 78;
 const DEFAULT_STEP = 4;
 
 export type ResizableWorkspaceOrientation = "horizontal" | "vertical";
+export type ResizableWorkspaceDesktopBreakpoint = "md" | "lg";
 
 export type ResizableWorkspaceProps = {
   ariaLabel: string;
@@ -35,6 +36,7 @@ export type ResizableWorkspaceProps = {
   minLeftPercent?: number;
   maxLeftPercent?: number;
   step?: number;
+  desktopBreakpoint?: ResizableWorkspaceDesktopBreakpoint;
 };
 
 export function ResizableWorkspace({
@@ -51,6 +53,7 @@ export function ResizableWorkspace({
   minLeftPercent = DEFAULT_MIN_LEFT_PERCENT,
   maxLeftPercent = DEFAULT_MAX_LEFT_PERCENT,
   step = DEFAULT_STEP,
+  desktopBreakpoint = "md",
 }: ResizableWorkspaceProps) {
   const isVertical = orientation === "vertical";
   const containerRef = useRef<HTMLDivElement | null>(null);
@@ -136,7 +139,7 @@ export function ResizableWorkspace({
       aria-label={ariaLabel}
       className={cn(
         "flex min-h-0 flex-1",
-        isVertical ? "flex-col" : "flex-col md:flex-row",
+        isVertical ? "flex-col" : horizontalLayoutClass(desktopBreakpoint),
         className,
       )}
       style={layoutStyle}
@@ -146,7 +149,7 @@ export function ResizableWorkspace({
           "min-h-0",
           isVertical
             ? "basis-[var(--workspace-left)] shrink-0 grow-0"
-            : "md:min-w-0 md:basis-[var(--workspace-left)] md:shrink-0 md:grow-0",
+            : horizontalPaneClass(desktopBreakpoint, "left"),
           leftClassName,
         )}
       >
@@ -165,7 +168,7 @@ export function ResizableWorkspace({
           "group shrink-0 touch-none items-stretch justify-center outline-none",
           isVertical
             ? "flex h-3 w-full cursor-row-resize"
-            : "hidden w-3 cursor-col-resize md:flex",
+            : horizontalSeparatorClass(desktopBreakpoint),
           "focus-visible:ring-2 focus-visible:ring-focus focus-visible:ring-offset-2 focus-visible:ring-offset-background",
         )}
         onPointerDown={handlePointerDown}
@@ -184,7 +187,7 @@ export function ResizableWorkspace({
       <div
         className={cn(
           "min-h-0",
-          isVertical ? "flex-1" : "md:min-w-0 md:flex-1",
+          isVertical ? "flex-1" : horizontalPaneClass(desktopBreakpoint, "right"),
           rightClassName,
         )}
       >
@@ -192,6 +195,28 @@ export function ResizableWorkspace({
       </div>
     </div>
   );
+}
+
+function horizontalLayoutClass(breakpoint: ResizableWorkspaceDesktopBreakpoint): string {
+  return breakpoint === "lg" ? "flex-col lg:flex-row" : "flex-col md:flex-row";
+}
+
+function horizontalSeparatorClass(breakpoint: ResizableWorkspaceDesktopBreakpoint): string {
+  return breakpoint === "lg" ? "hidden w-3 cursor-col-resize lg:flex" : "hidden w-3 cursor-col-resize md:flex";
+}
+
+function horizontalPaneClass(
+  breakpoint: ResizableWorkspaceDesktopBreakpoint,
+  side: "left" | "right",
+): string {
+  if (breakpoint === "lg") {
+    return side === "left"
+      ? "lg:min-w-0 lg:basis-[var(--workspace-left)] lg:shrink-0 lg:grow-0"
+      : "lg:min-w-0 lg:flex-1";
+  }
+  return side === "left"
+    ? "md:min-w-0 md:basis-[var(--workspace-left)] md:shrink-0 md:grow-0"
+    : "md:min-w-0 md:flex-1";
 }
 
 function readStoredPercent(

--- a/apps/web/src/shared/ui/__tests__/ResizableWorkspace.test.tsx
+++ b/apps/web/src/shared/ui/__tests__/ResizableWorkspace.test.tsx
@@ -62,6 +62,25 @@ describe("ResizableWorkspace", () => {
     );
   });
 
+  it("can delay the horizontal split until the large breakpoint", () => {
+    render(
+      <ResizableWorkspace
+        ariaLabel="大屏测试工作区"
+        separatorLabel="调整大屏测试工作区宽度"
+        storageKey="code-tape:large-workspace:left-percent"
+        desktopBreakpoint="lg"
+        left={<div>Left</div>}
+        right={<div>Right</div>}
+      />,
+    );
+
+    expect(screen.getByLabelText("大屏测试工作区")).toHaveClass("flex-col", "lg:flex-row");
+    expect(screen.getByRole("separator", { name: "调整大屏测试工作区宽度" })).toHaveClass(
+      "hidden",
+      "lg:flex",
+    );
+  });
+
   it("falls back from invalid persisted values and clamps out-of-range values", () => {
     window.localStorage.setItem("code-tape:invalid-workspace:left-percent", "not-a-number");
     const { unmount } = render(


### PR DESCRIPTION
## 关联

Refs #2（总控 issue，不在本 PR 中关闭）
Closes #252

## 改动点

- 为 `ResizableWorkspace` 增加 `desktopBreakpoint`，默认保持 `md` 行为，录制页改为 `lg` 后再进入左右分栏。
- 录制页窄屏下压缩编辑器最小高度，并让预览/输出区在 768px 宽度完整换行展示；堆叠布局下右侧预览/输出区会填满剩余工作区高度。
- 限制录制设置区 select 宽度，避免长设备名撑破工具栏。
- 增加窄屏录制页 e2e 回归，覆盖工具栏、设备选择、申请权限入口、页面级无横向溢出、长设备名、以及 768/1024/1280 三个关键宽度。

## 影响范围

- 录制页 `/record` 的 768px 到 1023px 宽度布局从左右分栏改为上下堆叠。
- `ResizableWorkspace` 默认断点未变，回放页等现有调用保持原有 `md` 分栏行为。
- `CodeEditor` 新增可选 compact 最小高度，默认高度保持不变，远程面试与回放调用不受默认行为影响。

## GitNexus 影响分析摘要

- 风险等级: high（完整 PR diff 初次 `npx gitnexus detect_changes --repo code-tape`）；后续 review 修复增量为 low。
- 关键骨架变更: 未触发关键契约面阻塞；`quality:local` 的 `contract:local` 输出为 advisory。
- GitNexus 影响面: 完整 PR diff 涉及 5 files / 10 symbols / 8 affected processes，主要由 `CodeEditor` 影响 `RemoteInterviewWorkbenchView` 的 Monaco worker、主题、快捷键和受控状态链路；`ResizableWorkspace` 影响 `RecorderPage` 与 `ReplayPage` 的工作区布局。后续增量仅触达 `RecorderPage`/scaffold e2e。
- 验证结果: 针对 `CodeEditor`、`ResizableWorkspace`、`RecorderPage`、`ReplayPage`、远程面试相关测试做过影响面验证；最终 push hook 已完整运行 `npm run quality:local`，包含 contract、lint、unit/build 与 7/7 e2e。另用 dev server 验证窄视口下 document overflow 为 0，output bottom 与 workspace bottom 对齐。

## 自检

- [x] 未修改 `docs/progress.json` 或 `docs/progress.md`
- [x] 已运行 `npm run quality:local`，或说明无法运行的原因
- [x] 涉及 AI 字幕时，已记录一次 `npm run subtitle:postprocess:evaluate` 的“纠错并生成章节”效果验证结果，包含 `representativeOutputSource`、`overallEvaluationDurationMs`，并区分输出校验耗时与真实端到端耗时（本 PR 不涉及 AI 字幕）
- [x] 涉及 AI 字幕点击链路、LLM worker、模型加载或性能时，已记录一次 `npm run subtitle:postprocess:runtime-benchmark` 结果，包含 `postprocessClickToResultReadyDurationMs`、`postProcessTimeoutBudgetMs` 和 `playbackProbeResponsiveDuringPostprocess`（本 PR 不涉及 AI 字幕）
- [x] 已说明改动点和影响范围
- [x] 如果改动关键骨架，已补充契约测试并填写 GitNexus 影响分析摘要
- [x] 已等待 repo-guard、codex 和 Copilot 评论，并完成必要审查
