### PR TITLE
#254 修复回放显示开关禁用态图标

### DIFF
--- a/apps/web/src/features/player/ReplayPage.tsx
+++ b/apps/web/src/features/player/ReplayPage.tsx
@@ -6,6 +6,7 @@ import {
   useState,
   type Dispatch,
   type MutableRefObject,
+  type ReactNode,
   type SetStateAction,
 } from "react";
 import { Link, useParams, useSearchParams } from "react-router-dom";
@@ -591,31 +592,31 @@ function ReplayDisplayToolbar({
 }) {
   return (
     <div className="flex min-h-11 flex-wrap items-center gap-1 border-b border-border bg-background px-3 py-2">
-      <Toggle
+      <ReplayDisplayToggle
         pressed={options.pointer}
         onPressedChange={(pressed) => onChange("pointer", pressed)}
         label="显示鼠标轨迹"
         icon={<MousePointer2 size={17} />}
       />
-      <Toggle
+      <ReplayDisplayToggle
         pressed={options.shortcuts}
         onPressedChange={(pressed) => onChange("shortcuts", pressed)}
         label="显示快捷键"
         icon={<Keyboard size={17} />}
       />
-      <Toggle
+      <ReplayDisplayToggle
         pressed={options.camera}
         onPressedChange={(pressed) => onChange("camera", pressed)}
         label="显示摄像头"
         icon={<Camera size={17} />}
       />
-      <Toggle
+      <ReplayDisplayToggle
         pressed={options.runtime}
         onPressedChange={(pressed) => onChange("runtime", pressed)}
         label="显示运行面板"
         icon={<TerminalSquare size={17} />}
       />
-      <Toggle
+      <ReplayDisplayToggle
         pressed={options.subtitles}
         onPressedChange={(pressed) => onChange("subtitles", pressed)}
         label="显示字幕"
@@ -634,6 +635,46 @@ function ReplayDisplayToolbar({
         </button>
       ) : null}
     </div>
+  );
+}
+
+function ReplayDisplayToggle({
+  pressed,
+  onPressedChange,
+  label,
+  icon,
+}: {
+  pressed: boolean;
+  onPressedChange(pressed: boolean): void;
+  label: string;
+  icon: ReactNode;
+}) {
+  return (
+    <Toggle
+      pressed={pressed}
+      onPressedChange={onPressedChange}
+      label={label}
+      icon={<ReplayDisplayToggleIcon visible={false}>{icon}</ReplayDisplayToggleIcon>}
+      iconPressed={<ReplayDisplayToggleIcon visible>{icon}</ReplayDisplayToggleIcon>}
+    />
+  );
+}
+
+function ReplayDisplayToggleIcon({ visible, children }: { visible: boolean; children: ReactNode }) {
+  return (
+    <span
+      aria-hidden
+      className="relative inline-flex h-[17px] w-[17px] items-center justify-center"
+      data-display-toggle-state={visible ? "visible" : "hidden"}
+    >
+      {children}
+      {visible ? null : (
+        <span
+          className="pointer-events-none absolute left-1/2 top-1/2 h-[2px] w-[23px] -translate-x-1/2 -translate-y-1/2 -rotate-45 rounded-full bg-current"
+          data-display-toggle-off-slash="true"
+        />
+      )}
+    </span>
   );
 }
 

--- a/apps/web/src/features/player/__tests__/ReplayPage.test.tsx
+++ b/apps/web/src/features/player/__tests__/ReplayPage.test.tsx
@@ -700,6 +700,10 @@ describe("ReplayPage", () => {
     expect(cameraToggle).toHaveAttribute("aria-pressed", "true");
     expect(runtimeToggle).toHaveAttribute("aria-pressed", "true");
     expect(subtitleToggle).toHaveAttribute("aria-pressed", "true");
+    for (const toggle of [pointerToggle, shortcutToggle, cameraToggle, runtimeToggle, subtitleToggle]) {
+      expect(toggle.querySelector("[data-display-toggle-state='visible']")).toBeInTheDocument();
+      expect(toggle.querySelector("[data-display-toggle-state='hidden']")).not.toBeInTheDocument();
+    }
 
     act(() => {
       replayPageMock.onTick?.(
@@ -755,6 +759,7 @@ describe("ReplayPage", () => {
 
     fireEvent.click(pointerToggle);
     fireEvent.click(shortcutToggle);
+    fireEvent.click(cameraToggle);
     fireEvent.click(runtimeToggle);
     fireEvent.click(subtitleToggle);
 
@@ -764,8 +769,14 @@ describe("ReplayPage", () => {
     expect(screen.queryByLabelText("Mock subtitle panel")).not.toBeInTheDocument();
     expect(pointerToggle).toHaveAttribute("aria-pressed", "false");
     expect(shortcutToggle).toHaveAttribute("aria-pressed", "false");
+    expect(cameraToggle).toHaveAttribute("aria-pressed", "false");
     expect(runtimeToggle).toHaveAttribute("aria-pressed", "false");
     expect(subtitleToggle).toHaveAttribute("aria-pressed", "false");
+    for (const toggle of [pointerToggle, shortcutToggle, cameraToggle, runtimeToggle, subtitleToggle]) {
+      expect(toggle.querySelector("[data-display-toggle-state='hidden']")).toBeInTheDocument();
+      expect(toggle.querySelector("[data-display-toggle-off-slash]")).toBeInTheDocument();
+      expect(toggle.querySelector("[data-display-toggle-state='visible']")).not.toBeInTheDocument();
+    }
   });
 
   it("renders recorded camera media when the package has a camera track", async () => {


### PR DESCRIPTION
## 关联

Refs #2（总控 issue，不在本 PR 中关闭）
Closes #254

## 改动点

- 回放页顶部 5 个显示开关关闭时，在原图标上叠加斜杠，明确表达隐藏/禁用显示状态。
- 保持按钮 `aria-pressed`、可访问名称和 36x36 稳定尺寸不变。
- 扩展 ReplayPage 测试，覆盖默认可见态、关闭态斜杠标记，以及摄像头开关的关闭状态断言。

## 影响范围

- 仅影响回放页显示开关的视觉反馈。
- 不改变回放调度器、录制包结构、媒体/字幕/运行面板业务语义。

## GitNexus 影响分析摘要

- 风险等级: low
- 关键骨架变更: 无；GitNexus contract 判定本 diff 未改关键 contract surface。
- GitNexus 影响面: 2 files / 3 symbols，Affected processes: 0。
- 验证结果: `npx gitnexus detect_changes --repo code-tape` 已运行；pre-push `npm run quality:local` 已通过。

## 自检

- [x] 未修改 `docs/progress.json` 或 `docs/progress.md`
- [x] 已运行 `npm run quality:local`，或说明无法运行的原因
- [x] 涉及 AI 字幕时，已记录一次 `npm run subtitle:postprocess:evaluate` 的“纠错并生成章节”效果验证结果，包含 `representativeOutputSource`、`overallEvaluationDurationMs`，并区分输出校验耗时与真实端到端耗时（不涉及）
- [x] 涉及 AI 字幕点击链路、LLM worker、模型加载或性能时，已记录一次 `npm run subtitle:postprocess:runtime-benchmark` 结果，包含 `postprocessClickToResultReadyDurationMs`、`postProcessTimeoutBudgetMs` 和 `playbackProbeResponsiveDuringPostprocess`（不涉及）
- [x] 已说明改动点和影响范围
- [x] 如果改动关键骨架，已补充契约测试并填写 GitNexus 影响分析摘要（不涉及关键骨架）
- [ ] 已等待 repo-guard、codex 和 Copilot 评论，并完成必要审查

## 验证

- `npm run test -w apps/web -- ReplayPage.test.tsx`
- 浏览器核对：5 个显示开关默认 `aria-pressed=true / visible / slashCount=0 / 36x36`，关闭后 `aria-pressed=false / hidden / slashCount=1 / 36x36`
- `npx gitnexus detect_changes --repo code-tape`
- `npm run quality:precommit`
- `npm run quality:local`（pre-push hook，含 7/7 e2e）
