### PR TITLE
#256 统一库页品牌字标

### DIFF
--- a/apps/web/src/app/AppShell.tsx
+++ b/apps/web/src/app/AppShell.tsx
@@ -12,7 +12,7 @@ export function AppShell() {
   return (
     <div className="flex h-screen flex-col bg-background text-foreground">
       <header className="flex h-12 items-center gap-4 border-b border-border bg-surface/80 px-4 backdrop-blur">
-        <span className="font-display text-sm font-semibold tracking-tight">code-tape</span>
+        <span className="font-display text-xs font-semibold tracking-[0.24em]">CODE-TAPE</span>
         <nav className="flex items-center gap-1 text-sm">
           <NavLink
             to="/"

--- a/apps/web/src/app/__tests__/routes.test.tsx
+++ b/apps/web/src/app/__tests__/routes.test.tsx
@@ -22,6 +22,19 @@ describe("appRoutes", () => {
 });
 
 describe("AppShell", () => {
+  it("uses the uppercase wordmark in the top navigation", () => {
+    render(
+      <ThemeProvider>
+        <MemoryRouter>
+          <AppShell />
+        </MemoryRouter>
+      </ThemeProvider>,
+    );
+
+    expect(screen.getByText("CODE-TAPE")).toBeInTheDocument();
+    expect(screen.queryByText("code-tape")).not.toBeInTheDocument();
+  });
+
   it("exposes the interview lobby entry in the top navigation", () => {
     render(
       <ThemeProvider>

--- a/apps/web/src/features/library/RecordingLibraryPage.tsx
+++ b/apps/web/src/features/library/RecordingLibraryPage.tsx
@@ -335,7 +335,6 @@ export function RecordingLibraryPage() {
     <div className="flex h-full flex-col gap-6 px-16 py-6">
       <header className="flex flex-wrap items-center justify-between gap-4">
         <div>
-          <p className="text-xs uppercase tracking-[0.3em] text-muted">code-tape</p>
           <h1 className="font-display text-3xl font-semibold">我的录制</h1>
           {quotaLabel ? <p className="mt-2 text-xs text-muted">{quotaLabel}</p> : null}
           <div

--- a/apps/web/src/features/library/__tests__/RecordingLibraryPage.test.tsx
+++ b/apps/web/src/features/library/__tests__/RecordingLibraryPage.test.tsx
@@ -154,6 +154,15 @@ describe("RecordingLibraryPage", () => {
     expect(await screen.findByText("\u8fd8\u6ca1\u6709\u5f55\u5236")).toBeInTheDocument();
   });
 
+  it("does not repeat the product wordmark above the library title", async () => {
+    renderPage();
+    await waitForElementToBeRemoved(() => screen.queryByRole("status"));
+
+    expect(screen.getByRole("heading", { name: "\u6211\u7684\u5f55\u5236" })).toBeInTheDocument();
+    expect(screen.queryByText("code-tape")).not.toBeInTheDocument();
+    expect(screen.queryByText("CODE-TAPE")).not.toBeInTheDocument();
+  });
+
   it("keeps persistent load error state after closing load-failed dialog", async () => {
     repositoryMocks.list.mockRejectedValueOnce(new Error("idb read failed"));
     renderPage();


### PR DESCRIPTION
## 关联

Refs #2（总控 issue，不在本 PR 中关闭）
Closes #256

## 改动点

- 将顶部导航左上角品牌字标统一为 `CODE-TAPE`，并使用更接近库页原字标的全大写、宽字距视觉。
- 移除库页标题区重复出现的 `code-tape` 字标，避免同屏出现两个品牌标识。
- 补充路由与库页测试，覆盖顶部字标与库页标题区不重复展示品牌字标。

## 影响范围

- `AppShell` 顶部导航品牌展示。
- `RecordingLibraryPage` 标题区文案结构。
- 不涉及数据结构、录制流程、字幕流程或关键骨架契约。

## GitNexus 影响分析摘要

- 风险等级: low
- 关键骨架变更: 无
- GitNexus 影响面: affected processes 0
- 验证结果: `npx gitnexus detect_changes --repo code-tape` 已完成，识别到 4 个文件、1 个符号变更，风险 low。

## 自检

- [x] 未修改 `docs/progress.json` 或 `docs/progress.md`
- [x] 已运行 `npm run quality:local`，或说明无法运行的原因
- [ ] 涉及 AI 字幕时，已记录一次 `npm run subtitle:postprocess:evaluate` 的“纠错并生成章节”效果验证结果，包含 `representativeOutputSource`、`overallEvaluationDurationMs`，并区分输出校验耗时与真实端到端耗时
- [ ] 涉及 AI 字幕点击链路、LLM worker、模型加载或性能时，已记录一次 `npm run subtitle:postprocess:runtime-benchmark` 结果，包含 `postprocessClickToResultReadyDurationMs`、`postProcessTimeoutBudgetMs` 和 `playbackProbeResponsiveDuringPostprocess`
- [x] 已说明改动点和影响范围
- [x] 如果改动关键骨架，已补充契约测试并填写 GitNexus 影响分析摘要
- [ ] 已等待 repo-guard、codex 和 Copilot 评论，并完成必要审查

## 验证

- `npm run test -w apps/web -- routes.test.tsx RecordingLibraryPage.test.tsx`
- 浏览器检查库页：顶部字标为 `CODE-TAPE`，重复字标数量为 0。
- `npx gitnexus detect_changes --repo code-tape`
- `npm run quality:precommit`
- `npm run quality:local`（由 pre-push 钩子执行）
