### PR TITLE
#258 补齐分享时间点回放测试

### DIFF
--- a/apps/web/src/features/player/__tests__/ReplayPage.cloudLoader.integration.test.tsx
+++ b/apps/web/src/features/player/__tests__/ReplayPage.cloudLoader.integration.test.tsx
@@ -1,4 +1,4 @@
-import { render, waitFor } from "@testing-library/react";
+import { act, render, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { CodeEditorProps } from "@/features/editor/CodeEditor";
 import type { PreviewPaneProps } from "@/features/runtime-preview/PreviewPane";
@@ -38,6 +38,7 @@ const replayIntegrationMock = vi.hoisted(() => {
   };
   const descriptorRepository = {
     getPlaybackDescriptor: vi.fn(),
+    getSharedPlaybackDescriptor: vi.fn(),
   };
   const localRepository = {
     load: vi.fn(),
@@ -54,10 +55,13 @@ const replayIntegrationMock = vi.hoisted(() => {
       scheduler.destroy.mockClear();
       scheduler.subscribe.mockClear();
       descriptorRepository.getPlaybackDescriptor.mockReset();
+      descriptorRepository.getSharedPlaybackDescriptor.mockReset();
       localRepository.load.mockReset();
       this.routeId = "cloud-rec-1";
+      this.routeToken = "share-token";
       this.search = "";
     },
+    routeToken: "share-token",
   };
 });
 
@@ -65,7 +69,7 @@ vi.mock("react-router-dom", async () => {
   const actual = await vi.importActual<typeof ReactRouterDom>("react-router-dom");
   return {
     ...actual,
-    useParams: () => ({ id: replayIntegrationMock.routeId }),
+    useParams: () => ({ id: replayIntegrationMock.routeId, token: replayIntegrationMock.routeToken }),
     useSearchParams: () => [new URLSearchParams(replayIntegrationMock.search), vi.fn()],
   };
 });
@@ -157,6 +161,60 @@ describe("ReplayPage cloud package loader integration", () => {
     });
     expect(replayIntegrationMock.localRepository.load).not.toHaveBeenCalled();
   });
+
+  it("loads share links by token and seeks to the t query after package load", async () => {
+    const parts = await makePackageParts();
+    let resolveLoad!: () => void;
+    const loadCompletion = new Promise<void>((resolve) => {
+      resolveLoad = resolve;
+    });
+    replayIntegrationMock.scheduler.load.mockImplementationOnce(async () => loadCompletion);
+    replayIntegrationMock.routeToken = "share-token-1";
+    replayIntegrationMock.search = "t=42000";
+    replayIntegrationMock.descriptorRepository.getSharedPlaybackDescriptor.mockResolvedValue({
+      ok: true,
+      value: makeDescriptor({ id: "shared-rec-1", durationMs: 60_000 }),
+    });
+    vi.stubGlobal("fetch", makeAssetFetch({
+      "https://assets.example.com/manifest.json": jsonResponse({
+        ...parts.manifest,
+        packageId: "shared-rec-1",
+      }),
+      "https://assets.example.com/meta.json": jsonResponse({
+        ...parts.meta,
+        id: "shared-rec-1",
+        durationMs: 60_000,
+      }),
+      "https://assets.example.com/events.json": jsonResponse(parts.events),
+      "https://assets.example.com/snapshots.json": jsonResponse(parts.snapshots),
+    }));
+    const { ReplayPage } = await import("../ReplayPage");
+
+    render(<ReplayPage source="share" />);
+
+    await waitFor(() => {
+      expect(replayIntegrationMock.descriptorRepository.getSharedPlaybackDescriptor).toHaveBeenCalledWith("share-token-1");
+    });
+    expect(replayIntegrationMock.descriptorRepository.getPlaybackDescriptor).not.toHaveBeenCalled();
+    await waitFor(() => {
+      expect(replayIntegrationMock.scheduler.load).toHaveBeenCalledWith(
+        expect.objectContaining({
+          meta: expect.objectContaining({ id: "shared-rec-1" }),
+        }),
+      );
+    });
+    expect(replayIntegrationMock.scheduler.seek).not.toHaveBeenCalled();
+    await act(async () => {
+      resolveLoad();
+      await loadCompletion;
+    });
+    await waitFor(() => {
+      expect(replayIntegrationMock.scheduler.seek).toHaveBeenCalledWith(42_000);
+    });
+    expect(replayIntegrationMock.scheduler.load.mock.invocationCallOrder[0]).toBeLessThan(
+      replayIntegrationMock.scheduler.seek.mock.invocationCallOrder[0]!,
+    );
+  });
 });
 
 async function makePackageParts() {
@@ -234,7 +292,7 @@ async function makePackageParts() {
   return { manifest, meta, events, snapshots };
 }
 
-function makeDescriptor(): CloudPlaybackDescriptor {
+function makeDescriptor(overrides: Partial<CloudPlaybackDescriptor> = {}): CloudPlaybackDescriptor {
   return {
     id: "cloud-rec-1",
     title: "Cloud Replay",
@@ -248,6 +306,7 @@ function makeDescriptor(): CloudPlaybackDescriptor {
     mediaUrl: null,
     thumbnailUrl: null,
     expiresAt: "2026-05-29T00:10:00.000Z",
+    ...overrides,
   };
 }
 


### PR DESCRIPTION
## 关联

Refs #2（总控 issue，不在本 PR 中关闭）
Closes #258

## 改动点

- 扩展 `ReplayPage.cloudLoader.integration.test.tsx` 的路由与 repository mock，覆盖 share token 路径。
- 新增分享链接 `?t=42000` 回放测试，验证分享页加载包后通过统一 `scheduler.seek(42000)` 定位。
- 验证 share 播放走 `getSharedPlaybackDescriptor(token)`，不误走 owner playback descriptor。

## 影响范围

- 仅测试文件变更，不修改生产代码。
- 覆盖 P1 时间点分享链接前端回归风险。

## GitNexus 影响分析摘要

- 风险等级: low
- 关键骨架变更: 无
- GitNexus 影响面: `npx gitnexus detect_changes --repo code-tape` 返回 `No changes detected`，本次为测试-only diff。
- 验证结果: targeted test、precommit、pre-push quality gates 均通过。

## 自检

- [x] 未修改 `docs/progress.json` 或 `docs/progress.md`
- [x] 已运行 `npm run quality:local`，或说明无法运行的原因
- [ ] 涉及 AI 字幕时，已记录一次 `npm run subtitle:postprocess:evaluate` 的“纠错并生成章节”效果验证结果，包含 `representativeOutputSource`、`overallEvaluationDurationMs`，并区分输出校验耗时与真实端到端耗时
- [ ] 涉及 AI 字幕点击链路、LLM worker、模型加载或性能时，已记录一次 `npm run subtitle:postprocess:runtime-benchmark` 结果，包含 `postprocessClickToResultReadyDurationMs`、`postProcessTimeoutBudgetMs` 和 `playbackProbeResponsiveDuringPostprocess`
- [x] 已说明改动点和影响范围
- [x] 如果改动关键骨架，已补充契约测试并填写 GitNexus 影响分析摘要
- [ ] 已等待 repo-guard、codex 和 Copilot 评论，并完成必要审查

## 验证

- `npm run test -w apps/web -- ReplayPage.cloudLoader.integration.test.tsx`
- `npx gitnexus detect_changes --repo code-tape`
- `npm run quality:precommit`
- `npm run quality:local`（由 pre-push 钩子执行，含 e2e）
