### PR TITLE
#214 对齐云端删除响应与 WebRTC hash 重同步

### DIFF
--- a/apps/api/src/cloud/__tests__/uploadSession.test.ts
+++ b/apps/api/src/cloud/__tests__/uploadSession.test.ts
@@ -720,6 +720,32 @@ for (const terminalStatus of ["purging", "deleted"] as const) {
   });
 }
 
+test("deleteRecording returns purgeAfter for the seven-day soft-delete retention window", async () => {
+  const metadata = createMemoryMetadataRepository();
+  const objectStorage = createMemoryObjectStorage();
+  const service = createCloudRecordingService({
+    metadata,
+    objectStorage,
+    now: () => new Date("2026-05-27T00:00:00.000Z"),
+  });
+  const pkg = await makePackage();
+  const request = await makeCreateSessionRequest(pkg);
+  const created = await service.createUploadSession({ ownerId: "owner-1", input: request });
+  assert.equal(created.ok, true);
+  if (!created.ok) return;
+
+  const deleted = await service.deleteRecording({
+    ownerId: "owner-1",
+    recordingId: created.value.recordingId,
+  });
+
+  assert.equal(deleted.ok, true);
+  if (!deleted.ok) return;
+  assert.equal(deleted.value.recordingId, created.value.recordingId);
+  assert.equal(deleted.value.deletedAt, "2026-05-27T00:00:00.000Z");
+  assert.equal(deleted.value.purgeAfter, "2026-06-03T00:00:00.000Z");
+});
+
 test("delete returns the persisted deletedAt when dirty soft-delete repair loses the conditional write race", async () => {
   const metadata = createMemoryMetadataRepository();
   const objectStorage = createMemoryObjectStorage();

--- a/apps/api/src/cloud/cloudRecordingService.ts
+++ b/apps/api/src/cloud/cloudRecordingService.ts
@@ -49,6 +49,7 @@ const SHA256_HEX_PATTERN = /^[a-f0-9]{64}$/u;
 const DEFAULT_LIST_LIMIT = 20;
 const SHARE_TOKEN_BYTES = 32;
 const MAX_SHARE_TOKEN_ATTEMPTS = 5;
+const SOFT_DELETE_RETENTION_MS = 7 * 24 * 60 * 60 * 1000;
 
 export type CloudRecordingService = {
   createUploadSession(input: {
@@ -327,8 +328,10 @@ export function createCloudRecordingService(deps: {
           ok: true,
           value: {
             id: recording.id,
+            recordingId: recording.id,
             status: "soft_deleted" as const,
             deletedAt,
+            purgeAfter: purgeAfterFor(deletedAt),
           },
         };
       }
@@ -357,7 +360,13 @@ export function createCloudRecordingService(deps: {
           });
           return {
             ok: true,
-            value: { id: write.recording.id, status: "soft_deleted" as const, deletedAt },
+            value: {
+              id: write.recording.id,
+              recordingId: write.recording.id,
+              status: "soft_deleted" as const,
+              deletedAt,
+              purgeAfter: purgeAfterFor(deletedAt),
+            },
           };
         }
 
@@ -381,7 +390,13 @@ export function createCloudRecordingService(deps: {
           });
           return {
             ok: true,
-            value: { id: latest.id, status: "soft_deleted" as const, deletedAt: latestDeletedAt },
+            value: {
+              id: latest.id,
+              recordingId: latest.id,
+              status: "soft_deleted" as const,
+              deletedAt: latestDeletedAt,
+              purgeAfter: purgeAfterFor(latestDeletedAt),
+            },
           };
         }
         if (!isOwnerVisibleStatus(latest.status)) {
@@ -613,6 +628,10 @@ async function ensureSoftDeleteTimestamp(input: {
     current = latest;
   }
   return current.deletedAt;
+}
+
+function purgeAfterFor(deletedAt: string): string {
+  return new Date(Date.parse(deletedAt) + SOFT_DELETE_RETENTION_MS).toISOString();
 }
 
 async function resolveExistingUploadSession(input: {

--- a/apps/api/src/cloud/types.ts
+++ b/apps/api/src/cloud/types.ts
@@ -167,8 +167,10 @@ export type RenameRecordingResponse = {
 
 export type DeleteRecordingResponse = {
   id: string;
+  recordingId: string;
   status: "soft_deleted";
   deletedAt: string;
+  purgeAfter: string;
 };
 
 export type CreateShareLinkRequest = {

--- a/apps/api/src/http/__tests__/cloudApiHandler.test.ts
+++ b/apps/api/src/http/__tests__/cloudApiHandler.test.ts
@@ -2110,12 +2110,23 @@ test("DELETE /api/recordings/:recordingId soft-deletes a ready recording", async
       headers: { "x-owner-token": "owner-1" },
     }),
   );
-  const body = (await response.json()) as { id: string; status: string; deletedAt: string };
+  const body = (await response.json()) as {
+    id: string;
+    recordingId: string;
+    status: string;
+    deletedAt: string;
+    purgeAfter: string;
+  };
 
   assert.equal(response.status, 200);
   assert.equal(body.id, "rec-ready");
+  assert.equal(body.recordingId, "rec-ready");
   assert.equal(body.status, "soft_deleted");
   assert.ok(body.deletedAt);
+  assert.equal(
+    Date.parse(body.purgeAfter) - Date.parse(body.deletedAt),
+    7 * 24 * 60 * 60 * 1000,
+  );
 
   // Verify the recording is no longer in the list
   const listResponse = await handler(

--- a/apps/web/src/features/interview/RemoteInterviewWorkbenchPage.tsx
+++ b/apps/web/src/features/interview/RemoteInterviewWorkbenchPage.tsx
@@ -215,12 +215,12 @@ function RemoteInterviewWorkbenchRoom({
     }
     const channel = mediaSession.getEventsDataChannel();
     if (!channel || channel.readyState !== "open") return;
-    const gapKey = `${need.expectedSeq}:${need.lastAppliedSeq}`;
+    const gapKey = `${need.reason}:${need.expectedSeq}:${need.lastAppliedSeq}`;
     if (lastRequestedGapRef.current === gapKey) return;
     const request = buildSnapshotRequestMessage({
       roomId,
       sessionId: roomId,
-      reason: "gap-timeout",
+      reason: need.reason === "hash-mismatch" ? "hash-mismatch" : "gap-timeout",
       expectedSeq: need.expectedSeq,
       lastAppliedSeq: need.lastAppliedSeq,
     });
@@ -788,7 +788,9 @@ function syncStatusView(state: RemoteInterviewWorkbenchState): {
     return {
       label: "等待候选人状态快照",
       detail: state.snapshotRequestNeeded
-        ? `缺失事件 seq ${state.snapshotRequestNeeded.expectedSeq}，已保留 seq ${state.snapshotRequestNeeded.lastAppliedSeq} 的稳定状态`
+        ? state.snapshotRequestNeeded.reason === "hash-mismatch"
+          ? `事件 seq ${state.snapshotRequestNeeded.expectedSeq} 内容校验失败，已保留 seq ${state.snapshotRequestNeeded.lastAppliedSeq} 的稳定状态`
+          : `缺失事件 seq ${state.snapshotRequestNeeded.expectedSeq}，已保留 seq ${state.snapshotRequestNeeded.lastAppliedSeq} 的稳定状态`
         : "正在等待候选人状态，已保留最后稳定代码",
       toneClass: "border-warning/40 bg-warning/10 text-warning",
       Icon: SignalHigh,

--- a/apps/web/src/features/interview/__tests__/RemoteInterviewWorkbenchPage.test.tsx
+++ b/apps/web/src/features/interview/__tests__/RemoteInterviewWorkbenchPage.test.tsx
@@ -702,6 +702,50 @@ describe("RemoteInterviewWorkbenchPage interviewer signaling", () => {
     expect(requestCount).toBe(1);
   });
 
+  it("sends a hash-mismatch snapshot-request when content validation fails", async () => {
+    const roomClient = makeRoomClient();
+    const signaling = makeSignalingFactory();
+    const media = makeInterviewerMediaSessionFactory();
+
+    renderInterviewerPage({
+      initialEntry: "/interview/interviewer/room-live?joinCode=JOIN1234",
+      roomClient,
+      createSignalingClient: signaling.create,
+      createMediaSession: media.create,
+    });
+    await waitFor(() => {
+      expect(signaling.create).toHaveBeenCalledTimes(1);
+    });
+
+    let channel!: TestEventsDataChannel;
+    act(() => {
+      channel = media.attachEventsDataChannel();
+      channel.emit(
+        JSON.stringify({
+          ...recordingMessage(contentEvent(1, "const corrupted = true;")),
+          contentHash: "fnv1a-deadbeef",
+        }),
+      );
+    });
+
+    await waitFor(() => {
+      const requests = vi
+        .mocked(channel.send)
+        .mock.calls.map(([data]) => JSON.parse(data))
+        .filter((message) => message.kind === "snapshot-request");
+      expect(requests).toHaveLength(1);
+      expect(requests[0]).toMatchObject({
+        roomId: "room-live",
+        reason: "hash-mismatch",
+        expectedSeq: 1,
+        lastAppliedSeq: 0,
+      });
+    });
+    expect(
+      screen.getByText("事件 seq 1 内容校验失败，已保留 seq 0 的稳定状态"),
+    ).toBeInTheDocument();
+  });
+
   it("ignores cross-room and non-candidate media messages", async () => {
     const roomClient = makeRoomClient();
     const signaling = makeSignalingFactory();

--- a/apps/web/src/features/interview/__tests__/remoteInterviewWorkbench.test.ts
+++ b/apps/web/src/features/interview/__tests__/remoteInterviewWorkbench.test.ts
@@ -212,6 +212,48 @@ describe("RemoteInterviewWorkbench", () => {
     expect(state.snapshotRequestNeeded).toBeNull();
   });
 
+  it("preserves the first missing gap when a future content event has a mismatched hash", () => {
+    const workbench = createRemoteInterviewWorkbench({
+      initialState: initialState(),
+      initialExpectedSeq: 2,
+    });
+
+    const state = workbench.pushRecordingEvent(
+      hashedMessageFor(contentEvent(3, "const futureCorrupted = true;"), "fnv1a-deadbeef"),
+    );
+
+    expect(state.stableState.editor.code).toBe("");
+    expect(state.lastAppliedSeq).toBe(1);
+    expect(state.syncStatus).toBe("waiting-for-snapshot");
+    expect(state.snapshotRequestNeeded).toEqual({
+      reason: "gap-detected",
+      expectedSeq: 2,
+      lastAppliedSeq: 1,
+    });
+  });
+
+  it("defers a future hash mismatch until the missing earlier event is applied", () => {
+    const workbench = createRemoteInterviewWorkbench({
+      initialState: initialState(),
+      initialExpectedSeq: 2,
+    });
+
+    workbench.pushRecordingEvent(
+      hashedMessageFor(contentEvent(3, "const futureCorrupted = true;"), "fnv1a-deadbeef"),
+    );
+    const state = workbench.pushRecordingEvent(messageFor(contentEvent(2, "const filled = true;")));
+
+    expect(state.stableState.editor.code).toBe("const filled = true;");
+    expect(state.lastAppliedSeq).toBe(2);
+    expect(state.expectedSeq).toBe(3);
+    expect(state.syncStatus).toBe("waiting-for-snapshot");
+    expect(state.snapshotRequestNeeded).toEqual({
+      reason: "hash-mismatch",
+      expectedSeq: 3,
+      lastAppliedSeq: 2,
+    });
+  });
+
   it("ignores duplicate and old events without rolling back stable state", () => {
     const workbench = createRemoteInterviewWorkbench({ initialState: initialState() });
 

--- a/apps/web/src/features/interview/__tests__/remoteInterviewWorkbench.test.ts
+++ b/apps/web/src/features/interview/__tests__/remoteInterviewWorkbench.test.ts
@@ -199,6 +199,19 @@ describe("RemoteInterviewWorkbench", () => {
     });
   });
 
+  it("applies content normally when the message hash matches the receiver contract", () => {
+    const workbench = createRemoteInterviewWorkbench({ initialState: initialState() });
+
+    const state = workbench.pushRecordingEvent(
+      hashedMessageFor(contentEvent(1, "const verified = true;"), "fnv1a-18971cb2"),
+    );
+
+    expect(state.stableState.editor.code).toBe("const verified = true;");
+    expect(state.lastAppliedSeq).toBe(1);
+    expect(state.syncStatus).toBe("live");
+    expect(state.snapshotRequestNeeded).toBeNull();
+  });
+
   it("ignores duplicate and old events without rolling back stable state", () => {
     const workbench = createRemoteInterviewWorkbench({ initialState: initialState() });
 

--- a/apps/web/src/features/interview/__tests__/remoteInterviewWorkbench.test.ts
+++ b/apps/web/src/features/interview/__tests__/remoteInterviewWorkbench.test.ts
@@ -104,6 +104,10 @@ function messageFor(event: RecordingEvent) {
   };
 }
 
+function hashedMessageFor(event: RecordingEvent, contentHash: string) {
+  return { ...messageFor(event), contentHash };
+}
+
 function snapshotMessage(snapshotSeq: number, code: string) {
   return {
     kind: "state-snapshot" as const,
@@ -176,6 +180,23 @@ describe("RemoteInterviewWorkbench", () => {
     expect(state.expectedSeq).toBe(4);
     expect(state.syncStatus).toBe("live");
     expect(state.snapshotRequestNeeded).toBeNull();
+  });
+
+  it("requests a snapshot without applying content when the message hash mismatches", () => {
+    const workbench = createRemoteInterviewWorkbench({ initialState: initialState() });
+
+    const state = workbench.pushRecordingEvent(
+      hashedMessageFor(contentEvent(1, "const corrupted = true;"), "fnv1a-deadbeef"),
+    );
+
+    expect(state.stableState.editor.code).toBe("");
+    expect(state.lastAppliedSeq).toBe(0);
+    expect(state.syncStatus).toBe("waiting-for-snapshot");
+    expect(state.snapshotRequestNeeded).toEqual({
+      reason: "hash-mismatch",
+      expectedSeq: 1,
+      lastAppliedSeq: 0,
+    });
   });
 
   it("ignores duplicate and old events without rolling back stable state", () => {

--- a/apps/web/src/features/interview/interviewSync.ts
+++ b/apps/web/src/features/interview/interviewSync.ts
@@ -236,7 +236,7 @@ const DEFAULT_SNAPSHOT_EVENT_INTERVAL = 50;
 const DEFAULT_SNAPSHOT_TIME_INTERVAL_MS = 5000;
 
 export type SnapshotRequestNeed = {
-  reason: "gap-detected";
+  reason: "gap-detected" | "hash-mismatch";
   expectedSeq: number;
   lastAppliedSeq: number;
 };

--- a/apps/web/src/features/interview/remoteInterviewWorkbench.ts
+++ b/apps/web/src/features/interview/remoteInterviewWorkbench.ts
@@ -38,15 +38,19 @@ export function createRemoteInterviewWorkbench(
   let stableState = cloneReplayStableState(options.initialState);
   const buffer = createRemoteTimelineBuffer({ initialExpectedSeq: options.initialExpectedSeq });
   const listeners = new Set<(state: RemoteInterviewWorkbenchState) => void>();
+  let hashMismatchNeed: SnapshotRequestNeed | null = null;
 
   const snapshot = (): RemoteInterviewWorkbenchState => {
     const bufferState = buffer.state();
+    const snapshotRequestNeeded =
+      cloneSnapshotRequestNeed(hashMismatchNeed) ??
+      cloneSnapshotRequestNeed(bufferState.snapshotRequestNeeded);
     return {
       stableState: cloneReplayStableState(stableState),
       expectedSeq: bufferState.expectedSeq,
       lastAppliedSeq: bufferState.lastAppliedSeq,
-      syncStatus: syncStatusFor(bufferState.snapshotRequestNeeded, bufferState.lastAppliedSeq),
-      snapshotRequestNeeded: cloneSnapshotRequestNeed(bufferState.snapshotRequestNeeded),
+      syncStatus: syncStatusFor(snapshotRequestNeeded, bufferState.lastAppliedSeq),
+      snapshotRequestNeeded,
     };
   };
 
@@ -59,7 +63,22 @@ export function createRemoteInterviewWorkbench(
   return {
     getState: snapshot,
     pushRecordingEvent(message) {
+      const bufferState = buffer.state();
+      if (message.event.seq >= bufferState.expectedSeq && hasMismatchedContentHash(message)) {
+        hashMismatchNeed = {
+          reason: "hash-mismatch",
+          expectedSeq: message.event.seq,
+          lastAppliedSeq: bufferState.lastAppliedSeq,
+        };
+        return notify();
+      }
       const result = buffer.pushRecordingEvent(message);
+      if (
+        hashMismatchNeed &&
+        result.appliedEvents.some((event) => event.seq >= hashMismatchNeed!.expectedSeq)
+      ) {
+        hashMismatchNeed = null;
+      }
       stableState = result.appliedEvents.reduce(replayReducer, stableState);
       return notify();
     },
@@ -67,6 +86,7 @@ export function createRemoteInterviewWorkbench(
       const result = buffer.pushSnapshot(message);
       if (result.snapshotAccepted) {
         stableState = cloneReplayStableState(message.state);
+        hashMismatchNeed = null;
       }
       stableState = result.appliedEvents.reduce(replayReducer, stableState);
       return notify();
@@ -98,4 +118,20 @@ function syncStatusFor(
     return "waiting-for-snapshot";
   }
   return lastAppliedSeq > 0 ? "live" : "idle";
+}
+
+function hasMismatchedContentHash(message: InterviewRecordingEventMessage): boolean {
+  if (message.event.type !== "content-change" || message.contentHash === undefined) {
+    return false;
+  }
+  return hashContent(message.event.payload.code) !== message.contentHash;
+}
+
+function hashContent(value: string): string {
+  let hash = 0x811c9dc5;
+  for (let index = 0; index < value.length; index += 1) {
+    hash ^= value.charCodeAt(index);
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return `fnv1a-${(hash >>> 0).toString(16)}`;
 }

--- a/apps/web/src/features/interview/remoteInterviewWorkbench.ts
+++ b/apps/web/src/features/interview/remoteInterviewWorkbench.ts
@@ -39,12 +39,15 @@ export function createRemoteInterviewWorkbench(
   const buffer = createRemoteTimelineBuffer({ initialExpectedSeq: options.initialExpectedSeq });
   const listeners = new Set<(state: RemoteInterviewWorkbenchState) => void>();
   let hashMismatchNeed: SnapshotRequestNeed | null = null;
+  const deferredHashMismatchSeqs = new Set<number>();
+  let deferredGapNeed: SnapshotRequestNeed | null = null;
 
   const snapshot = (): RemoteInterviewWorkbenchState => {
     const bufferState = buffer.state();
     const snapshotRequestNeeded =
       cloneSnapshotRequestNeed(hashMismatchNeed) ??
-      cloneSnapshotRequestNeed(bufferState.snapshotRequestNeeded);
+      cloneSnapshotRequestNeed(bufferState.snapshotRequestNeeded) ??
+      cloneSnapshotRequestNeed(deferredGapNeed);
     return {
       stableState: cloneReplayStableState(stableState),
       expectedSeq: bufferState.expectedSeq,
@@ -64,7 +67,7 @@ export function createRemoteInterviewWorkbench(
     getState: snapshot,
     pushRecordingEvent(message) {
       const bufferState = buffer.state();
-      if (message.event.seq >= bufferState.expectedSeq && hasMismatchedContentHash(message)) {
+      if (message.event.seq === bufferState.expectedSeq && hasMismatchedContentHash(message)) {
         hashMismatchNeed = {
           reason: "hash-mismatch",
           expectedSeq: message.event.seq,
@@ -72,12 +75,25 @@ export function createRemoteInterviewWorkbench(
         };
         return notify();
       }
+      if (message.event.seq > bufferState.expectedSeq && hasMismatchedContentHash(message)) {
+        deferredHashMismatchSeqs.add(message.event.seq);
+        deferredGapNeed = {
+          reason: "gap-detected",
+          expectedSeq: bufferState.expectedSeq,
+          lastAppliedSeq: bufferState.lastAppliedSeq,
+        };
+        return notify();
+      }
       const result = buffer.pushRecordingEvent(message);
+      reconcileDeferredHashMismatches();
       if (
         hashMismatchNeed &&
         result.appliedEvents.some((event) => event.seq >= hashMismatchNeed!.expectedSeq)
       ) {
         hashMismatchNeed = null;
+      }
+      for (const event of result.appliedEvents) {
+        deferredHashMismatchSeqs.delete(event.seq);
       }
       stableState = result.appliedEvents.reduce(replayReducer, stableState);
       return notify();
@@ -87,7 +103,14 @@ export function createRemoteInterviewWorkbench(
       if (result.snapshotAccepted) {
         stableState = cloneReplayStableState(message.state);
         hashMismatchNeed = null;
+        deferredGapNeed = null;
+        for (const seq of deferredHashMismatchSeqs) {
+          if (seq <= message.snapshotSeq) {
+            deferredHashMismatchSeqs.delete(seq);
+          }
+        }
       }
+      reconcileDeferredHashMismatches();
       stableState = result.appliedEvents.reduce(replayReducer, stableState);
       return notify();
     },
@@ -96,6 +119,25 @@ export function createRemoteInterviewWorkbench(
       return () => listeners.delete(listener);
     },
   };
+
+  function reconcileDeferredHashMismatches() {
+    const state = buffer.state();
+    deferredGapNeed =
+      deferredGapNeed && deferredGapNeed.expectedSeq === state.expectedSeq
+        ? {
+            reason: "gap-detected",
+            expectedSeq: state.expectedSeq,
+            lastAppliedSeq: state.lastAppliedSeq,
+          }
+        : null;
+    if (!hashMismatchNeed && deferredHashMismatchSeqs.has(state.expectedSeq)) {
+      hashMismatchNeed = {
+        reason: "hash-mismatch",
+        expectedSeq: state.expectedSeq,
+        lastAppliedSeq: state.lastAppliedSeq,
+      };
+    }
+  }
 }
 
 function cloneWorkbenchState(state: RemoteInterviewWorkbenchState): RemoteInterviewWorkbenchState {


### PR DESCRIPTION
## 关联

Closes #214
Refs #202（候选人周期性 state-snapshot 发送已由主干既有实现覆盖；本 PR 不关闭 #202）
Refs #213（旧 PR 超时关闭，本 PR 基于最新 main 重新提交同一 #214 范围）

## 改动点

- 补齐云端删除响应契约：返回 `recordingId` 与 `purgeAfter`，其中 `purgeAfter = deletedAt + 7d`，并保留兼容字段。
- 补齐 WebRTC 面试官端 hash 校验链路：`content-change` 的 `contentHash` 校验失败时不污染稳定代码状态，发出 `hash-mismatch` snapshot request，并在 UI 中展示等待快照状态。
- 保留乱序语义：未来 seq 的坏 hash 不覆盖 first-missing gap；补齐缺失事件后才在对应 seq 暴露 hash mismatch。

## 影响范围

- 云端回放中心删除 API 响应向后兼容保留 `id`/`deletedAt`，新增技术方案要求字段；前端现有删除调用忽略响应体，不受破坏。
- 面试官实时工作台新增 hash mismatch 重同步分支；正常乱序缓冲、gap snapshot request、snapshot 恢复路径保持原行为。

## GitNexus 影响分析摘要

- 风险等级: 本地 `contract:local` 判定未修改 critical contract surface，属于 advisory。
- GitNexus 影响面: 本 diff 仅触及 Cloud 删除 service/API 响应和 Interview workbench hash mismatch 恢复链路；`npx gitnexus detect_changes --repo code-tape` 对当前工作树返回 `No changes detected`（变更已提交）。
- 验证结果: `npm run test -w apps/api` 210/210；`npm run test -w apps/web -- RemoteInterviewWorkbenchPage.test.tsx remoteInterviewWorkbench.test.ts` 44/44；`npm run quality:precommit` 通过；pre-push `npm run quality:local` 通过，包含 7 条 Playwright e2e。

## 自检

- [x] 未修改 `docs/progress.json` 或 `docs/progress.md`
- [x] 已运行 `npm run quality:local`，或说明无法运行的原因
- [x] 已说明改动点和影响范围
- [x] 如果改动关键骨架，已补充契约测试并填写 GitNexus 影响分析摘要
- [ ] 已等待 repo-guard、codex 和 Copilot 评论，并完成必要审查