### PR TITLE
#261 补齐活动密度时间轴

### DIFF
--- a/apps/web/src/features/library/__tests__/recordingStore.test.ts
+++ b/apps/web/src/features/library/__tests__/recordingStore.test.ts
@@ -158,6 +158,27 @@ describe("createRecordingStore — two-phase commit", () => {
     }
   });
 
+  it("load preserves generated activity density indexes", async () => {
+    const store = createRecordingStore({ databaseName: uniqueDbName() });
+    const input = makeInput("rec-activity-density");
+    input.indexes = {
+      ...input.indexes,
+      activityDensity: [
+        { kind: "silence", startMs: 0, endMs: 1_000, count: 0, eventSeqs: [] },
+      ],
+    };
+
+    await store.saveDraft(input);
+    await store.commit("rec-activity-density");
+
+    const result = await store.load("rec-activity-density");
+
+    if (!result.ok) throw new Error(JSON.stringify(result.error));
+    expect(result.package.indexes?.activityDensity).toEqual([
+      { kind: "silence", startMs: 0, endMs: 1_000, count: 0, eventSeqs: [] },
+    ]);
+  });
+
   it("load returns the verified media blob for replay", async () => {
     const store = createRecordingStore({ databaseName: uniqueDbName() });
     await store.saveDraft(makeInput("rec-media"));

--- a/apps/web/src/features/player/ReplayControls.tsx
+++ b/apps/web/src/features/player/ReplayControls.tsx
@@ -1,4 +1,9 @@
-import type { ReplayPlaybackRate, ReplaySchedulerState } from "@/shared/recording-schema";
+import type {
+  ActivityDensityBucket,
+  ActivityDensityKind,
+  ReplayPlaybackRate,
+  ReplaySchedulerState,
+} from "@/shared/recording-schema";
 import { formatDurationMs } from "@/shared/time/duration";
 import { IconButton, Slider, Toggle, Toolbar, ToolbarSeparator, cn } from "@/shared/ui";
 import { Pause, Play, Volume2, VolumeX, Gauge } from "lucide-react";
@@ -16,6 +21,7 @@ export type ReplayControlsProps = {
   muted: boolean;
   onVolume(volume: number): void;
   onMuted(muted: boolean): void;
+  activityDensity?: ActivityDensityBucket[];
 };
 
 const PLAYBACK_RATES: ReplayPlaybackRate[] = [2, 1.5, 1, 0.5];
@@ -30,6 +36,7 @@ export function ReplayControls({
   muted,
   onVolume,
   onMuted,
+  activityDensity = [],
 }: ReplayControlsProps) {
   const [ratePopoverOpen, setRatePopoverOpen] = useState(false);
   const [volumePopoverOpen, setVolumePopoverOpen] = useState(false);
@@ -124,7 +131,8 @@ export function ReplayControls({
         </span>
       </div>
 
-      <div className="flex-1 min-w-[120px]" data-replay-progress-control>
+      <div className="relative flex-1 min-w-[120px]" data-replay-progress-control>
+        <ReplayActivityMarkers activityDensity={activityDensity} durationMs={safeDuration} />
         <Slider
           value={currentProgressPercent}
           min={0}
@@ -240,4 +248,70 @@ export function ReplayControls({
       </div>
     </Toolbar>
   );
+}
+
+function ReplayActivityMarkers({
+  activityDensity,
+  durationMs,
+}: {
+  activityDensity: ActivityDensityBucket[];
+  durationMs: number;
+}) {
+  if (durationMs <= 0 || activityDensity.length === 0) return null;
+  return (
+    <div className="pointer-events-none absolute inset-x-2 top-1/2 z-10 h-2 -translate-y-1/2">
+      {activityDensity.map((bucket, index) => {
+        const left = clampPercent((bucket.startMs / durationMs) * 100);
+        const width = Math.max(
+          0.8,
+          clampPercent(((bucket.endMs - bucket.startMs) / durationMs) * 100),
+        );
+        return (
+          <span
+            key={`${bucket.kind}-${bucket.startMs}-${bucket.endMs}-${index}`}
+            aria-label={`活动：${activityKindLabel(bucket.kind)} ${formatDurationMs(bucket.startMs)}-${formatDurationMs(bucket.endMs)}`}
+            className={cn(
+              "absolute top-1/2 h-1.5 -translate-y-1/2 rounded-full border border-background/80",
+              activityKindClassName(bucket.kind),
+            )}
+            style={{ left: `${left}%`, width: `${width}%` }}
+          />
+        );
+      })}
+    </div>
+  );
+}
+
+function clampPercent(value: number): number {
+  return Math.min(100, Math.max(0, value));
+}
+
+function activityKindLabel(kind: ActivityDensityKind): string {
+  switch (kind) {
+    case "edit":
+      return "编辑";
+    case "run":
+      return "运行";
+    case "error":
+      return "错误";
+    case "shortcut":
+      return "快捷键";
+    case "silence":
+      return "静默";
+  }
+}
+
+function activityKindClassName(kind: ActivityDensityKind): string {
+  switch (kind) {
+    case "error":
+      return "bg-danger shadow-[0_0_10px_var(--ct-color-danger)]";
+    case "run":
+      return "bg-primary";
+    case "shortcut":
+      return "bg-warning";
+    case "edit":
+      return "bg-foreground/70";
+    case "silence":
+      return "bg-border";
+  }
 }

--- a/apps/web/src/features/player/ReplayPage.tsx
+++ b/apps/web/src/features/player/ReplayPage.tsx
@@ -12,6 +12,7 @@ import {
 import { Link, useParams, useSearchParams } from "react-router-dom";
 import { Camera, Captions, CircleAlert, Keyboard, MousePointer2, Share2, TerminalSquare } from "lucide-react";
 import { createReplayScheduler, defaultTickStrategy } from "./replayScheduler";
+import { buildReplayActivityDensity } from "./replayIndex";
 import { createTimelineClock } from "./timelineClock";
 import { ReplayControls } from "./ReplayControls";
 import { createMediaClockAdapter } from "./mediaClockAdapter";
@@ -156,6 +157,10 @@ export function ReplayPage({ source = "local" }: ReplayPageProps) {
   const pointerTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const shortcutTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const currentMedia = pkg?.media ?? null;
+  const activityDensity = useMemo(
+    () => (pkg ? buildReplayActivityDensity(pkg) : []),
+    [pkg],
+  );
   const createRecordedMediaAdapter = useCallback((media: RecordedMedia) => {
     const segment = recordedMediaSegment(media);
     return createMediaClockAdapter({
@@ -434,6 +439,7 @@ export function ReplayPage({ source = "local" }: ReplayPageProps) {
       <ReplayControls
         state={schedulerState}
         durationMs={pkg?.meta.durationMs ?? 0}
+        activityDensity={activityDensity}
         onPlayPause={() =>
           schedulerState.status === "playing" || schedulerState.status === "buffering"
             ? pauseReplay()

--- a/apps/web/src/features/player/__tests__/ReplayControls.test.tsx
+++ b/apps/web/src/features/player/__tests__/ReplayControls.test.tsx
@@ -144,6 +144,34 @@ describe("ReplayControls", () => {
     expect(screen.getAllByText("00:00")).toHaveLength(2);
   });
 
+  it("renders activity density markers on the progress timeline", () => {
+    renderControls({
+      durationMs: 60_000,
+      activityDensity: [
+        { kind: "edit", startMs: 0, endMs: 10_000, count: 3, eventSeqs: [1, 2, 3] },
+        { kind: "run", startMs: 20_000, endMs: 30_000, count: 1, eventSeqs: [4] },
+        { kind: "error", startMs: 40_000, endMs: 50_000, count: 1, eventSeqs: [5] },
+        { kind: "silence", startMs: 50_000, endMs: 60_000, count: 0, eventSeqs: [] },
+      ],
+    });
+
+    expect(screen.getByLabelText("活动：编辑 00:00-00:10")).toBeInTheDocument();
+    expect(screen.getByLabelText("活动：运行 00:20-00:30")).toBeInTheDocument();
+    expect(screen.getByLabelText("活动：错误 00:40-00:50")).toBeInTheDocument();
+    expect(screen.getByLabelText("活动：静默 00:50-01:00")).toBeInTheDocument();
+  });
+
+  it("renders short full-duration silence markers", () => {
+    renderControls({
+      durationMs: 5_000,
+      activityDensity: [
+        { kind: "silence", startMs: 0, endMs: 5_000, count: 0, eventSeqs: [] },
+      ],
+    });
+
+    expect(screen.getByLabelText("活动：静默 00:00-00:05")).toBeInTheDocument();
+  });
+
   it.each(["loading", "seeking", "error"] as const)(
     "disables progress seeking while status is %s",
     (status) => {

--- a/apps/web/src/features/player/__tests__/ReplayPage.test.tsx
+++ b/apps/web/src/features/player/__tests__/ReplayPage.test.tsx
@@ -147,6 +147,9 @@ const replayPageMock = vi.hoisted(() => {
       cloudLoader.load.mockClear();
       createCloudRecordingRepository.mockClear();
       createCloudPackageLoader.mockClear();
+      packageData.events = [];
+      packageData.snapshots = [];
+      packageData.indexes = undefined;
       this.routeId = "recording-1";
       this.routeToken = "share-token";
       this.search = "";
@@ -366,6 +369,46 @@ describe("ReplayPage", () => {
       play.mockRestore();
       pause.mockRestore();
     }
+  });
+
+  it("rebuilds malformed activity density indexes before rendering controls", async () => {
+    replayPageMock.packageData.events = [
+      {
+        id: "activity-1",
+        seq: 1,
+        timestampMs: 12_000,
+        source: "editor",
+        track: "main",
+        type: "content-change",
+        payload: {
+          fileId: "main",
+          version: 1,
+          code: "console.log('activity')",
+          contentHash: "activity",
+          language: "javascript",
+          changeReason: "input",
+          changeCount: 1,
+          flushedBy: "debounce",
+        },
+      },
+    ];
+    replayPageMock.packageData.indexes = {
+      generatedAt: "2026-05-26T00:00:00.000Z",
+      eventsByType: {} as NonNullable<RecordingPackageV1["indexes"]>["eventsByType"],
+      snapshotSeqsByTime: [],
+      markers: [],
+      activityDensity: "not-an-array" as never,
+    };
+    const { ReplayPage } = await import("../ReplayPage");
+
+    render(<ReplayPage />);
+
+    await waitFor(() => expect(replayPageMock.controlsProps).not.toBeNull());
+    expect(replayPageMock.controlsProps?.activityDensity).toEqual(
+      expect.arrayContaining([
+        { kind: "edit", startMs: 10_000, endMs: 20_000, count: 1, eventSeqs: [1] },
+      ]),
+    );
   });
 
   it("renders scheduler stable state into the read-only editor and runtime panel", async () => {

--- a/apps/web/src/features/player/__tests__/replayIndex.test.ts
+++ b/apps/web/src/features/player/__tests__/replayIndex.test.ts
@@ -7,7 +7,11 @@ import {
 import type { RecordingPackageV1, RecordingSnapshot } from "@/shared/recording-schema";
 import { RECORDING_SCHEMA_VERSION } from "@/shared/recording-schema";
 
-function pkgFrom(events: RecordingPackageV1["events"], snapshots: RecordingSnapshot[]): RecordingPackageV1 {
+function pkgFrom(
+  events: RecordingPackageV1["events"],
+  snapshots: RecordingSnapshot[],
+  durationMs = 1000,
+): RecordingPackageV1 {
   return {
     schemaVersion: RECORDING_SCHEMA_VERSION,
     manifest: {
@@ -22,7 +26,7 @@ function pkgFrom(events: RecordingPackageV1["events"], snapshots: RecordingSnaps
       id: "rec",
       title: "t",
       createdAt: "2026-05-24T00:00:00.000Z",
-      durationMs: 1000,
+      durationMs,
       appVersion: "0",
       ownerId: null,
       creatorInfo: null,
@@ -73,10 +77,136 @@ describe("buildReplayIndex", () => {
         payload: { x: 1, y: 2, containerWidth: 1, containerHeight: 1 },
       },
     ];
-    const index = buildReplayIndex(pkgFrom(events, []));
+    const index = buildReplayIndex(pkgFrom(events, [], 30_000));
     expect(index.eventsBySeq.length).toBe(2);
     expect(index.eventsByType.get("content-change")?.length).toBe(1);
     expect(index.stableEventsByTime.length).toBe(1);
+  });
+
+  it("rebuilds activity density from events when package indexes are absent", () => {
+    const events: RecordingPackageV1["events"] = [
+      {
+        id: "1",
+        seq: 1,
+        timestampMs: 100,
+        source: "editor",
+        track: "main",
+        type: "content-change",
+        payload: {
+          fileId: "main",
+          version: 1,
+          code: "a",
+          contentHash: "a",
+          language: "javascript",
+          changeReason: "input",
+          changeCount: 1,
+          flushedBy: "debounce",
+        },
+      },
+      {
+        id: "2",
+        seq: 2,
+        timestampMs: 12_000,
+        source: "runtime",
+        track: "runtime",
+        type: "run-error",
+        payload: {
+          runId: "run-1",
+          phase: "runtime",
+          message: "boom",
+          stdout: [],
+          stderr: ["boom"],
+          previewHtml: null,
+        },
+      },
+    ];
+
+    const index = buildReplayIndex(pkgFrom(events, [], 30_000));
+
+    expect(index.activityDensity).toEqual(
+      expect.arrayContaining([
+        { kind: "edit", startMs: 0, endMs: 10_000, count: 1, eventSeqs: [1] },
+        { kind: "error", startMs: 10_000, endMs: 20_000, count: 1, eventSeqs: [2] },
+      ]),
+    );
+  });
+
+  it("rebuilds activity density when the packaged index is an empty placeholder", () => {
+    const events: RecordingPackageV1["events"] = [
+      {
+        id: "1",
+        seq: 1,
+        timestampMs: 12_000,
+        source: "editor",
+        track: "main",
+        type: "content-change",
+        payload: {
+          fileId: "main",
+          version: 1,
+          code: "a",
+          contentHash: "a",
+          language: "javascript",
+          changeReason: "input",
+          changeCount: 1,
+          flushedBy: "debounce",
+        },
+      },
+    ];
+    const pkg = pkgFrom(events, [], 30_000);
+    pkg.indexes = {
+      generatedAt: "2026-05-24T00:00:00.000Z",
+      eventsByType: {} as NonNullable<RecordingPackageV1["indexes"]>["eventsByType"],
+      snapshotSeqsByTime: [],
+      markers: [],
+      activityDensity: [],
+    };
+
+    const index = buildReplayIndex(pkg);
+
+    expect(index.activityDensity).toEqual(
+      expect.arrayContaining([
+        { kind: "edit", startMs: 10_000, endMs: 20_000, count: 1, eventSeqs: [1] },
+      ]),
+    );
+  });
+
+  it("rebuilds activity density when the packaged index has malformed buckets", () => {
+    const events: RecordingPackageV1["events"] = [
+      {
+        id: "1",
+        seq: 1,
+        timestampMs: 12_000,
+        source: "editor",
+        track: "main",
+        type: "content-change",
+        payload: {
+          fileId: "main",
+          version: 1,
+          code: "a",
+          contentHash: "a",
+          language: "javascript",
+          changeReason: "input",
+          changeCount: 1,
+          flushedBy: "debounce",
+        },
+      },
+    ];
+    const pkg = pkgFrom(events, [], 30_000);
+    pkg.indexes = {
+      generatedAt: "2026-05-24T00:00:00.000Z",
+      eventsByType: {} as NonNullable<RecordingPackageV1["indexes"]>["eventsByType"],
+      snapshotSeqsByTime: [],
+      markers: [],
+      activityDensity: [{ kind: "bad", startMs: "0", eventSeqs: null } as never],
+    };
+
+    const index = buildReplayIndex(pkg);
+
+    expect(index.activityDensity).toEqual(
+      expect.arrayContaining([
+        { kind: "edit", startMs: 10_000, endMs: 20_000, count: 1, eventSeqs: [1] },
+      ]),
+    );
   });
 });
 

--- a/apps/web/src/features/player/replayIndex.ts
+++ b/apps/web/src/features/player/replayIndex.ts
@@ -1,10 +1,12 @@
 import type {
+  ActivityDensityBucket,
   RecordingEvent,
   RecordingEventType,
   RecordingPackageV1,
   RecordingSnapshot,
   ReplayIndex,
 } from "@/shared/recording-schema";
+import { buildActivityDensity } from "@/shared/recording-schema";
 import { STABLE_EVENT_TYPES } from "./replayReducer";
 
 /**
@@ -26,7 +28,55 @@ export function buildReplayIndex(pkg: RecordingPackageV1): ReplayIndex {
     .filter((event) => STABLE_EVENT_TYPES.has(event.type))
     .sort((a, b) => a.timestampMs - b.timestampMs);
   const markersByTime = (eventsByType.get("chapter-marker") ?? []).slice();
-  return { eventsBySeq, eventsByType, snapshotsByTime, stableEventsByTime, markersByTime };
+  const activityDensity = buildReplayActivityDensity(pkg);
+  return {
+    eventsBySeq,
+    eventsByType,
+    snapshotsByTime,
+    stableEventsByTime,
+    markersByTime,
+    activityDensity,
+  };
+}
+
+export function buildReplayActivityDensity(pkg: RecordingPackageV1): ActivityDensityBucket[] {
+  const packagedActivityDensity = pkg.indexes?.activityDensity as unknown;
+  const activityDensity =
+    isValidPackagedActivityDensity(packagedActivityDensity)
+      ? packagedActivityDensity
+      : buildActivityDensity(pkg.events, pkg.meta.durationMs);
+  return normalizeActivityDensity(activityDensity);
+}
+
+const ACTIVITY_DENSITY_KINDS = new Set(["edit", "run", "error", "shortcut", "silence"]);
+
+function isValidPackagedActivityDensity(value: unknown): value is ActivityDensityBucket[] {
+  return Array.isArray(value) && value.length > 0 && value.every(isValidActivityDensityBucket);
+}
+
+function isValidActivityDensityBucket(value: unknown): value is ActivityDensityBucket {
+  if (!value || typeof value !== "object") return false;
+  const bucket = value as Partial<ActivityDensityBucket>;
+  return (
+    typeof bucket.kind === "string" &&
+    ACTIVITY_DENSITY_KINDS.has(bucket.kind) &&
+    isNonNegativeFiniteNumber(bucket.startMs) &&
+    isNonNegativeFiniteNumber(bucket.endMs) &&
+    bucket.endMs >= bucket.startMs &&
+    isNonNegativeFiniteNumber(bucket.count) &&
+    Array.isArray(bucket.eventSeqs) &&
+    bucket.eventSeqs.every(Number.isFinite)
+  );
+}
+
+function isNonNegativeFiniteNumber(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0;
+}
+
+function normalizeActivityDensity(activityDensity: ActivityDensityBucket[]): ActivityDensityBucket[] {
+  return activityDensity
+    .slice()
+    .sort((left, right) => left.startMs - right.startMs || left.endMs - right.endMs);
 }
 
 /** Find the snapshot whose timestamp is the greatest one `<= targetMs`. */

--- a/apps/web/src/features/player/replayScheduler.ts
+++ b/apps/web/src/features/player/replayScheduler.ts
@@ -497,6 +497,7 @@ function emptyIndex() {
     snapshotsByTime: [],
     stableEventsByTime: [],
     markersByTime: [],
+    activityDensity: [],
   } as const as ReturnType<typeof buildReplayIndex>;
 }
 

--- a/apps/web/src/features/recorder/__tests__/packageBuilder.test.ts
+++ b/apps/web/src/features/recorder/__tests__/packageBuilder.test.ts
@@ -61,6 +61,37 @@ function makeMarker(seq: number, ts: number, title: string): RecordingEvent {
   };
 }
 
+function makeRunStart(seq: number, ts: number): RecordingEvent {
+  return {
+    id: `run-${seq}`,
+    seq,
+    timestampMs: ts,
+    source: "runtime",
+    track: "runtime",
+    type: "run-start",
+    payload: { language: "javascript", runtime: "iframe", runId: `run-${seq}` },
+  };
+}
+
+function makeRunError(seq: number, ts: number): RecordingEvent {
+  return {
+    id: `error-${seq}`,
+    seq,
+    timestampMs: ts,
+    source: "runtime",
+    track: "runtime",
+    type: "run-error",
+    payload: {
+      runId: `run-${seq}`,
+      phase: "runtime",
+      message: "boom",
+      stdout: [],
+      stderr: ["boom"],
+      previewHtml: null,
+    },
+  };
+}
+
 function makeSnapshot(id: string, ts: number, eventSeq: number): RecordingSnapshot {
   return {
     id,
@@ -120,6 +151,30 @@ describe("createPackageBuilder", () => {
     expect(pkg.indexes?.eventsByType["content-change"]).toEqual([1, 3]);
     expect(pkg.indexes?.markers.map((m) => m.timestampMs)).toEqual([500, 1500]);
     expect(pkg.indexes?.markers.map((m) => m.eventSeq)).toEqual([2, 4]);
+  });
+
+  it("includes activity density buckets in generated indexes", async () => {
+    const builder = createPackageBuilder();
+    const events: RecordingEvent[] = [
+      makeContentEvent(1, "a"),
+      makeRunStart(2, 12_000),
+      makeRunError(3, 13_000),
+    ];
+
+    const { pkg } = await builder.build({
+      meta: { ...makeMeta(), durationMs: 30_000 },
+      events,
+      snapshots: [],
+      media: null,
+    });
+
+    expect(pkg.indexes?.activityDensity).toEqual(
+      expect.arrayContaining([
+        { kind: "edit", startMs: 0, endMs: 10_000, count: 1, eventSeqs: [1] },
+        { kind: "run", startMs: 10_000, endMs: 20_000, count: 1, eventSeqs: [2] },
+        { kind: "error", startMs: 10_000, endMs: 20_000, count: 1, eventSeqs: [3] },
+      ]),
+    );
   });
 
   it("includes media metadata + media checksum when media is provided", async () => {

--- a/apps/web/src/features/recorder/packageBuilder.ts
+++ b/apps/web/src/features/recorder/packageBuilder.ts
@@ -1,6 +1,7 @@
 import { canonicalStringify, sha256Hex } from "@/shared/util/hash";
 import { generateId } from "@/shared/util/ids";
 import {
+  buildActivityDensity,
   RECORDING_SCHEMA_VERSION,
   type PackageBuildInput,
   type PackageBuilder,
@@ -50,7 +51,11 @@ function dedupeSnapshots(snapshots: RecordingSnapshot[]): RecordingSnapshot[] {
   return Array.from(seen.values()).sort((a, b) => a.timestampMs - b.timestampMs);
 }
 
-function buildIndexes(events: RecordingEvent[], snapshots: RecordingSnapshot[]): RecordingIndexes {
+function buildIndexes(
+  events: RecordingEvent[],
+  snapshots: RecordingSnapshot[],
+  durationMs: number,
+): RecordingIndexes {
   const eventsByType: Record<RecordingEventType, number[]> = Object.fromEntries(
     ALL_EVENT_TYPES.map((t) => [t, [] as number[]]),
   ) as Record<RecordingEventType, number[]>;
@@ -70,6 +75,7 @@ function buildIndexes(events: RecordingEvent[], snapshots: RecordingSnapshot[]):
     eventsByType,
     snapshotSeqsByTime,
     markers,
+    activityDensity: buildActivityDensity(events, durationMs),
   };
 }
 
@@ -111,7 +117,7 @@ export function createPackageBuilder(): PackageBuilder {
       }
 
       const completedAt = new Date().toISOString();
-      const indexes = buildIndexes(events, snapshots);
+      const indexes = buildIndexes(events, snapshots, input.meta.durationMs);
 
       const pkg: RecordingPackageV1 = {
         schemaVersion: RECORDING_SCHEMA_VERSION,

--- a/packages/recording-schema/src/activityDensity.test.ts
+++ b/packages/recording-schema/src/activityDensity.test.ts
@@ -1,0 +1,168 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { buildActivityDensity } from "./activityDensity.js";
+import type { RecordingEvent } from "./types.js";
+
+test("buildActivityDensity groups edit, shortcut, run, and error activity into timeline buckets", () => {
+  const density = buildActivityDensity(
+    [
+      contentEvent(1, 1_000),
+      shortcutEvent(2, 2_000),
+      runStartEvent(3, 12_000),
+      runErrorEvent(4, 13_000),
+    ],
+    30_000,
+    { bucketSizeMs: 10_000, silenceGapMs: 10_000 },
+  );
+
+  assert.deepEqual(
+    density.filter((bucket) => bucket.kind !== "silence"),
+    [
+      { kind: "edit", startMs: 0, endMs: 10_000, count: 1, eventSeqs: [1] },
+      { kind: "shortcut", startMs: 0, endMs: 10_000, count: 1, eventSeqs: [2] },
+      { kind: "run", startMs: 10_000, endMs: 20_000, count: 1, eventSeqs: [3] },
+      { kind: "error", startMs: 10_000, endMs: 20_000, count: 1, eventSeqs: [4] },
+    ],
+  );
+});
+
+test("buildActivityDensity emits silence buckets for long gaps and trailing quiet time", () => {
+  const density = buildActivityDensity(
+    [contentEvent(1, 1_000), runStartEvent(2, 28_000)],
+    45_000,
+    { bucketSizeMs: 10_000, silenceGapMs: 10_000 },
+  );
+
+  assert.deepEqual(
+    density.filter((bucket) => bucket.kind === "silence"),
+    [
+      { kind: "silence", startMs: 10_000, endMs: 20_000, count: 0, eventSeqs: [] },
+      { kind: "silence", startMs: 30_000, endMs: 45_000, count: 0, eventSeqs: [] },
+    ],
+  );
+});
+
+test("buildActivityDensity emits non-overlapping leading silence before the first activity", () => {
+  const density = buildActivityDensity([contentEvent(1, 18_000)], 30_000, {
+    bucketSizeMs: 10_000,
+    silenceGapMs: 10_000,
+  });
+
+  assert.deepEqual(
+    density.filter((bucket) => bucket.kind === "silence"),
+    [
+      { kind: "silence", startMs: 0, endMs: 10_000, count: 0, eventSeqs: [] },
+      { kind: "silence", startMs: 20_000, endMs: 30_000, count: 0, eventSeqs: [] },
+    ],
+  );
+});
+
+test("buildActivityDensity emits full-duration silence when no activity is present", () => {
+  const density = buildActivityDensity([], 30_000, {
+    bucketSizeMs: 10_000,
+    silenceGapMs: 10_000,
+  });
+
+  assert.deepEqual(density, [
+    { kind: "silence", startMs: 0, endMs: 30_000, count: 0, eventSeqs: [] },
+  ]);
+});
+
+test("buildActivityDensity emits full-duration silence for short recordings with no activity", () => {
+  const density = buildActivityDensity([], 5_000, {
+    bucketSizeMs: 10_000,
+    silenceGapMs: 10_000,
+  });
+
+  assert.deepEqual(density, [
+    { kind: "silence", startMs: 0, endMs: 5_000, count: 0, eventSeqs: [] },
+  ]);
+});
+
+test("buildActivityDensity keeps late activity buckets inside the replay duration", () => {
+  const density = buildActivityDensity([runStartEvent(1, 35_000)], 30_000, {
+    bucketSizeMs: 10_000,
+    silenceGapMs: 10_000,
+  });
+
+  assert.deepEqual(
+    density.filter((bucket) => bucket.kind === "run"),
+    [{ kind: "run", startMs: 20_000, endMs: 30_000, count: 1, eventSeqs: [1] }],
+  );
+});
+
+test("buildActivityDensity orders same-range activity so higher-priority markers render last", () => {
+  const density = buildActivityDensity([runErrorEvent(1, 1_000), contentEvent(2, 2_000)], 10_000, {
+    bucketSizeMs: 10_000,
+    silenceGapMs: 10_000,
+  });
+
+  assert.deepEqual(
+    density.filter((bucket) => bucket.kind !== "silence").map((bucket) => bucket.kind),
+    ["edit", "error"],
+  );
+});
+
+function contentEvent(seq: number, timestampMs: number): RecordingEvent {
+  return {
+    id: `content-${seq}`,
+    seq,
+    timestampMs,
+    source: "editor",
+    track: "main",
+    type: "content-change",
+    payload: {
+      fileId: "main",
+      version: seq,
+      code: "console.log('activity')",
+      contentHash: `hash-${seq}`,
+      language: "javascript",
+      changeReason: "input",
+      changeCount: 1,
+      flushedBy: "debounce",
+    },
+  };
+}
+
+function shortcutEvent(seq: number, timestampMs: number): RecordingEvent {
+  return {
+    id: `shortcut-${seq}`,
+    seq,
+    timestampMs,
+    source: "shortcut",
+    track: "ui",
+    type: "shortcut",
+    payload: { keys: ["Mod", "Enter"], label: "Cmd Enter", command: "run" },
+  };
+}
+
+function runStartEvent(seq: number, timestampMs: number): RecordingEvent {
+  return {
+    id: `run-${seq}`,
+    seq,
+    timestampMs,
+    source: "runtime",
+    track: "runtime",
+    type: "run-start",
+    payload: { language: "javascript", runtime: "iframe", runId: `run-${seq}` },
+  };
+}
+
+function runErrorEvent(seq: number, timestampMs: number): RecordingEvent {
+  return {
+    id: `error-${seq}`,
+    seq,
+    timestampMs,
+    source: "runtime",
+    track: "runtime",
+    type: "run-error",
+    payload: {
+      runId: `run-${seq}`,
+      phase: "runtime",
+      message: "boom",
+      stdout: [],
+      stderr: ["boom"],
+      previewHtml: null,
+    },
+  };
+}

--- a/packages/recording-schema/src/activityDensity.ts
+++ b/packages/recording-schema/src/activityDensity.ts
@@ -1,0 +1,155 @@
+import type {
+  ActivityDensityBucket,
+  ActivityDensityKind,
+  RecordingEvent,
+  RecordingEventType,
+} from "./types.js";
+
+const DEFAULT_BUCKET_SIZE_MS = 10_000;
+const DEFAULT_SILENCE_GAP_MS = 10_000;
+
+const EVENT_KIND_BY_TYPE: Partial<Record<RecordingEventType, ActivityDensityKind>> = {
+  "content-change": "edit",
+  "language-change": "edit",
+  "selection-change": "edit",
+  "editor-scroll": "edit",
+  "run-start": "run",
+  "run-output": "run",
+  "run-error": "error",
+  shortcut: "shortcut",
+};
+
+export type BuildActivityDensityOptions = {
+  bucketSizeMs?: number;
+  silenceGapMs?: number;
+};
+
+export function buildActivityDensity(
+  events: RecordingEvent[],
+  durationMs: number,
+  options: BuildActivityDensityOptions = {},
+): ActivityDensityBucket[] {
+  const bucketSizeMs = positiveOrDefault(options.bucketSizeMs, DEFAULT_BUCKET_SIZE_MS);
+  const silenceGapMs = positiveOrDefault(options.silenceGapMs, DEFAULT_SILENCE_GAP_MS);
+  const safeDurationMs = Math.max(0, durationMs);
+  const sortedActivities = events
+    .flatMap((event) => {
+      const kind = EVENT_KIND_BY_TYPE[event.type];
+      return kind ? [{ event, kind }] : [];
+    })
+    .sort(
+      (left, right) =>
+        left.event.timestampMs - right.event.timestampMs || left.event.seq - right.event.seq,
+    );
+
+  const buckets = new Map<string, ActivityDensityBucket>();
+  for (const activity of sortedActivities) {
+    const { startMs, endMs } = activityBucketRange(
+      activity.event.timestampMs,
+      bucketSizeMs,
+      safeDurationMs,
+    );
+    const key = `${activity.kind}:${startMs}:${endMs}`;
+    const existing = buckets.get(key);
+    if (existing) {
+      existing.count += 1;
+      existing.eventSeqs.push(activity.event.seq);
+    } else {
+      buckets.set(key, {
+        kind: activity.kind,
+        startMs,
+        endMs,
+        count: 1,
+        eventSeqs: [activity.event.seq],
+      });
+    }
+  }
+
+  const silenceBuckets: ActivityDensityBucket[] = [];
+  const firstActivity = sortedActivities[0];
+  if (!firstActivity) {
+    if (safeDurationMs > 0) {
+      silenceBuckets.push(silenceBucket(0, safeDurationMs));
+    }
+  } else {
+    const firstRange = activityBucketRange(firstActivity.event.timestampMs, bucketSizeMs, safeDurationMs);
+    if (safeDurationMs > 0 && firstRange.startMs >= silenceGapMs) {
+      silenceBuckets.push(silenceBucket(0, firstRange.startMs));
+    }
+  }
+  for (let index = 1; index < sortedActivities.length; index += 1) {
+    const previous = activityBucketRange(
+      sortedActivities[index - 1].event.timestampMs,
+      bucketSizeMs,
+      safeDurationMs,
+    );
+    const next = activityBucketRange(
+      sortedActivities[index].event.timestampMs,
+      bucketSizeMs,
+      safeDurationMs,
+    );
+    if (next.startMs - previous.endMs >= silenceGapMs) {
+      silenceBuckets.push(silenceBucket(previous.endMs, next.startMs));
+    }
+  }
+  const lastActivity = sortedActivities.at(-1);
+  if (lastActivity) {
+    const lastRange = activityBucketRange(lastActivity.event.timestampMs, bucketSizeMs, safeDurationMs);
+    if (safeDurationMs > 0 && safeDurationMs - lastRange.endMs >= silenceGapMs) {
+      silenceBuckets.push(silenceBucket(lastRange.endMs, safeDurationMs));
+    }
+  }
+
+  return [...buckets.values(), ...silenceBuckets].sort(
+    (left, right) =>
+      left.startMs - right.startMs ||
+      left.endMs - right.endMs ||
+      kindPriority(right.kind) - kindPriority(left.kind) ||
+      firstEventSeq(left) - firstEventSeq(right),
+  );
+}
+
+function activityBucketRange(
+  timestampMs: number,
+  bucketSizeMs: number,
+  safeDurationMs: number,
+): { startMs: number; endMs: number } {
+  if (safeDurationMs <= 0) return { startMs: 0, endMs: 0 };
+  const clampedTimestampMs = Math.min(Math.max(0, timestampMs), safeDurationMs - 1);
+  const startMs = Math.floor(clampedTimestampMs / bucketSizeMs) * bucketSizeMs;
+  const endMs = Math.min(safeDurationMs, startMs + bucketSizeMs);
+  return { startMs, endMs };
+}
+
+function positiveOrDefault(value: number | undefined, fallback: number): number {
+  return typeof value === "number" && Number.isFinite(value) && value > 0 ? value : fallback;
+}
+
+function silenceBucket(startMs: number, endMs: number): ActivityDensityBucket {
+  return {
+    kind: "silence",
+    startMs: Math.max(0, startMs),
+    endMs: Math.max(0, endMs),
+    count: 0,
+    eventSeqs: [],
+  };
+}
+
+function firstEventSeq(bucket: ActivityDensityBucket): number {
+  return bucket.eventSeqs[0] ?? Number.MAX_SAFE_INTEGER;
+}
+
+function kindPriority(kind: ActivityDensityKind): number {
+  switch (kind) {
+    case "error":
+      return 0;
+    case "run":
+      return 1;
+    case "shortcut":
+      return 2;
+    case "edit":
+      return 3;
+    case "silence":
+      return 4;
+  }
+}

--- a/packages/recording-schema/src/index.ts
+++ b/packages/recording-schema/src/index.ts
@@ -7,3 +7,5 @@ export {
 export { migrateRecordingPackage, migrationRegistry } from "./migrations.js";
 export { verifyRecordingPackageIntegrity, sha256Blob } from "./integrity.js";
 export * from "./replayState.js";
+export { buildActivityDensity } from "./activityDensity.js";
+export type { BuildActivityDensityOptions } from "./activityDensity.js";

--- a/packages/recording-schema/src/types.ts
+++ b/packages/recording-schema/src/types.ts
@@ -289,6 +289,17 @@ export type RecordingIndexes = {
   eventsByType: Record<RecordingEventType, number[]>;
   snapshotSeqsByTime: number[];
   markers: Array<{ timestampMs: number; eventSeq: number; type: RecordingEventType }>;
+  activityDensity?: ActivityDensityBucket[];
+};
+
+export type ActivityDensityKind = "edit" | "run" | "error" | "shortcut" | "silence";
+
+export type ActivityDensityBucket = {
+  kind: ActivityDensityKind;
+  startMs: number;
+  endMs: number;
+  count: number;
+  eventSeqs: number[];
 };
 
 export type RecordingPackageV1 = {
@@ -399,6 +410,7 @@ export type ReplayIndex = {
   snapshotsByTime: RecordingSnapshot[];
   stableEventsByTime: RecordingEvent[];
   markersByTime: RecordingEvent[];
+  activityDensity: ActivityDensityBucket[];
 };
 
 export type ReplayPlaybackRate = 0.5 | 1 | 1.5 | 2;


### PR DESCRIPTION
## 关联

Refs #2（总控 issue，不在本 PR 中关闭）
Closes #261

## 改动点

- 新增 `buildActivityDensity`，从事件流派生 edit/run/error/shortcut/silence 活动密度桶，并覆盖开头静默、活动间静默、尾部静默、全程无活动静默和短时长全程静默。
- silence 桶按活动 bucket 边界生成，避免静默标记覆盖编辑/运行/错误等活动标记。
- `RecordingIndexes` 支持可选 `activityDensity`；本地 package builder 写入该派生索引，旧包、缺 indexes、空占位或 malformed activityDensity 路径由 `buildReplayIndex` / `ReplayPage` 从 events 重建。
- 回放控制条在进度条上渲染活动标记，保持 pointer-events none，不改变现有 seek 调度入口。
- 补齐 schema、recording repository、package builder、ReplayIndex、ReplayPage 和 ReplayControls 测试。

## 影响范围

- 录制包 indexes 派生数据：新增可选字段，兼容旧包；缺失、空占位或非法活动密度索引会重建。
- 本地/云端回放：进度条新增活动密度视觉层；播放、拖动、倍速、音量和 scheduler seek API 不变。
- schema 包导出新增纯函数，无网络、存储、媒体格式变更。

## GitNexus 影响分析摘要

- 风险等级: HIGH
- 关键骨架变更: `RecordingIndexes`、`buildReplayIndex`、`ReplayControls`、`ReplayPage`、package builder、recording repository indexes round-trip。
- GitNexus 影响面: 初始 `detect_changes` 标记 HIGH，原因是 diff 触达 replay/schema/package builder/recording repository 骨架；处理 review 反馈后的增量 `detect_changes` 为 MEDIUM，短时长静默边界增量为 LOW；最新处理 late activity clamp 与同段 marker priority 后，增量 `detect_changes` 仍为 LOW，affected processes 为 0，`context buildActivityDensity` 仅显示 schema test incoming。`context buildReplayIndex` 显示 incoming 为 scheduler `load`，流程为 `Load → NormalizeActivityDensity`；`impact buildActivityDensity` upstream 风险 LOW；`impact ReplayPage` upstream 风险 LOW；`impact createRecordingStore` upstream 影响 3 个直接调用点，风险 LOW；package builder `build` upstream 影响 0，风险 LOW；`ReplayControls` 仅由 `ReplayPage` 调用。
- 验证结果: 已补 schema 边界单测、短时长全程静默单测、recordingStore 索引保真测试、package builder 单测、ReplayIndex 缺/空索引重建测试、ReplayPage malformed index 重建测试、ReplayControls 标记渲染测试、late activity 不越界测试、同段高优先级 marker 后渲染测试；`npm run test -w @code-tape/recording-schema -- activityDensity.test.ts`、`npm run test -w apps/web -- ReplayControls.test.tsx replayIndex.test.ts ReplayPage.test.tsx`、`npm run lint:web`、`npm run build -w apps/web`、提交钩子 `quality:precommit` 均通过。

## 自检

- [x] 未修改 `docs/progress.json` 或 `docs/progress.md`
- [x] 已运行 `npm run quality:local`，或说明无法运行的原因
- [x] 涉及 AI 字幕时，已记录一次 `npm run subtitle:postprocess:evaluate` 的“纠错并生成章节”效果验证结果，包含 `representativeOutputSource`、`overallEvaluationDurationMs`，并区分输出校验耗时与真实端到端耗时（不涉及 AI 字幕）
- [x] 涉及 AI 字幕点击链路、LLM worker、模型加载或性能时，已记录一次 `npm run subtitle:postprocess:runtime-benchmark` 结果，包含 `postprocessClickToResultReadyDurationMs`、`postProcessTimeoutBudgetMs` 和 `playbackProbeResponsiveDuringPostprocess`（不涉及 AI 字幕）
- [x] 已说明改动点和影响范围
- [x] 如果改动关键骨架，已补充契约测试并填写 GitNexus 影响分析摘要
- [x] 已等待 repo-guard、codex 和 Copilot 评论，并完成必要审查

## 额外验证

- `npm run quality:precommit`：通过
- `npm run dev` + Playwright smoke：回放页可访问活动标记 `活动：编辑/静默/快捷键/运行/错误`，页面无 pageerror


