### PR TITLE
#263 补齐主题跟随系统入口

### DIFF
--- a/apps/web/e2e/scaffold.spec.ts
+++ b/apps/web/e2e/scaffold.spec.ts
@@ -27,8 +27,10 @@ test("recorder route renders Monaco with usable recorder controls", async ({ pag
   await expect(page.getByRole("button", { name: "停止录制" })).toBeDisabled();
   await expect(page.getByRole("button", { name: "运行代码" })).toBeEnabled();
 
-  await page.getByRole("button", { name: /Dark|Light/ }).click();
-  await expect(page.locator("html")).toHaveAttribute("data-theme", /light|dark/);
+  await page.getByRole("button", { name: "切换到浅色主题" }).click();
+  await expect(page.locator("html")).toHaveAttribute("data-theme", "light");
+  await page.getByRole("button", { name: "切换到深色主题" }).click();
+  await expect(page.locator("html")).toHaveAttribute("data-theme", "dark");
   expect(runtimeErrors.filter((message) => /monaco|worker/i.test(message))).toEqual([]);
 });
 

--- a/apps/web/src/app/AppShell.tsx
+++ b/apps/web/src/app/AppShell.tsx
@@ -1,4 +1,6 @@
 import { Outlet, NavLink } from "react-router-dom";
+import { Monitor, Moon, Sun } from "lucide-react";
+import type { ThemePreference } from "@/shared/ui";
 import { useTheme } from "@/shared/ui/useTheme";
 
 /**
@@ -9,9 +11,20 @@ import { useTheme } from "@/shared/ui/useTheme";
  */
 export function AppShell() {
   const theme = useTheme();
+  const themeOptions: Array<{
+    preference: ThemePreference;
+    label: string;
+    ariaLabel: string;
+    icon: typeof Monitor;
+  }> = [
+    { preference: "system", label: "系统", ariaLabel: "跟随系统主题", icon: Monitor },
+    { preference: "light", label: "浅色", ariaLabel: "切换到浅色主题", icon: Sun },
+    { preference: "dark", label: "深色", ariaLabel: "切换到深色主题", icon: Moon },
+  ];
+
   return (
     <div className="flex h-screen flex-col bg-background text-foreground">
-      <header className="flex h-12 items-center gap-4 border-b border-border bg-surface/80 px-4 backdrop-blur">
+      <header className="flex h-12 items-center gap-2 border-b border-border bg-surface/80 px-2 backdrop-blur sm:gap-4 sm:px-4">
         <span className="font-display text-xs font-semibold tracking-[0.24em]">CODE-TAPE</span>
         <nav className="flex items-center gap-1 text-sm">
           <NavLink
@@ -50,13 +63,34 @@ export function AppShell() {
           </NavLink>
         </nav>
         <span className="flex-1" />
-        <button
-          type="button"
-          onClick={theme.toggle}
-          className="rounded-md border border-border bg-surface px-3 py-1 text-xs text-muted hover:text-foreground"
+        <div
+          aria-label="主题偏好"
+          className="grid grid-cols-3 overflow-hidden rounded-md border border-border bg-surface p-0.5"
+          role="group"
         >
-          {theme.resolved === "dark" ? "☾ Dark" : "☀ Light"}
-        </button>
+          {themeOptions.map((option) => {
+            const Icon = option.icon;
+            const selected = theme.preference === option.preference;
+            return (
+              <button
+                key={option.preference}
+                type="button"
+                aria-label={option.ariaLabel}
+                aria-pressed={selected}
+                onClick={() => theme.setPreference(option.preference)}
+                className={[
+                  "inline-flex h-7 w-8 items-center justify-center gap-1 rounded-[5px] text-xs transition-colors sm:w-auto sm:min-w-14 sm:px-2",
+                  selected
+                    ? "bg-primary text-primary-foreground shadow-sm"
+                    : "text-muted hover:bg-surface-raised hover:text-foreground",
+                ].join(" ")}
+              >
+                <Icon aria-hidden="true" className="h-3.5 w-3.5" />
+                <span className="hidden sm:inline">{option.label}</span>
+              </button>
+            );
+          })}
+        </div>
       </header>
       <main className="min-h-0 flex-1 overflow-hidden">
         <Outlet />

--- a/apps/web/src/app/AppShell.tsx
+++ b/apps/web/src/app/AppShell.tsx
@@ -1,7 +1,18 @@
 import { Outlet, NavLink } from "react-router-dom";
 import { Monitor, Moon, Sun } from "lucide-react";
-import type { ThemePreference } from "@/shared/ui";
+import type { ThemeMode, ThemePreference } from "@/shared/ui";
 import { useTheme } from "@/shared/ui/useTheme";
+
+const THEME_PREFERENCE_LABEL: Record<ThemePreference, string> = {
+  system: "跟随系统",
+  light: "浅色",
+  dark: "深色",
+};
+
+const THEME_MODE_LABEL: Record<ThemeMode, string> = {
+  light: "浅色",
+  dark: "深色",
+};
 
 /**
  * AppShell — top-level chrome that hosts page outlets.
@@ -11,6 +22,7 @@ import { useTheme } from "@/shared/ui/useTheme";
  */
 export function AppShell() {
   const theme = useTheme();
+  const themeStatusLabel = `主题偏好，当前偏好：${THEME_PREFERENCE_LABEL[theme.preference]}，当前生效：${THEME_MODE_LABEL[theme.resolved]}`;
   const themeOptions: Array<{
     preference: ThemePreference;
     label: string;
@@ -64,7 +76,7 @@ export function AppShell() {
         </nav>
         <span className="flex-1" />
         <div
-          aria-label="主题偏好"
+          aria-label={themeStatusLabel}
           className="grid grid-cols-3 overflow-hidden rounded-md border border-border bg-surface p-0.5"
           role="group"
         >

--- a/apps/web/src/app/__tests__/routes.test.tsx
+++ b/apps/web/src/app/__tests__/routes.test.tsx
@@ -78,20 +78,24 @@ describe("AppShell", () => {
     const lightButton = screen.getByRole("button", { name: "切换到浅色主题" });
     const darkButton = screen.getByRole("button", { name: "切换到深色主题" });
 
+    expect(screen.getByRole("group", { name: "主题偏好，当前偏好：跟随系统，当前生效：深色" })).toBeInTheDocument();
     expect(systemButton).toHaveAttribute("aria-pressed", "true");
     expect(document.documentElement.dataset.theme).toBe("dark");
 
     fireEvent.click(lightButton);
+    expect(screen.getByRole("group", { name: "主题偏好，当前偏好：浅色，当前生效：浅色" })).toBeInTheDocument();
     expect(lightButton).toHaveAttribute("aria-pressed", "true");
     expect(window.localStorage.getItem("code-tape:theme")).toBe("light");
     expect(document.documentElement.dataset.theme).toBe("light");
 
     fireEvent.click(darkButton);
+    expect(screen.getByRole("group", { name: "主题偏好，当前偏好：深色，当前生效：深色" })).toBeInTheDocument();
     expect(darkButton).toHaveAttribute("aria-pressed", "true");
     expect(window.localStorage.getItem("code-tape:theme")).toBe("dark");
     expect(document.documentElement.dataset.theme).toBe("dark");
 
     fireEvent.click(systemButton);
+    expect(screen.getByRole("group", { name: "主题偏好，当前偏好：跟随系统，当前生效：深色" })).toBeInTheDocument();
     expect(systemButton).toHaveAttribute("aria-pressed", "true");
     expect(window.localStorage.getItem("code-tape:theme")).toBe("system");
     expect(document.documentElement.dataset.theme).toBe("dark");

--- a/apps/web/src/app/__tests__/routes.test.tsx
+++ b/apps/web/src/app/__tests__/routes.test.tsx
@@ -1,9 +1,27 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 import { ThemeProvider } from "@/shared/ui/themeProvider";
 import { AppShell } from "../AppShell";
 import { appRoutes } from "../routes";
+
+beforeEach(() => {
+  window.localStorage.clear();
+  document.documentElement.dataset.theme = "";
+  Object.defineProperty(window, "matchMedia", {
+    writable: true,
+    value: (query: string) => ({
+      matches: query === "(prefers-color-scheme: dark)",
+      media: query,
+      onchange: null,
+      addListener: () => {},
+      removeListener: () => {},
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      dispatchEvent: () => false,
+    }),
+  });
+});
 
 describe("appRoutes", () => {
   it("registers cloud replay routes", () => {
@@ -45,5 +63,37 @@ describe("AppShell", () => {
     );
 
     expect(screen.getByRole("link", { name: "面试" })).toHaveAttribute("href", "/interview");
+  });
+
+  it("lets users choose system, light, and dark theme preferences", () => {
+    render(
+      <ThemeProvider>
+        <MemoryRouter>
+          <AppShell />
+        </MemoryRouter>
+      </ThemeProvider>,
+    );
+
+    const systemButton = screen.getByRole("button", { name: "跟随系统主题" });
+    const lightButton = screen.getByRole("button", { name: "切换到浅色主题" });
+    const darkButton = screen.getByRole("button", { name: "切换到深色主题" });
+
+    expect(systemButton).toHaveAttribute("aria-pressed", "true");
+    expect(document.documentElement.dataset.theme).toBe("dark");
+
+    fireEvent.click(lightButton);
+    expect(lightButton).toHaveAttribute("aria-pressed", "true");
+    expect(window.localStorage.getItem("code-tape:theme")).toBe("light");
+    expect(document.documentElement.dataset.theme).toBe("light");
+
+    fireEvent.click(darkButton);
+    expect(darkButton).toHaveAttribute("aria-pressed", "true");
+    expect(window.localStorage.getItem("code-tape:theme")).toBe("dark");
+    expect(document.documentElement.dataset.theme).toBe("dark");
+
+    fireEvent.click(systemButton);
+    expect(systemButton).toHaveAttribute("aria-pressed", "true");
+    expect(window.localStorage.getItem("code-tape:theme")).toBe("system");
+    expect(document.documentElement.dataset.theme).toBe("dark");
   });
 });

--- a/apps/web/src/shared/ui/__tests__/themeProvider.test.tsx
+++ b/apps/web/src/shared/ui/__tests__/themeProvider.test.tsx
@@ -8,21 +8,53 @@ beforeEach(() => {
   document.documentElement.dataset.theme = "";
 });
 
+function installColorSchemeMatchMedia(initialMatches: boolean) {
+  let matches = initialMatches;
+  const listeners = new Set<EventListener>();
+  const mediaQueryList = {
+    get matches() {
+      return matches;
+    },
+    media: "(prefers-color-scheme: dark)",
+    onchange: null as EventListener | null,
+    addListener: (listener: EventListener) => listeners.add(listener),
+    removeListener: (listener: EventListener) => listeners.delete(listener),
+    addEventListener: (_type: string, listener: EventListener) => listeners.add(listener),
+    removeEventListener: (_type: string, listener: EventListener) => listeners.delete(listener),
+    dispatchEvent: (event: Event) => {
+      listeners.forEach((listener) => listener.call(mediaQueryList, event));
+      mediaQueryList.onchange?.call(mediaQueryList, event);
+      return true;
+    },
+    setMatches: (nextMatches: boolean) => {
+      matches = nextMatches;
+      mediaQueryList.dispatchEvent(new Event("change"));
+    },
+  };
+
+  Object.defineProperty(window, "matchMedia", {
+    writable: true,
+    value: (query: string) =>
+      query === "(prefers-color-scheme: dark)"
+        ? mediaQueryList
+        : {
+            matches: false,
+            media: query,
+            onchange: null,
+            addListener: () => {},
+            removeListener: () => {},
+            addEventListener: () => {},
+            removeEventListener: () => {},
+            dispatchEvent: () => false,
+          },
+  });
+
+  return mediaQueryList;
+}
+
 describe("ThemeProvider", () => {
   it("defaults to system preference and resolves to dark when matchMedia returns dark", () => {
-    Object.defineProperty(window, "matchMedia", {
-      writable: true,
-      value: (query: string) => ({
-        matches: query === "(prefers-color-scheme: dark)",
-        media: query,
-        onchange: null,
-        addListener: () => {},
-        removeListener: () => {},
-        addEventListener: () => {},
-        removeEventListener: () => {},
-        dispatchEvent: () => false,
-      }),
-    });
+    installColorSchemeMatchMedia(true);
 
     const { result } = renderHook(() => useTheme(), { wrapper: ThemeProvider });
     expect(result.current.preference).toBe("system");
@@ -43,6 +75,21 @@ describe("ThemeProvider", () => {
     expect(result.current.resolved).toBe("dark");
     act(() => result.current.toggle());
     expect(result.current.resolved).toBe("light");
+  });
+
+  it("updates the resolved system theme when the color scheme media query changes", () => {
+    const colorScheme = installColorSchemeMatchMedia(true);
+
+    const { result } = renderHook(() => useTheme(), { wrapper: ThemeProvider });
+    expect(result.current.preference).toBe("system");
+    expect(result.current.resolved).toBe("dark");
+    expect(document.documentElement.dataset.theme).toBe("dark");
+
+    act(() => colorScheme.setMatches(false));
+
+    expect(result.current.preference).toBe("system");
+    expect(result.current.resolved).toBe("light");
+    expect(document.documentElement.dataset.theme).toBe("light");
   });
 
   it("throws when used outside provider", () => {


### PR DESCRIPTION
## 关联

Closes #263
Refs #2（总控 issue，不在本 PR 中关闭）

## 改动点

- 将顶部主题入口从单个明暗切换按钮升级为 `system / light / dark` 三态 segmented control。
- 小屏下主题入口收敛为图标按钮，避免顶部导航横向溢出；大屏保留图标 + 文案。
- 补充 AppShell 单测与 recorder e2e，覆盖系统、浅色、深色主题选择。

## 影响范围

- 影响 Web 顶部导航的主题偏好入口。
- 复用现有 `ThemeProvider.setPreference`、持久化和系统偏好解析逻辑，不变更主题 token、路由或录制/回放核心数据结构。

## GitNexus 影响分析摘要

- 风险等级: low
- 关键骨架变更: 无，GitNexus contract 显示非关键契约面变更，仅 advisory。
- GitNexus 影响面: `detect_changes` 显示 3 files / 1 symbol，变更符号为 `AppShell`，受影响流程 0；`context AppShell` 显示仅由 `routes.tsx` 引入并调用 `useTheme`。
- 验证结果: `npm run quality:local` 通过；`npm run e2e -w apps/web -- scaffold.spec.ts` 通过；本地浏览器检查 390px 与 1280px 宽度无横向溢出。

## 自检

- [x] 未修改 `docs/progress.json` 或 `docs/progress.md`
- [x] 已运行 `npm run quality:local`，或说明无法运行的原因
- [x] 涉及 AI 字幕时，已记录一次 `npm run subtitle:postprocess:evaluate` 的“纠错并生成章节”效果验证结果，包含 `representativeOutputSource`、`overallEvaluationDurationMs`，并区分输出校验耗时与真实端到端耗时（不涉及 AI 字幕）
- [x] 涉及 AI 字幕点击链路、LLM worker、模型加载或性能时，已记录一次 `npm run subtitle:postprocess:runtime-benchmark` 结果，包含 `postprocessClickToResultReadyDurationMs`、`postProcessTimeoutBudgetMs` 和 `playbackProbeResponsiveDuringPostprocess`（不涉及 AI 字幕）
- [x] 已说明改动点和影响范围
- [x] 如果改动关键骨架，已补充契约测试并填写 GitNexus 影响分析摘要（未改动关键骨架）
- [ ] 已等待 repo-guard、codex 和 Copilot 评论，并完成必要审查
