### PR TITLE
#265 增强运行 Console 与错误输出面板

### DIFF
--- a/apps/web/src/features/recorder/RecorderPage.tsx
+++ b/apps/web/src/features/recorder/RecorderPage.tsx
@@ -8,6 +8,7 @@ import { RecorderControls } from "./RecorderControls";
 import { CodeEditor, type CodeEditorHandle } from "@/features/editor/CodeEditor";
 import { CameraPreview } from "@/features/media/CameraPreview";
 import { PreviewPane } from "@/features/runtime-preview/PreviewPane";
+import { RuntimeOutputPanel } from "@/features/runtime-preview/RuntimeOutputPanel";
 import { createPreviewCompiler } from "@/features/runtime-preview/previewCompiler";
 import { createIframeRuntime } from "@/features/runtime-preview/iframeRuntime";
 import { createMediaDevicesController } from "@/features/media/mediaDevices";
@@ -737,7 +738,7 @@ export function RecorderPage({ onEventBusReady }: RecorderPageProps = {}) {
                 onReset={() => setRuntimeState(INITIAL_RUNTIME_STATE)}
               />
             }
-            right={<RecorderRuntimeOutputPanel runtime={runtimeState} />}
+            right={<RuntimeOutputPanel runtime={runtimeState} />}
           />
         }
       />
@@ -901,40 +902,6 @@ function eventOnlyMedia(warnings: OpenStreamResult["warnings"] = []): OpenStream
     warnings,
     capability: INITIAL_CONTROLLER_STATE.mediaCapability,
   };
-}
-
-function RecorderRuntimeOutputPanel({ runtime }: { runtime: RecorderRuntimeState }) {
-  const hasOutput = runtime.stdout.length > 0 || runtime.stderr.length > 0 || runtime.errorMessage;
-
-  return (
-    <section className="border-t border-border bg-background px-4 py-3" aria-label="Runtime output">
-      <div className="mb-2 flex items-center justify-between gap-3">
-        <h2 className="text-xs font-semibold uppercase text-muted">Console</h2>
-        <span className="rounded-sm border border-border px-2 py-0.5 text-[11px] font-medium text-muted">
-          {runtime.status}
-        </span>
-      </div>
-      {hasOutput ? (
-        <div className="max-h-40 space-y-2 overflow-auto font-mono text-xs leading-5">
-          {runtime.stdout.map((line, index) => (
-            <pre key={`stdout-${index}`} className="whitespace-pre-wrap text-foreground">
-              {line}
-            </pre>
-          ))}
-          {runtime.stderr.map((line, index) => (
-            <pre key={`stderr-${index}`} className="whitespace-pre-wrap text-warning">
-              {line}
-            </pre>
-          ))}
-          {runtime.errorMessage ? (
-            <pre className="whitespace-pre-wrap text-danger">{runtime.errorMessage}</pre>
-          ) : null}
-        </div>
-      ) : (
-        <p className="text-xs text-muted">No output</p>
-      )}
-    </section>
-  );
 }
 
 function formatPermissionNotice(audio: PermissionStatus, camera: PermissionStatus): string {

--- a/apps/web/src/features/runtime-preview/RuntimeOutputPanel.tsx
+++ b/apps/web/src/features/runtime-preview/RuntimeOutputPanel.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { Check, Copy } from "lucide-react";
 
 export type RuntimeOutputPanelProps = {
@@ -17,6 +17,10 @@ type RuntimeOutputEntry = {
   channel: Exclude<RuntimeOutputChannel, "all">;
   line: string;
 };
+type CopyFeedback = {
+  message: string;
+  tone: "success" | "error";
+};
 
 const CHANNEL_OPTIONS: { value: RuntimeOutputChannel; label: string }[] = [
   { value: "all", label: "全部" },
@@ -27,7 +31,8 @@ const CHANNEL_OPTIONS: { value: RuntimeOutputChannel; label: string }[] = [
 
 export function RuntimeOutputPanel({ runtime }: RuntimeOutputPanelProps) {
   const [selectedChannel, setSelectedChannel] = useState<RuntimeOutputChannel>("all");
-  const [copyFeedback, setCopyFeedback] = useState<string | null>(null);
+  const [copyFeedback, setCopyFeedback] = useState<CopyFeedback | null>(null);
+  const clearCopyFeedbackTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const entries = useMemo(() => runtimeOutputEntries(runtime), [runtime]);
   const counts = {
     all: entries.length,
@@ -47,13 +52,28 @@ export function RuntimeOutputPanel({ runtime }: RuntimeOutputPanelProps) {
   const selectedLabel =
     CHANNEL_OPTIONS.find((option) => option.value === selectedChannel)?.label ?? "output";
 
+  useEffect(() => {
+    return () => {
+      if (clearCopyFeedbackTimer.current) clearTimeout(clearCopyFeedbackTimer.current);
+    };
+  }, []);
+
+  const showCopyFeedback = (nextFeedback: CopyFeedback) => {
+    if (clearCopyFeedbackTimer.current) clearTimeout(clearCopyFeedbackTimer.current);
+    setCopyFeedback(nextFeedback);
+    clearCopyFeedbackTimer.current = setTimeout(() => {
+      setCopyFeedback(null);
+      clearCopyFeedbackTimer.current = null;
+    }, 2000);
+  };
+
   const copyOutput = async () => {
     if (!hasOutput) return;
     try {
       await navigator.clipboard.writeText(formatRuntimeOutput(entries));
-      setCopyFeedback("输出已复制");
+      showCopyFeedback({ message: "输出已复制", tone: "success" });
     } catch {
-      setCopyFeedback("复制失败");
+      showCopyFeedback({ message: "复制失败", tone: "error" });
     }
   };
 
@@ -81,7 +101,7 @@ export function RuntimeOutputPanel({ runtime }: RuntimeOutputPanelProps) {
             onClick={copyOutput}
             className="inline-flex h-7 w-7 items-center justify-center rounded-md border border-border text-foreground/80 transition-[background-color,color] duration-150 ease-out-soft hover:bg-surface hover:text-foreground disabled:cursor-not-allowed disabled:opacity-40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus focus-visible:ring-offset-2 focus-visible:ring-offset-background"
           >
-            {copyFeedback === "输出已复制" ? (
+            {copyFeedback?.tone === "success" ? (
               <Check aria-hidden size={14} />
             ) : (
               <Copy aria-hidden size={14} />
@@ -99,7 +119,6 @@ export function RuntimeOutputPanel({ runtime }: RuntimeOutputPanelProps) {
               key={option.value}
               type="button"
               aria-pressed={selected}
-              aria-label={`${option.label} ${count}`}
               className={[
                 "inline-flex h-7 items-center gap-1 rounded-md border px-2 text-[11px] font-medium transition-colors",
                 "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus focus-visible:ring-offset-2 focus-visible:ring-offset-background",
@@ -117,8 +136,14 @@ export function RuntimeOutputPanel({ runtime }: RuntimeOutputPanelProps) {
       </div>
 
       {copyFeedback ? (
-        <p role="status" className="mb-2 text-[11px] text-muted">
-          {copyFeedback}
+        <p
+          role={copyFeedback.tone === "error" ? "alert" : "status"}
+          className={[
+            "mb-2 text-[11px]",
+            copyFeedback.tone === "error" ? "text-danger" : "text-muted",
+          ].join(" ")}
+        >
+          {copyFeedback.message}
         </p>
       ) : null}
 

--- a/apps/web/src/features/runtime-preview/RuntimeOutputPanel.tsx
+++ b/apps/web/src/features/runtime-preview/RuntimeOutputPanel.tsx
@@ -1,39 +1,170 @@
-import type { ReplayStableState } from "@/shared/recording-schema";
+import { useMemo, useState } from "react";
+import { Check, Copy } from "lucide-react";
 
 export type RuntimeOutputPanelProps = {
-  runtime: ReplayStableState["runtime"];
+  runtime: RuntimeOutputState;
 };
 
+export type RuntimeOutputState = {
+  status: string;
+  stdout: string[];
+  stderr: string[];
+  errorMessage: string | null;
+};
+
+type RuntimeOutputChannel = "all" | "stdout" | "stderr" | "error";
+type RuntimeOutputEntry = {
+  channel: Exclude<RuntimeOutputChannel, "all">;
+  line: string;
+};
+
+const CHANNEL_OPTIONS: { value: RuntimeOutputChannel; label: string }[] = [
+  { value: "all", label: "全部" },
+  { value: "stdout", label: "stdout" },
+  { value: "stderr", label: "stderr" },
+  { value: "error", label: "error" },
+];
+
 export function RuntimeOutputPanel({ runtime }: RuntimeOutputPanelProps) {
-  const hasOutput = runtime.stdout.length > 0 || runtime.stderr.length > 0 || runtime.errorMessage;
+  const [selectedChannel, setSelectedChannel] = useState<RuntimeOutputChannel>("all");
+  const [copyFeedback, setCopyFeedback] = useState<string | null>(null);
+  const entries = useMemo(() => runtimeOutputEntries(runtime), [runtime]);
+  const counts = {
+    all: entries.length,
+    stdout: runtime.stdout.length,
+    stderr: runtime.stderr.length,
+    error: runtime.errorMessage ? 1 : 0,
+  };
+  const visibleEntries =
+    selectedChannel === "all"
+      ? entries
+      : entries.filter((entry) => entry.channel === selectedChannel);
+  const hasOutput = entries.length > 0;
+  const canCopy =
+    hasOutput &&
+    typeof navigator !== "undefined" &&
+    typeof navigator.clipboard?.writeText === "function";
+  const selectedLabel =
+    CHANNEL_OPTIONS.find((option) => option.value === selectedChannel)?.label ?? "output";
+
+  const copyOutput = async () => {
+    if (!hasOutput) return;
+    try {
+      await navigator.clipboard.writeText(formatRuntimeOutput(entries));
+      setCopyFeedback("输出已复制");
+    } catch {
+      setCopyFeedback("复制失败");
+    }
+  };
 
   return (
-    <section className="border-t border-border bg-background px-4 py-3" aria-label="Runtime output">
-      <div className="mb-2 flex items-center justify-between gap-3">
-        <h2 className="text-xs font-semibold uppercase tracking-wide text-muted">Console</h2>
-        <span className="rounded-sm border border-border px-2 py-0.5 text-[11px] font-medium text-muted">
-          {runtime.status}
-        </span>
-      </div>
-      {hasOutput ? (
-        <div className="max-h-40 space-y-2 overflow-auto font-mono text-xs leading-5">
-          {runtime.stdout.map((line, index) => (
-            <pre key={`stdout-${index}`} className="whitespace-pre-wrap text-foreground">
-              {line}
-            </pre>
-          ))}
-          {runtime.stderr.map((line, index) => (
-            <pre key={`stderr-${index}`} className="whitespace-pre-wrap text-warning">
-              {line}
-            </pre>
-          ))}
-          {runtime.errorMessage ? (
-            <pre className="whitespace-pre-wrap text-danger">{runtime.errorMessage}</pre>
-          ) : null}
+    <section
+      className="flex min-h-0 flex-1 flex-col border-t border-border bg-background px-4 py-3"
+      aria-label="Runtime output"
+    >
+      <div className="mb-3 flex flex-wrap items-start justify-between gap-3">
+        <div className="min-w-0">
+          <h2 className="text-xs font-semibold uppercase tracking-wide text-muted">Console</h2>
+          <p className="mt-1 text-[11px] text-muted">
+            stdout {counts.stdout} · stderr {counts.stderr} · error {counts.error}
+          </p>
         </div>
+        <div className="flex items-center gap-2">
+          <span className="rounded-sm border border-border px-2 py-0.5 text-[11px] font-medium text-muted">
+            {runtime.status}
+          </span>
+          <button
+            type="button"
+            aria-label="复制运行输出"
+            title="复制运行输出"
+            disabled={!canCopy}
+            onClick={copyOutput}
+            className="inline-flex h-7 w-7 items-center justify-center rounded-md border border-border text-foreground/80 transition-[background-color,color] duration-150 ease-out-soft hover:bg-surface hover:text-foreground disabled:cursor-not-allowed disabled:opacity-40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+          >
+            {copyFeedback === "输出已复制" ? (
+              <Check aria-hidden size={14} />
+            ) : (
+              <Copy aria-hidden size={14} />
+            )}
+          </button>
+        </div>
+      </div>
+
+      <div className="mb-3 flex flex-wrap gap-1" aria-label="运行输出筛选">
+        {CHANNEL_OPTIONS.map((option) => {
+          const count = counts[option.value];
+          const selected = selectedChannel === option.value;
+          return (
+            <button
+              key={option.value}
+              type="button"
+              aria-pressed={selected}
+              aria-label={`${option.label} ${count}`}
+              className={[
+                "inline-flex h-7 items-center gap-1 rounded-md border px-2 text-[11px] font-medium transition-colors",
+                "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus focus-visible:ring-offset-2 focus-visible:ring-offset-background",
+                selected
+                  ? "border-primary bg-primary/10 text-primary"
+                  : "border-border text-muted hover:bg-surface hover:text-foreground",
+              ].join(" ")}
+              onClick={() => setSelectedChannel(option.value)}
+            >
+              <span>{option.label}</span>
+              <span className="font-mono">{count}</span>
+            </button>
+          );
+        })}
+      </div>
+
+      {copyFeedback ? (
+        <p role="status" className="mb-2 text-[11px] text-muted">
+          {copyFeedback}
+        </p>
+      ) : null}
+
+      {visibleEntries.length > 0 ? (
+        <div className="min-h-0 flex-1 space-y-2 overflow-auto font-mono text-xs leading-5">
+          {visibleEntries.map((entry, index) => (
+            <pre
+              key={`${entry.channel}-${index}`}
+              className={[
+                "whitespace-pre-wrap rounded-sm border border-border/70 bg-surface/40 px-2 py-1.5",
+                outputTextClass(entry.channel),
+              ].join(" ")}
+            >
+              <span className="select-none text-muted">[{entry.channel}] </span>
+              <span>{entry.line}</span>
+            </pre>
+          ))}
+        </div>
+      ) : hasOutput ? (
+        <p className="text-xs text-muted">{selectedLabel} 暂无输出</p>
       ) : (
-        <p className="text-xs text-muted">No output</p>
+        <p className="text-xs text-muted">暂无运行输出</p>
       )}
     </section>
   );
+}
+
+function runtimeOutputEntries(runtime: RuntimeOutputState): RuntimeOutputEntry[] {
+  return [
+    ...runtime.stdout.map((line) => ({ channel: "stdout" as const, line })),
+    ...runtime.stderr.map((line) => ({ channel: "stderr" as const, line })),
+    ...(runtime.errorMessage ? [{ channel: "error" as const, line: runtime.errorMessage }] : []),
+  ];
+}
+
+function formatRuntimeOutput(entries: RuntimeOutputEntry[]): string {
+  return entries.map((entry) => `[${entry.channel}] ${entry.line}`).join("\n");
+}
+
+function outputTextClass(channel: RuntimeOutputEntry["channel"]): string {
+  switch (channel) {
+    case "stdout":
+      return "text-foreground";
+    case "stderr":
+      return "text-warning";
+    case "error":
+      return "text-danger";
+  }
 }

--- a/apps/web/src/features/runtime-preview/__tests__/RuntimeOutputPanel.test.tsx
+++ b/apps/web/src/features/runtime-preview/__tests__/RuntimeOutputPanel.test.tsx
@@ -1,5 +1,5 @@
-import { render, screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { ReplayStableState } from "@/shared/recording-schema";
 import { RuntimeOutputPanel } from "../RuntimeOutputPanel";
 
@@ -16,16 +16,24 @@ function makeRuntime(
   };
 }
 
+beforeEach(() => {
+  Object.defineProperty(navigator, "clipboard", {
+    configurable: true,
+    value: { writeText: vi.fn().mockResolvedValue(undefined) },
+  });
+});
+
 describe("RuntimeOutputPanel", () => {
   it("renders the status badge and a No output placeholder when empty", () => {
     render(<RuntimeOutputPanel runtime={makeRuntime({ status: "idle" })} />);
 
     expect(screen.getByText("Console")).toBeInTheDocument();
     expect(screen.getByText("idle")).toBeInTheDocument();
-    expect(screen.getByText("No output")).toBeInTheDocument();
+    expect(screen.getByText("暂无运行输出")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "复制运行输出" })).toBeDisabled();
   });
 
-  it("renders stdout, stderr, and error lines", () => {
+  it("renders categorized output counts and filters lines by channel", () => {
     render(
       <RuntimeOutputPanel
         runtime={makeRuntime({
@@ -37,10 +45,66 @@ describe("RuntimeOutputPanel", () => {
       />,
     );
 
+    expect(screen.getByRole("button", { name: "全部 3" })).toHaveAttribute("aria-pressed", "true");
+    expect(screen.getByRole("button", { name: "stdout 1" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "stderr 1" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "error 1" })).toBeInTheDocument();
     expect(screen.getByText("out line")).toBeInTheDocument();
     expect(screen.getByText("warn line")).toBeInTheDocument();
     expect(screen.getByText("boom")).toBeInTheDocument();
-    expect(screen.getByText("error")).toBeInTheDocument();
-    expect(screen.queryByText("No output")).not.toBeInTheDocument();
+    expect(screen.getAllByText("error").length).toBeGreaterThanOrEqual(2);
+    expect(screen.queryByText("暂无运行输出")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "stderr 1" }));
+
+    expect(screen.queryByText("out line")).not.toBeInTheDocument();
+    expect(screen.getByText("warn line")).toBeInTheDocument();
+    expect(screen.queryByText("boom")).not.toBeInTheDocument();
+  });
+
+  it("shows an explicit empty state when the selected channel has no output", () => {
+    render(<RuntimeOutputPanel runtime={makeRuntime({ status: "success", stdout: ["done"] })} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "stderr 0" }));
+
+    expect(screen.getByText("stderr 暂无输出")).toBeInTheDocument();
+    expect(screen.queryByText("done")).not.toBeInTheDocument();
+  });
+
+  it("copies the complete output with channel labels", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText },
+    });
+    render(
+      <RuntimeOutputPanel
+        runtime={makeRuntime({
+          status: "error",
+          stdout: ["out line"],
+          stderr: ["warn line"],
+          errorMessage: "boom",
+        })}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "复制运行输出" }));
+
+    await waitFor(() =>
+      expect(writeText).toHaveBeenCalledWith("[stdout] out line\n[stderr] warn line\n[error] boom"),
+    );
+    expect(await screen.findByRole("status")).toHaveTextContent("输出已复制");
+  });
+
+  it("reports copy failures", async () => {
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText: vi.fn().mockRejectedValue(new Error("denied")) },
+    });
+    render(<RuntimeOutputPanel runtime={makeRuntime({ status: "success", stdout: ["done"] })} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "复制运行输出" }));
+
+    expect(await screen.findByRole("status")).toHaveTextContent("复制失败");
   });
 });

--- a/apps/web/src/features/runtime-preview/__tests__/RuntimeOutputPanel.test.tsx
+++ b/apps/web/src/features/runtime-preview/__tests__/RuntimeOutputPanel.test.tsx
@@ -1,5 +1,5 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ReplayStableState } from "@/shared/recording-schema";
 import { RuntimeOutputPanel } from "../RuntimeOutputPanel";
 
@@ -23,8 +23,12 @@ beforeEach(() => {
   });
 });
 
+afterEach(() => {
+  vi.useRealTimers();
+});
+
 describe("RuntimeOutputPanel", () => {
-  it("renders the status badge and a No output placeholder when empty", () => {
+  it("renders the status badge and the empty-state placeholder when there is no output", () => {
     render(<RuntimeOutputPanel runtime={makeRuntime({ status: "idle" })} />);
 
     expect(screen.getByText("Console")).toBeInTheDocument();
@@ -49,6 +53,7 @@ describe("RuntimeOutputPanel", () => {
     expect(screen.getByRole("button", { name: "stdout 1" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "stderr 1" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "error 1" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "stdout 1" })).not.toHaveAttribute("aria-label");
     expect(screen.getByText("out line")).toBeInTheDocument();
     expect(screen.getByText("warn line")).toBeInTheDocument();
     expect(screen.getByText("boom")).toBeInTheDocument();
@@ -96,7 +101,30 @@ describe("RuntimeOutputPanel", () => {
     expect(await screen.findByRole("status")).toHaveTextContent("输出已复制");
   });
 
-  it("reports copy failures", async () => {
+  it("clears copy success feedback after a short confirmation window", async () => {
+    vi.useFakeTimers();
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText },
+    });
+    render(<RuntimeOutputPanel runtime={makeRuntime({ status: "success", stdout: ["done"] })} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "复制运行输出" }));
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(screen.getByRole("status")).toHaveTextContent("输出已复制");
+
+    act(() => {
+      vi.advanceTimersByTime(2000);
+    });
+
+    expect(screen.queryByRole("status")).not.toBeInTheDocument();
+  });
+
+  it("reports copy failures as alerts", async () => {
     Object.defineProperty(navigator, "clipboard", {
       configurable: true,
       value: { writeText: vi.fn().mockRejectedValue(new Error("denied")) },
@@ -105,6 +133,8 @@ describe("RuntimeOutputPanel", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "复制运行输出" }));
 
-    expect(await screen.findByRole("status")).toHaveTextContent("复制失败");
+    const alert = await screen.findByRole("alert");
+    expect(alert).toHaveTextContent("复制失败");
+    expect(alert).toHaveClass("text-danger");
   });
 });


### PR DESCRIPTION
## 关联

Refs #2（总控 issue，不在本 PR 中关闭）
Closes #265

## 改动点

- 将 recorder 与 replay 运行输出统一收敛到共享 `RuntimeOutputPanel`。
- 补齐运行状态、stdout/stderr/error 计数、通道筛选、按通道标注复制与复制反馈。
- 增加空状态与通道空状态，覆盖 recorder 页面复用链路。
- 根据 Copilot review 补齐复制反馈自动清理、失败 alert 呈现，并移除筛选按钮冗余 `aria-label`。

## 影响范围

- `apps/web/src/features/runtime-preview/RuntimeOutputPanel.tsx`
- `apps/web/src/features/recorder/RecorderPage.tsx`
- `apps/web/src/features/runtime-preview/__tests__/RuntimeOutputPanel.test.tsx`

## GitNexus 影响分析摘要

- 风险等级: HIGH
- 关键骨架变更: runtime-preview 属于 critical contract surface；已补充 `RuntimeOutputPanel.test.tsx` 覆盖计数、筛选、空状态、复制反馈清理与复制失败 alert
- GitNexus 影响面: `detect_changes` 显示 3 files、17 changed symbols、affected processes 0、risk low；`context(RuntimeOutputPanel)` 显示直接调用方为 `RemoteInterviewWorkbenchView`、`ReplayPage`、`RecorderPage`；`impact(RuntimeOutputPanel, upstream)` 显示 direct 3、processes affected 2、modules affected 3
- 验证结果: 针对输出面板、录制/回放页面、lint、e2e、build、pre-commit `quality:precommit` 与 pre-push `quality:local` 均已通过

## 自检

- [x] 未修改 `docs/progress.json` 或 `docs/progress.md`
- [x] 已运行 `npm run quality:local`，或说明无法运行的原因
- [x] 涉及 AI 字幕时，已记录一次 `npm run subtitle:postprocess:evaluate` 的“纠错并生成章节”效果验证结果，包含 `representativeOutputSource`、`overallEvaluationDurationMs`，并区分输出校验耗时与真实端到端耗时（不涉及 AI 字幕）
- [x] 涉及 AI 字幕点击链路、LLM worker、模型加载或性能时，已记录一次 `npm run subtitle:postprocess:runtime-benchmark` 结果，包含 `postprocessClickToResultReadyDurationMs`、`postProcessTimeoutBudgetMs` 和 `playbackProbeResponsiveDuringPostprocess`（不涉及 AI 字幕）
- [x] 已说明改动点和影响范围
- [x] 如果改动关键骨架，已补充契约测试并填写 GitNexus 影响分析摘要
- [ ] 已等待 repo-guard、codex 和 Copilot 评论，并完成必要审查

## 本地验证

- `npm run quality:predev`
- `npm run agent:bootstrap`
- `npm run test -w apps/web -- RuntimeOutputPanel.test.tsx`
- `npm run test -w apps/web -- RecorderPage.test.tsx ReplayPage.test.tsx`
- `npm run lint:web`
- `npm run e2e -w apps/web -- record-replay.spec.ts`
- `npm run build -w apps/web`
- `npm run e2e -w apps/web -- editor-shortcuts.spec.ts`
- `npm run quality:precommit`（pre-commit hook）
- `npm run quality:local`（pre-push hook）

## 手动体验

- `/record` 输入会产生 stdout/stderr 的代码后运行，桌面与 390px 视口下输出面板无水平溢出。
- `stderr` 筛选会隐藏 stdout 并保留 stderr 输出。
- 复制输出包含 `[stdout]` / `[stderr]` / `[error]` 通道前缀并给出可访问反馈。