### PR TITLE
[codex] Fix video replay cover frame

### DIFF
--- a/apps/web/src/features/library/__tests__/recordingStore.test.ts
+++ b/apps/web/src/features/library/__tests__/recordingStore.test.ts
@@ -12,6 +12,14 @@ import type {
   SaveDraftInput,
 } from "@/shared/recording-schema";
 
+const { replayThumbnailMock } = vi.hoisted(() => ({
+  replayThumbnailMock: vi.fn(async (): Promise<Blob | null> => null),
+}));
+
+vi.mock("../replayThumbnail", () => ({
+  createReplayThumbnail: replayThumbnailMock,
+}));
+
 function makeMeta(id = "rec-1"): RecordingMeta {
   return {
     id,
@@ -119,6 +127,8 @@ function uniqueDbName() {
 }
 
 beforeEach(() => {
+  replayThumbnailMock.mockReset();
+  replayThumbnailMock.mockResolvedValue(null);
   /* fake-indexeddb auto-wipes; nothing to do, each test uses a unique db name */
 });
 
@@ -215,6 +225,84 @@ describe("createRecordingStore — two-phase commit", () => {
     expect(thumbnail).toBeInstanceOf(Blob);
     expect(thumbnail?.type).toBe("image/webp");
     expect(new TextDecoder().decode(await thumbnail!.arrayBuffer())).toBe("thumbnail");
+  });
+
+  it("generates a replay thumbnail when no media blob is stored", async () => {
+    replayThumbnailMock.mockResolvedValueOnce(new Blob(["replay-thumbnail"], { type: "image/webp" }));
+    const store = createRecordingStore({ databaseName: uniqueDbName() });
+    const input = makeInput("rec-replay-thumbnail-only");
+    input.mediaBlob = null;
+
+    const saved = await store.saveDraft(input);
+    if (!saved.ok) throw new Error(saved.message);
+    await store.commit("rec-replay-thumbnail-only");
+
+    const item = await waitForListedRecordingWithThumbnail(store, "rec-replay-thumbnail-only");
+    expect(replayThumbnailMock).toHaveBeenCalled();
+    expect(item?.thumbnailBlobId).toMatch(/^thumbnail-/);
+    const thumbnail = await store.loadThumbnail(item!.thumbnailBlobId!);
+    expect(new TextDecoder().decode(await thumbnail!.arrayBuffer())).toBe("replay-thumbnail");
+  });
+
+  it("does not expose a thumbnail id when replay thumbnail generation returns null without media fallback", async () => {
+    replayThumbnailMock.mockResolvedValueOnce(null);
+    const dbName = uniqueDbName();
+    const store = createRecordingStore({ databaseName: dbName });
+    const input = makeInput("rec-replay-thumbnail-null");
+    input.mediaBlob = null;
+
+    const saved = await store.saveDraft(input);
+    if (!saved.ok) throw new Error(saved.message);
+    await store.commit("rec-replay-thumbnail-null");
+
+    await waitForCondition(() => replayThumbnailMock.mock.calls.length > 0);
+    const raw = await waitForRawRecording(dbName, "rec-replay-thumbnail-null");
+    expect(raw?.thumbnailBlobId).toBeNull();
+    const list = await store.list();
+    expect(list[0].thumbnailBlobId).toBeNull();
+  });
+
+  it("falls back to video thumbnail generation when replay thumbnail rendering rejects", async () => {
+    replayThumbnailMock.mockRejectedValueOnce(new Error("canvas failed"));
+    const thumbnailBlob = new Blob(["video-fallback"], { type: "image/webp" });
+    const thumbnailGenerator = vi.fn(async () => thumbnailBlob);
+    const store = createRecordingStore({
+      databaseName: uniqueDbName(),
+      thumbnailGenerator,
+    });
+    const input = makeInput("rec-replay-thumbnail-rejects");
+    input.mediaBlob = new Blob(["video"], { type: "video/webm" });
+
+    const saved = await store.saveDraft(input);
+    if (!saved.ok) throw new Error(saved.message);
+    await store.commit("rec-replay-thumbnail-rejects");
+
+    const item = await waitForListedRecordingWithThumbnail(store, "rec-replay-thumbnail-rejects");
+    expect(thumbnailGenerator).toHaveBeenCalledWith(
+      input.mediaBlob,
+      expect.objectContaining({ width: 320, height: 180, mimeType: "image/webp" }),
+    );
+    const thumbnail = await store.loadThumbnail(item!.thumbnailBlobId!);
+    expect(new TextDecoder().decode(await thumbnail!.arrayBuffer())).toBe("video-fallback");
+  });
+
+  it("does not expose a thumbnail id for non-video media when replay thumbnails are disabled", async () => {
+    const thumbnailGenerator = vi.fn(async () => new Blob(["thumbnail"], { type: "image/webp" }));
+    const store = createRecordingStore({
+      databaseName: uniqueDbName(),
+      replayThumbnailGenerator: null,
+      thumbnailGenerator,
+    });
+    const input = makeInput("rec-replay-thumbnail-disabled-audio");
+    input.mediaBlob = new Blob(["audio"], { type: "audio/webm" });
+
+    const saved = await store.saveDraft(input);
+    if (!saved.ok) throw new Error(saved.message);
+    await store.commit("rec-replay-thumbnail-disabled-audio");
+
+    const list = await store.list();
+    expect(list[0].thumbnailBlobId).toBeNull();
+    expect(thumbnailGenerator).not.toHaveBeenCalled();
   });
 
   it("returns after writing the draft before optional video thumbnail generation settles", async () => {
@@ -503,6 +591,15 @@ async function waitForListedRecordingWithThumbnail(
     await new Promise((resolve) => setTimeout(resolve, 5));
   }
   return lastValue;
+}
+
+async function waitForCondition(predicate: () => boolean): Promise<void> {
+  const deadline = Date.now() + 250;
+  while (Date.now() < deadline) {
+    if (predicate()) return;
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+  expect(predicate()).toBe(true);
 }
 
 async function readRawRecording(dbName: string, id: string): Promise<{ manifest: { status: string }; thumbnailBlobId: string | null } | undefined> {

--- a/apps/web/src/features/library/__tests__/replayThumbnail.test.ts
+++ b/apps/web/src/features/library/__tests__/replayThumbnail.test.ts
@@ -1,0 +1,99 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { RECORDING_SCHEMA_VERSION, type RecordingPackageV1 } from "@/shared/recording-schema";
+import { createReplayThumbnail } from "../replayThumbnail";
+import { DEFAULT_VIDEO_THUMBNAIL_OPTIONS } from "../videoThumbnail";
+
+describe("createReplayThumbnail", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("draws the final replay state instead of depending on a raw media frame", async () => {
+    const fillText = vi.fn();
+    const context = {
+      fillStyle: "",
+      font: "",
+      textBaseline: "",
+      fillRect: vi.fn(),
+      fillText,
+      measureText: vi.fn((text: string) => ({ width: text.length * 7 })),
+      beginPath: vi.fn(),
+      moveTo: vi.fn(),
+      lineTo: vi.fn(),
+      quadraticCurveTo: vi.fn(),
+      closePath: vi.fn(),
+      fill: vi.fn(),
+    };
+    const canvas = {
+      width: 0,
+      height: 0,
+      getContext: vi.fn(() => context),
+      toBlob: vi.fn((callback: BlobCallback) => callback(new Blob(["thumbnail"], { type: "image/webp" }))),
+    };
+    const originalCreateElement = document.createElement.bind(document);
+    vi.spyOn(document, "createElement").mockImplementation((tagName, options) => {
+      if (tagName === "canvas") return canvas as unknown as HTMLCanvasElement;
+      return originalCreateElement(tagName, options);
+    });
+
+    const thumbnail = await createReplayThumbnail(makePackageWithFinalCode(), DEFAULT_VIDEO_THUMBNAIL_OPTIONS);
+
+    expect(thumbnail).toBeInstanceOf(Blob);
+    expect(thumbnail?.type).toBe("image/webp");
+    expect(fillText.mock.calls.some(([text]) => String(text).startsWith("console.log('final"))).toBe(true);
+  });
+});
+
+function makePackageWithFinalCode(): RecordingPackageV1 {
+  return {
+    schemaVersion: RECORDING_SCHEMA_VERSION,
+    manifest: {
+      packageId: "pkg-1",
+      schemaVersion: RECORDING_SCHEMA_VERSION,
+      status: "complete",
+      createdAt: "2026-06-01T00:00:00.000Z",
+      completedAt: "2026-06-01T00:01:00.000Z",
+      checksums: { eventsSha256: "events", snapshotsSha256: "snapshots" },
+    },
+    meta: {
+      id: "rec-1",
+      title: "Final frame",
+      createdAt: "2026-06-01T00:00:00.000Z",
+      durationMs: 10_000,
+      appVersion: "test",
+      ownerId: null,
+      creatorInfo: null,
+      initialLanguage: "javascript",
+      initialFontSize: 14,
+      initialTheme: "dark",
+      mediaCapability: {
+        audio: "available",
+        camera: "available",
+        selectedAudioDeviceId: null,
+        selectedCameraDeviceId: null,
+      },
+    },
+    events: [
+      {
+        id: "edit-final",
+        seq: 1,
+        timestampMs: 9_000,
+        source: "editor",
+        track: "main",
+        type: "content-change",
+        payload: {
+          fileId: "main",
+          version: 1,
+          code: "console.log('final frame');",
+          contentHash: "final",
+          language: "javascript",
+          changeReason: "input",
+          changeCount: 1,
+          flushedBy: "debounce",
+        },
+      },
+    ],
+    snapshots: [],
+    media: null,
+  };
+}

--- a/apps/web/src/features/library/recordingStore.ts
+++ b/apps/web/src/features/library/recordingStore.ts
@@ -27,12 +27,16 @@ import {
   DEFAULT_VIDEO_THUMBNAIL_OPTIONS,
   type VideoThumbnailOptions,
 } from "./videoThumbnail";
+import { createReplayThumbnail } from "./replayThumbnail";
 
 export type RecordingStoreOptions = {
   databaseName?: string;
   /** Drafts older than this are removed by sweep(). Defaults to 24h. */
   draftMaxAgeMs?: number;
+  /** Media-blob fallback used only when replay thumbnail rendering is unavailable. */
   thumbnailGenerator?: ThumbnailGenerator;
+  /** Final replay-state renderer. Pass null to disable replay thumbnails in tests. */
+  replayThumbnailGenerator?: ReplayThumbnailGenerator | null;
 };
 
 const DEFAULT_DB_NAME = "code-tape";
@@ -42,6 +46,7 @@ const STORE_BLOBS = "blobs";
 const STORE_THUMBNAILS = "thumbnails";
 
 type ThumbnailGenerator = (mediaBlob: Blob, options: VideoThumbnailOptions) => Promise<Blob | null>;
+type ReplayThumbnailGenerator = (pkg: RecordingPackageV1, options: VideoThumbnailOptions) => Promise<Blob | null>;
 type StoredBlob = { buffer?: ArrayBuffer; dataBase64?: string; mimeType: string };
 
 type StoredRecording = {
@@ -76,6 +81,9 @@ export function createRecordingStore(options: RecordingStoreOptions = {}): Recor
   const databaseName = options.databaseName ?? DEFAULT_DB_NAME;
   const draftMaxAgeMs = options.draftMaxAgeMs ?? 24 * 60 * 60 * 1000;
   const thumbnailGenerator = options.thumbnailGenerator ?? createVideoThumbnail;
+  const replayThumbnailGenerator = options.replayThumbnailGenerator === undefined
+    ? createReplayThumbnail
+    : options.replayThumbnailGenerator;
 
   const getDb = (() => {
     let cached: Promise<IDBDatabase> | null = null;
@@ -137,7 +145,8 @@ export function createRecordingStore(options: RecordingStoreOptions = {}): Recor
       const db = await getDb();
       const recordingId = input.meta.id;
       const blobId = input.mediaBlob ? generateId("blob") : null;
-      const thumbnailBlobId = input.mediaBlob && isVideoBlob(input.mediaBlob) ? generateId("thumbnail") : null;
+      const shouldGenerateThumbnail =
+        replayThumbnailGenerator !== null || (input.mediaBlob !== null && isVideoBlob(input.mediaBlob));
       const eventsSha256 = await sha256Hex(canonicalStringify(input.events));
       const snapshotsSha256 = await sha256Hex(canonicalStringify(input.snapshots));
       // Materialize the blob to ArrayBuffer BEFORE opening the transaction so
@@ -205,8 +214,25 @@ export function createRecordingStore(options: RecordingStoreOptions = {}): Recor
           blobs.put(payload, blobId);
         }
         await awaitTransaction(tx);
-        if (thumbnailBlobId && input.mediaBlob) {
-          void generateAndPersistThumbnail(getDb, recordingId, thumbnailBlobId, input.mediaBlob, thumbnailGenerator);
+        if (shouldGenerateThumbnail) {
+          const pkg: RecordingPackageV1 = {
+            schemaVersion: RECORDING_SCHEMA_VERSION,
+            manifest: stored.manifest,
+            meta: stored.meta,
+            events: stored.events,
+            snapshots: stored.snapshots,
+            media: stored.media,
+            indexes: stored.indexes,
+          };
+          void generateAndPersistThumbnail(
+            getDb,
+            recordingId,
+            generateId("thumbnail"),
+            input.mediaBlob,
+            pkg,
+            thumbnailGenerator,
+            replayThumbnailGenerator,
+          );
         }
         return { ok: true, recordingId };
       } catch (err) {
@@ -494,10 +520,12 @@ async function generateAndPersistThumbnail(
   getDb: () => Promise<IDBDatabase>,
   recordingId: string,
   thumbnailBlobId: string,
-  mediaBlob: Blob,
+  mediaBlob: Blob | null,
+  pkg: RecordingPackageV1,
   thumbnailGenerator: ThumbnailGenerator,
+  replayThumbnailGenerator: ReplayThumbnailGenerator | null,
 ): Promise<void> {
-  const thumbnailPayload = await prepareThumbnailPayload(mediaBlob, thumbnailGenerator);
+  const thumbnailPayload = await prepareThumbnailPayload(mediaBlob, pkg, thumbnailGenerator, replayThumbnailGenerator);
   if (!thumbnailPayload) return;
   try {
     const db = await getDb();
@@ -508,11 +536,19 @@ async function generateAndPersistThumbnail(
 }
 
 async function prepareThumbnailPayload(
-  mediaBlob: Blob,
+  mediaBlob: Blob | null,
+  pkg: RecordingPackageV1,
   thumbnailGenerator: ThumbnailGenerator,
+  replayThumbnailGenerator: ReplayThumbnailGenerator | null,
 ): Promise<StoredBlob | null> {
   try {
-    const thumbnail = await thumbnailGenerator(mediaBlob, DEFAULT_VIDEO_THUMBNAIL_OPTIONS);
+    const replayThumbnail = replayThumbnailGenerator
+      ? await replayThumbnailGenerator(pkg, DEFAULT_VIDEO_THUMBNAIL_OPTIONS).catch(() => null)
+      : null;
+    const thumbnail = replayThumbnail ??
+      (mediaBlob && isVideoBlob(mediaBlob)
+        ? await thumbnailGenerator(mediaBlob, DEFAULT_VIDEO_THUMBNAIL_OPTIONS)
+        : null);
     if (!thumbnail || thumbnail.size === 0) return null;
     const buffer = await thumbnail.arrayBuffer();
     return {

--- a/apps/web/src/features/library/replayThumbnail.ts
+++ b/apps/web/src/features/library/replayThumbnail.ts
@@ -1,0 +1,201 @@
+import {
+  buildFinalReplayStateFromPackage,
+  type RecordingPackageV1,
+  type ReplayStableState,
+} from "@/shared/recording-schema";
+import type { VideoThumbnailOptions } from "./videoThumbnail";
+
+export async function createReplayThumbnail(
+  pkg: RecordingPackageV1,
+  options: VideoThumbnailOptions,
+): Promise<Blob | null> {
+  if (typeof document === "undefined") return null;
+  const canvas = document.createElement("canvas");
+  if (isJsdomCanvasWithoutImplementation(canvas)) return null;
+  canvas.width = options.width;
+  canvas.height = options.height;
+  const context = canvas.getContext("2d");
+  if (!context) return null;
+
+  drawReplayFrame(context, buildFinalReplayStateFromPackage(pkg), canvas.width, canvas.height);
+  return canvasToBlob(canvas, options.mimeType, options.quality);
+}
+
+function drawReplayFrame(
+  context: CanvasRenderingContext2D,
+  state: ReplayStableState,
+  width: number,
+  height: number,
+) {
+  const dark = state.editor.theme === "dark";
+  const palette = dark
+    ? {
+        page: "#111827",
+        panel: "#1f2937",
+        rail: "#374151",
+        text: "#f9fafb",
+        muted: "#9ca3af",
+        accent: "#38bdf8",
+        preview: "#0f172a",
+      }
+    : {
+        page: "#f8fafc",
+        panel: "#ffffff",
+        rail: "#e5e7eb",
+        text: "#111827",
+        muted: "#64748b",
+        accent: "#0284c7",
+        preview: "#f1f5f9",
+      };
+
+  context.fillStyle = palette.page;
+  context.fillRect(0, 0, width, height);
+
+  const margin = Math.round(width * 0.045);
+  const gap = Math.round(width * 0.035);
+  const editorWidth = Math.round(width * 0.62);
+  const panelWidth = width - margin * 2 - gap - editorWidth;
+  const panelHeight = height - margin * 2;
+
+  fillRoundRect(context, margin, margin, editorWidth, panelHeight, 8, palette.panel);
+  fillRoundRect(context, margin + editorWidth + gap, margin, panelWidth, panelHeight, 8, palette.preview);
+
+  context.fillStyle = palette.rail;
+  context.fillRect(margin, margin, editorWidth, 18);
+  context.fillRect(margin + editorWidth + gap, margin, panelWidth, 18);
+  context.fillStyle = palette.accent;
+  context.fillRect(margin, margin + 17, editorWidth, 1);
+
+  context.font = "700 11px ui-monospace, SFMono-Regular, Menlo, monospace";
+  context.fillStyle = palette.muted;
+  context.fillText(state.editor.language.toUpperCase(), margin + 12, margin + 13);
+  context.fillText("OUTPUT", margin + editorWidth + gap + 12, margin + 13);
+
+  context.font = "12px ui-monospace, SFMono-Regular, Menlo, monospace";
+  context.fillStyle = palette.text;
+  drawCodeLines(context, state.editor.code, margin + 12, margin + 38, editorWidth - 24, 17, 7, palette.text);
+
+  context.font = "11px ui-monospace, SFMono-Regular, Menlo, monospace";
+  context.fillStyle = state.runtime.status === "error" ? "#ef4444" : palette.text;
+  const outputText = replayOutputText(state) || "No output";
+  drawWrappedText(context, outputText, margin + editorWidth + gap + 12, margin + 42, panelWidth - 24, 16, 6);
+}
+
+function drawCodeLines(
+  context: CanvasRenderingContext2D,
+  code: string,
+  x: number,
+  y: number,
+  maxWidth: number,
+  lineHeight: number,
+  maxLines: number,
+  textColor: string,
+) {
+  const lines = code.trim() ? code.split(/\r?\n/) : ["// Empty recording"];
+  const lineNumberWidth = 26;
+  context.textBaseline = "top";
+  for (let index = 0; index < Math.min(lines.length, maxLines); index += 1) {
+    context.fillStyle = "rgba(148, 163, 184, 0.85)";
+    context.fillText(String(index + 1), x, y + index * lineHeight);
+    context.fillStyle = textColor;
+    drawEllipsizedText(context, lines[index], x + lineNumberWidth, y + index * lineHeight, maxWidth - lineNumberWidth);
+  }
+}
+
+function drawWrappedText(
+  context: CanvasRenderingContext2D,
+  text: string,
+  x: number,
+  y: number,
+  maxWidth: number,
+  lineHeight: number,
+  maxLines: number,
+) {
+  const chunks = text.split(/\s+/).filter(Boolean);
+  const lines: string[] = [];
+  let current = "";
+  for (const chunk of chunks) {
+    const next = current ? `${current} ${chunk}` : chunk;
+    if (context.measureText(next).width <= maxWidth) {
+      current = next;
+    } else {
+      if (current) lines.push(current);
+      current = chunk;
+    }
+    if (lines.length >= maxLines) break;
+  }
+  if (current && lines.length < maxLines) lines.push(current);
+  if (lines.length === 0) lines.push(text.slice(0, 32));
+  context.textBaseline = "top";
+  lines.slice(0, maxLines).forEach((line, index) => {
+    drawEllipsizedText(context, line, x, y + index * lineHeight, maxWidth);
+  });
+}
+
+function drawEllipsizedText(
+  context: CanvasRenderingContext2D,
+  text: string,
+  x: number,
+  y: number,
+  maxWidth: number,
+) {
+  if (context.measureText(text).width <= maxWidth) {
+    context.fillText(text, x, y);
+    return;
+  }
+  let clipped = text;
+  while (clipped.length > 1 && context.measureText(`${clipped}...`).width > maxWidth) {
+    clipped = clipped.slice(0, -1);
+  }
+  context.fillText(`${clipped}...`, x, y);
+}
+
+function fillRoundRect(
+  context: CanvasRenderingContext2D,
+  x: number,
+  y: number,
+  width: number,
+  height: number,
+  radius: number,
+  fillStyle: string,
+) {
+  context.fillStyle = fillStyle;
+  context.beginPath();
+  context.moveTo(x + radius, y);
+  context.lineTo(x + width - radius, y);
+  context.quadraticCurveTo(x + width, y, x + width, y + radius);
+  context.lineTo(x + width, y + height - radius);
+  context.quadraticCurveTo(x + width, y + height, x + width - radius, y + height);
+  context.lineTo(x + radius, y + height);
+  context.quadraticCurveTo(x, y + height, x, y + height - radius);
+  context.lineTo(x, y + radius);
+  context.quadraticCurveTo(x, y, x + radius, y);
+  context.closePath();
+  context.fill();
+}
+
+function replayOutputText(state: ReplayStableState): string {
+  return [
+    ...state.runtime.stdout,
+    ...state.runtime.stderr,
+    state.runtime.errorMessage ?? "",
+  ]
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .join("\n");
+}
+
+function canvasToBlob(canvas: HTMLCanvasElement, mimeType: string, quality: number) {
+  return new Promise<Blob | null>((resolve) => {
+    canvas.toBlob((blob) => resolve(blob), mimeType, quality);
+  });
+}
+
+function isJsdomCanvasWithoutImplementation(canvas: HTMLCanvasElement): boolean {
+  return (
+    typeof navigator !== "undefined" &&
+    /\bjsdom\b/i.test(navigator.userAgent) &&
+    typeof HTMLCanvasElement !== "undefined" &&
+    canvas instanceof HTMLCanvasElement
+  );
+}

--- a/apps/web/src/features/player/ReplayPage.tsx
+++ b/apps/web/src/features/player/ReplayPage.tsx
@@ -33,6 +33,7 @@ import type {
   ReplaySchedulerState,
   ReplayStableState,
 } from "@/shared/recording-schema";
+import { buildFinalReplayStateFromPackage } from "@/shared/recording-schema";
 import { createCloudPackageLoader } from "./cloudPackageLoader";
 
 const INITIAL_SCHEDULER_STATE: ReplaySchedulerState = {
@@ -142,6 +143,7 @@ export function ReplayPage({ source = "local" }: ReplayPageProps) {
   const [schedulerState, setSchedulerState] =
     useState<ReplaySchedulerState>(INITIAL_SCHEDULER_STATE);
   const [stableState, setStableState] = useState<ReplayStableState>(INITIAL_STABLE_STATE);
+  const [posterState, setPosterState] = useState<ReplayStableState | null>(null);
   const [overlayState, setOverlayState] = useState<ReplayOverlayState>(EMPTY_OVERLAY_STATE);
   const [pkg, setPkg] = useState<RecordingPackageV1 | null>(null);
   const [mediaBlob, setMediaBlob] = useState<Blob | null>(null);
@@ -191,6 +193,7 @@ export function ReplayPage({ source = "local" }: ReplayPageProps) {
       clock: createTimelineClock(),
       tickStrategy: defaultTickStrategy(),
       onTick: (state, transientEvents = []) => {
+        setPosterState(null);
         setStableState(state);
         setOverlayState((current) => overlayStateFromEvents(current, transientEvents));
         scheduleOverlayCleanup(transientEvents, setOverlayState, pointerTimerRef, shortcutTimerRef);
@@ -218,6 +221,7 @@ export function ReplayPage({ source = "local" }: ReplayPageProps) {
   }, []);
   const playReplay = useCallback(() => {
     const timelineTimeMs = schedulerState.status === "ended" ? 0 : schedulerState.timelineTimeMs;
+    setPosterState(null);
     playRecordedMedia(timelineTimeMs);
     scheduler.play();
   }, [playRecordedMedia, scheduler, schedulerState.status, schedulerState.timelineTimeMs]);
@@ -225,6 +229,10 @@ export function ReplayPage({ source = "local" }: ReplayPageProps) {
     pauseRecordedMedia();
     scheduler.pause();
   }, [pauseRecordedMedia, scheduler]);
+  const seekReplay = useCallback(async (targetMs: number) => {
+    setPosterState(null);
+    await scheduler.seek(targetMs);
+  }, [scheduler]);
   const setDisplayOption = useCallback(
     (key: keyof ReplayDisplayOptions, value: boolean) => {
       setDisplayOptions((current) => ({ ...current, [key]: value }));
@@ -266,6 +274,7 @@ export function ReplayPage({ source = "local" }: ReplayPageProps) {
     setPkg(null);
     setMediaBlob(null);
     setStableState(INITIAL_STABLE_STATE);
+    setPosterState(null);
     setOverlayState(EMPTY_OVERLAY_STATE);
     clearOverlayTimers();
     recordedMediaVideoRef.current?.pause();
@@ -290,7 +299,11 @@ export function ReplayPage({ source = "local" }: ReplayPageProps) {
       );
       await scheduler.load(result.package);
       if (cancelled) return;
-      if (initialSeekTimeMs !== null) await scheduler.seek(initialSeekTimeMs);
+      if (initialSeekTimeMs !== null) {
+        await scheduler.seek(initialSeekTimeMs);
+      } else {
+        setPosterState(buildFinalReplayStateFromPackage(result.package));
+      }
     })();
     return () => {
       cancelled = true;
@@ -315,19 +328,21 @@ export function ReplayPage({ source = "local" }: ReplayPageProps) {
     );
   }
 
+  const visibleStableState = posterState ?? stableState;
+
   const replayStage = (
     <div className="relative h-full min-h-0">
       <CodeEditor
-        language={stableState.editor.language}
-        initialValue={stableState.editor.code}
-        value={stableState.editor.code}
-        fontSize={stableState.editor.fontSize}
-        theme={stableState.editor.theme}
+        language={visibleStableState.editor.language}
+        initialValue={visibleStableState.editor.code}
+        value={visibleStableState.editor.code}
+        fontSize={visibleStableState.editor.fontSize}
+        theme={visibleStableState.editor.theme}
         readOnly
-        cursor={stableState.editor.cursor}
-        selection={stableState.editor.selection}
-        scrollTop={stableState.editor.scrollTop}
-        scrollLeft={stableState.editor.scrollLeft}
+        cursor={visibleStableState.editor.cursor}
+        selection={visibleStableState.editor.selection}
+        scrollTop={visibleStableState.editor.scrollTop}
+        scrollLeft={visibleStableState.editor.scrollLeft}
       />
       <ReplayVisualOverlays
         state={overlayState}
@@ -338,7 +353,7 @@ export function ReplayPage({ source = "local" }: ReplayPageProps) {
         videoRef={recordedMediaVideoRef}
         media={currentMedia}
         mediaBlob={mediaBlob}
-        mediaState={stableState.media}
+        mediaState={visibleStableState.media}
         schedulerState={schedulerState}
         volume={volume}
         muted={muted}
@@ -406,12 +421,12 @@ export function ReplayPage({ source = "local" }: ReplayPageProps) {
               left={
                 <PreviewPane
                   runtime={runtime}
-                  previewHtml={stableState.runtime.previewHtml}
-                  theme={stableState.editor.theme}
+                  previewHtml={visibleStableState.runtime.previewHtml}
+                  theme={visibleStableState.editor.theme}
                   className="min-h-0 flex-1"
                 />
               }
-              right={<RuntimeOutputPanel runtime={stableState.runtime} />}
+              right={<RuntimeOutputPanel runtime={visibleStableState.runtime} />}
             />
           }
         />
@@ -427,11 +442,11 @@ export function ReplayPage({ source = "local" }: ReplayPageProps) {
           hasAudio={Boolean(pkg?.media?.hasAudio)}
           durationMs={pkg?.meta.durationMs ?? 0}
           currentTimeMs={schedulerState.timelineTimeMs}
-          onSeek={(target) => scheduler.seek(target)}
+          onSeek={seekReplay}
           postProcessorContext={{
-            language: stableState.editor.language,
-            code: stableState.editor.code,
-            runtimeOutput: replayRuntimeOutputText(stableState.runtime),
+            language: visibleStableState.editor.language,
+            code: visibleStableState.editor.code,
+            runtimeOutput: replayRuntimeOutputText(visibleStableState.runtime),
             glossary: DEFAULT_SUBTITLE_GLOSSARY,
           }}
         />
@@ -445,7 +460,7 @@ export function ReplayPage({ source = "local" }: ReplayPageProps) {
             ? pauseReplay()
             : playReplay()
         }
-        onSeek={(target) => scheduler.seek(target)}
+        onSeek={seekReplay}
         onRate={(rate) => scheduler.setRate(rate)}
         volume={volume}
         muted={muted}

--- a/apps/web/src/features/player/__tests__/ReplayPage.test.tsx
+++ b/apps/web/src/features/player/__tests__/ReplayPage.test.tsx
@@ -371,6 +371,38 @@ describe("ReplayPage", () => {
     }
   });
 
+  it("shows the final replay state as the initial poster frame without moving the timeline", async () => {
+    replayPageMock.packageData.events = [
+      {
+        id: "edit-final",
+        seq: 1,
+        timestampMs: 12_000,
+        source: "editor",
+        track: "main",
+        type: "content-change",
+        payload: {
+          fileId: "main",
+          version: 1,
+          code: "console.log('final frame');",
+          contentHash: "final",
+          language: "javascript",
+          changeReason: "input",
+          changeCount: 1,
+          flushedBy: "debounce",
+        },
+      },
+    ];
+    const { ReplayPage } = await import("../ReplayPage");
+
+    render(<ReplayPage />);
+
+    await waitFor(() => expect(replayPageMock.scheduler.load).toHaveBeenCalledWith(replayPageMock.packageData));
+    await waitFor(() => {
+      expect(replayPageMock.codeEditorProps?.value).toBe("console.log('final frame');");
+    });
+    expect(replayPageMock.controlsProps?.state.timelineTimeMs).toBe(0);
+  });
+
   it("rebuilds malformed activity density indexes before rendering controls", async () => {
     replayPageMock.packageData.events = [
       {

--- a/apps/web/src/shared/recording-schema/__tests__/replayState.test.ts
+++ b/apps/web/src/shared/recording-schema/__tests__/replayState.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  buildFinalReplayStateFromPackage,
   buildInitialReplayStateFromPackage,
   buildInitialReplayStateFromRecordStart,
   cloneReplayStableState,
@@ -69,6 +70,19 @@ describe("replay stable state contract", () => {
 
     expect(state.editor.code).toBe("let answer = 42;");
     expect(state.runtime.stdout).toEqual([]);
+  });
+
+  it("builds the final stable state from package events", () => {
+    const pkg = makePackage();
+    pkg.events = [
+      contentChangeEvent(1, "console.log('final frame');"),
+      runOutputEvent(2),
+    ];
+
+    const state = buildFinalReplayStateFromPackage(pkg);
+
+    expect(state.editor.code).toBe("console.log('final frame');");
+    expect(state.runtime.previewHtml).toBe("<main>P0</main>");
   });
 });
 

--- a/packages/recording-schema/src/replayState.ts
+++ b/packages/recording-schema/src/replayState.ts
@@ -16,6 +16,14 @@ export function buildInitialReplayStateFromPackage(pkg: RecordingPackageV1): Rep
   return buildInitialReplayState(pkg.meta);
 }
 
+export function buildFinalReplayStateFromPackage(pkg: RecordingPackageV1): ReplayStableState {
+  return pkg.events
+    .filter((event) => STABLE_EVENT_TYPES.has(event.type))
+    .slice()
+    .sort((left, right) => left.timestampMs - right.timestampMs || left.seq - right.seq)
+    .reduce(replayReducer, buildInitialReplayStateFromPackage(pkg));
+}
+
 export function buildInitialReplayStateFromRecordStart(
   payload: RecordStartPayload,
 ): ReplayStableState {


### PR DESCRIPTION
## What changed

- Generate library thumbnails from the final replay state instead of sampling the raw recorded video blob.
- Add a schema helper that folds replay events into the final stable state.
- Show the final stable state as the initial replay poster when opening a replay without a timestamp, while playback still starts from `0` once the user plays or seeks.
- Decouple replay thumbnail generation from `mediaBlob`, so replay-only packages can persist a final-state thumbnail; video frame extraction remains a fallback when replay rendering fails and a video blob exists.
- Replace the implicit `thumbnailGenerator === createVideoThumbnail` strategy check with explicit replay thumbnail and media fallback generator options.
- Handle replay thumbnail renderer exceptions by falling back to video thumbnail generation, and avoid starting fallback generation for non-video media when replay thumbnails are disabled.
- Keep recording records at `thumbnailBlobId: null` until a thumbnail blob is actually generated and persisted, so failed replay-only thumbnail attempts do not expose dangling ids.
- Add focused coverage for replay state folding, replay poster behavior, replay thumbnail rendering, media-less thumbnail persistence, replay-renderer failure fallback, and no-dangling-thumbnail fallback behavior.

## Why

The previous cover pipeline sampled the final frame from the MediaRecorder WebM. In practice those captures could resolve to a black frame in the library, and the replay page still initialized from the beginning of the timeline rather than the final stable state expected as the cover/poster frame.

Fixes #271

## GitNexus 影响分析摘要

- 风险等级: MEDIUM
- 关键骨架变更: touches `apps/web/src/features/library/recordingStore.ts`, `apps/web/src/features/player/ReplayPage.tsx`, and replay-state schema/test helpers; no protected progress files changed.
- GitNexus 影响面: `detect_changes --repo code-tape --scope unstaged` reported 2 files / 3 symbols and affected flows concentrated in `ImportZip` / Library thumbnail persistence; `impact createRecordingStore --repo code-tape --direction upstream --include-tests` reported LOW risk with direct callers in Library, ReplayPage, and RecorderPage.
- 验证结果: targeted library/player/schema tests, `lint:web`, `test:web` (70 files / 805 tests), `build`, pre-commit `quality:precommit`, and pre-push `quality:local` including 7 Playwright e2e tests passed.

## Validation

- `npm run quality:predev`
- `npm run agent:bootstrap`
- `npm run test -w apps/web -- src/shared/recording-schema/__tests__/replayState.test.ts`
- `npm run test -w apps/web -- src/features/player/__tests__/ReplayPage.test.tsx`
- `npm run test -w apps/web -- src/features/library/__tests__/replayThumbnail.test.ts src/features/library/__tests__/recordingStore.test.ts src/features/library/__tests__/videoThumbnail.test.ts`
- `npm run test -w apps/web -- src/features/library/__tests__/recordingStore.test.ts` (25 tests)
- `npm run lint:web`
- `npm run test:web` (70 files / 805 tests)
- `npm run build`
- `npm run dev` smoke at `http://127.0.0.1:5173/`
- pre-commit `quality:precommit`
- pre-push `quality:local`, including 7 Playwright e2e tests
