### PR TITLE
#272 支持 GitHub 仓库入口

### DIFF
--- a/apps/web/src/app/AppShell.tsx
+++ b/apps/web/src/app/AppShell.tsx
@@ -1,7 +1,9 @@
 import { Outlet, NavLink } from "react-router-dom";
-import { Monitor, Moon, Sun } from "lucide-react";
-import type { ThemeMode, ThemePreference } from "@/shared/ui";
+import { Github, Monitor, Moon, Sun } from "lucide-react";
+import { Tooltip, type ThemeMode, type ThemePreference } from "@/shared/ui";
 import { useTheme } from "@/shared/ui/useTheme";
+
+const GITHUB_REPOSITORY_URL = "https://github.com/ceilf6/code-tape";
 
 const THEME_PREFERENCE_LABEL: Record<ThemePreference, string> = {
   system: "跟随系统",
@@ -75,6 +77,21 @@ export function AppShell() {
           </NavLink>
         </nav>
         <span className="flex-1" />
+        <Tooltip content="打开 GitHub 仓库">
+          <a
+            href={GITHUB_REPOSITORY_URL}
+            target="_blank"
+            rel="noreferrer"
+            aria-label="打开 GitHub 仓库"
+            className={[
+              "inline-flex h-8 w-8 items-center justify-center rounded-md border border-transparent text-muted transition-colors",
+              "hover:bg-surface-raised hover:text-foreground",
+              "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus focus-visible:ring-offset-2 focus-visible:ring-offset-background",
+            ].join(" ")}
+          >
+            <Github aria-hidden="true" className="h-4 w-4" />
+          </a>
+        </Tooltip>
         <div
           aria-label={themeStatusLabel}
           className="grid grid-cols-3 overflow-hidden rounded-md border border-border bg-surface p-0.5"

--- a/apps/web/src/app/__tests__/routes.test.tsx
+++ b/apps/web/src/app/__tests__/routes.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { beforeEach, describe, expect, it } from "vitest";
+import { TooltipProvider } from "@/shared/ui";
 import { ThemeProvider } from "@/shared/ui/themeProvider";
 import { AppShell } from "../AppShell";
 import { appRoutes } from "../routes";
@@ -23,6 +24,18 @@ beforeEach(() => {
   });
 });
 
+function renderAppShell() {
+  return render(
+    <ThemeProvider>
+      <TooltipProvider>
+        <MemoryRouter>
+          <AppShell />
+        </MemoryRouter>
+      </TooltipProvider>
+    </ThemeProvider>,
+  );
+}
+
 describe("appRoutes", () => {
   it("registers cloud replay routes", () => {
     const childPaths = appRoutes[0]?.children?.map((route) => route.path) ?? [];
@@ -41,38 +54,30 @@ describe("appRoutes", () => {
 
 describe("AppShell", () => {
   it("uses the uppercase wordmark in the top navigation", () => {
-    render(
-      <ThemeProvider>
-        <MemoryRouter>
-          <AppShell />
-        </MemoryRouter>
-      </ThemeProvider>,
-    );
+    renderAppShell();
 
     expect(screen.getByText("CODE-TAPE")).toBeInTheDocument();
     expect(screen.queryByText("code-tape")).not.toBeInTheDocument();
   });
 
   it("exposes the interview lobby entry in the top navigation", () => {
-    render(
-      <ThemeProvider>
-        <MemoryRouter>
-          <AppShell />
-        </MemoryRouter>
-      </ThemeProvider>,
-    );
+    renderAppShell();
 
     expect(screen.getByRole("link", { name: "面试" })).toHaveAttribute("href", "/interview");
   });
 
+  it("links the GitHub icon to the repository in a new tab", () => {
+    renderAppShell();
+
+    const repositoryLink = screen.getByRole("link", { name: "打开 GitHub 仓库" });
+
+    expect(repositoryLink).toHaveAttribute("href", "https://github.com/ceilf6/code-tape");
+    expect(repositoryLink).toHaveAttribute("target", "_blank");
+    expect(repositoryLink).toHaveAttribute("rel", "noreferrer");
+  });
+
   it("lets users choose system, light, and dark theme preferences", () => {
-    render(
-      <ThemeProvider>
-        <MemoryRouter>
-          <AppShell />
-        </MemoryRouter>
-      </ThemeProvider>,
-    );
+    renderAppShell();
 
     const systemButton = screen.getByRole("button", { name: "跟随系统主题" });
     const lightButton = screen.getByRole("button", { name: "切换到浅色主题" });


### PR DESCRIPTION
## 关联

Closes #272
Refs #2（总控 issue，不在本 PR 中关闭）

## 改动点

- 在顶层导航主题切换左侧新增 GitHub 图标外链，指向 https://github.com/ceilf6/code-tape。
- 为仓库入口补充可访问名称、tooltip、`target="_blank"` 与 `rel="noreferrer"`。
- 补充 AppShell 测试，覆盖仓库链接、打开方式和安全属性。

## 影响范围

- 仅影响应用顶层导航 `AppShell` 和对应路由测试。
- 不改录制、回放、媒体、运行沙箱或存储逻辑。

## GitNexus 影响分析摘要

- 风险等级: low
- 关键骨架变更: 无，GitNexus contract 提示本 diff 未触及 critical contract surface。
- GitNexus 影响面: `npx gitnexus detect_changes --repo code-tape` 显示 2 files / 4 symbols，Affected processes: 0。
- 验证结果: `npm --workspace apps/web run test -- --run src/app/__tests__/routes.test.tsx` 通过；`npm run quality:local` 通过；Playwright 页面检查确认链接 href/target/rel 正确且顶栏未挤压。

## 自检

- [x] 未修改 `docs/progress.json` 或 `docs/progress.md`
- [x] 已运行 `npm run quality:local`，或说明无法运行的原因
- [x] 涉及 AI 字幕时，已记录一次 `npm run subtitle:postprocess:evaluate` 的“纠错并生成章节”效果验证结果，包含 `representativeOutputSource`、`overallEvaluationDurationMs`，并区分输出校验耗时与真实端到端耗时
  - 不涉及 AI 字幕
- [x] 涉及 AI 字幕点击链路、LLM worker、模型加载或性能时，已记录一次 `npm run subtitle:postprocess:runtime-benchmark` 结果，包含 `postprocessClickToResultReadyDurationMs`、`postProcessTimeoutBudgetMs` 和 `playbackProbeResponsiveDuringPostprocess`
  - 不涉及 AI 字幕
- [x] 已说明改动点和影响范围
- [x] 如果改动关键骨架，已补充契约测试并填写 GitNexus 影响分析摘要
  - 未改动关键骨架
- [ ] 已等待 repo-guard、codex 和 Copilot 评论，并完成必要审查