### PR TITLE
fix: remove duplicate replay progress rail

### DIFF
--- a/apps/web/src/features/player/ReplayControls.tsx
+++ b/apps/web/src/features/player/ReplayControls.tsx
@@ -1,6 +1,5 @@
 import type {
   ActivityDensityBucket,
-  ActivityDensityKind,
   ReplayPlaybackRate,
   ReplaySchedulerState,
 } from "@/shared/recording-schema";
@@ -37,7 +36,6 @@ export function ReplayControls({
   muted,
   onVolume,
   onMuted,
-  activityDensity = [],
 }: ReplayControlsProps) {
   const [ratePopoverOpen, setRatePopoverOpen] = useState(false);
   const [volumePopoverOpen, setVolumePopoverOpen] = useState(false);
@@ -168,8 +166,7 @@ export function ReplayControls({
         </span>
       </div>
 
-      <div className="relative flex-1 min-w-[120px] pb-2" data-replay-progress-control>
-        <ReplayActivityMarkers activityDensity={activityDensity} durationMs={safeDuration} />
+      <div className="flex-1 min-w-[120px]" data-replay-progress-control>
         <Slider
           value={currentProgressPercent}
           min={0}
@@ -285,73 +282,4 @@ export function ReplayControls({
       </div>
     </Toolbar>
   );
-}
-
-function ReplayActivityMarkers({
-  activityDensity,
-  durationMs,
-}: {
-  activityDensity: ActivityDensityBucket[];
-  durationMs: number;
-}) {
-  if (durationMs <= 0 || activityDensity.length === 0) return null;
-  return (
-    <div
-      className="pointer-events-none absolute inset-x-2 bottom-0 h-1"
-      data-replay-activity-markers
-    >
-      {activityDensity.map((bucket, index) => {
-        const left = clampPercent((bucket.startMs / durationMs) * 100);
-        const width = Math.max(
-          0.8,
-          clampPercent(((bucket.endMs - bucket.startMs) / durationMs) * 100),
-        );
-        return (
-          <span
-            key={`${bucket.kind}-${bucket.startMs}-${bucket.endMs}-${index}`}
-            aria-label={`活动：${activityKindLabel(bucket.kind)} ${formatDurationMs(bucket.startMs)}-${formatDurationMs(bucket.endMs)}`}
-            className={cn(
-              "absolute top-0 h-1 rounded-full opacity-80",
-              activityKindClassName(bucket.kind),
-            )}
-            style={{ left: `${left}%`, width: `${width}%` }}
-          />
-        );
-      })}
-    </div>
-  );
-}
-
-function clampPercent(value: number): number {
-  return Math.min(100, Math.max(0, value));
-}
-
-function activityKindLabel(kind: ActivityDensityKind): string {
-  switch (kind) {
-    case "edit":
-      return "编辑";
-    case "run":
-      return "运行";
-    case "error":
-      return "错误";
-    case "shortcut":
-      return "快捷键";
-    case "silence":
-      return "静默";
-  }
-}
-
-function activityKindClassName(kind: ActivityDensityKind): string {
-  switch (kind) {
-    case "error":
-      return "bg-danger shadow-[0_0_10px_var(--ct-color-danger)]";
-    case "run":
-      return "bg-primary";
-    case "shortcut":
-      return "bg-warning";
-    case "edit":
-      return "bg-foreground/70";
-    case "silence":
-      return "bg-border";
-  }
 }

--- a/apps/web/src/features/player/__tests__/ReplayControls.test.tsx
+++ b/apps/web/src/features/player/__tests__/ReplayControls.test.tsx
@@ -144,7 +144,7 @@ describe("ReplayControls", () => {
     expect(screen.getAllByText("00:00")).toHaveLength(2);
   });
 
-  it("renders activity density markers on the progress timeline", () => {
+  it("does not render activity density as a second progress timeline", () => {
     const { container } = renderControls({
       durationMs: 60_000,
       activityDensity: [
@@ -155,22 +155,8 @@ describe("ReplayControls", () => {
       ],
     });
 
-    expect(screen.getByLabelText("活动：编辑 00:00-00:10")).toBeInTheDocument();
-    expect(screen.getByLabelText("活动：运行 00:20-00:30")).toBeInTheDocument();
-    expect(screen.getByLabelText("活动：错误 00:40-00:50")).toBeInTheDocument();
-    expect(screen.getByLabelText("活动：静默 00:50-01:00")).toBeInTheDocument();
-    expect(container.querySelector("[data-replay-activity-markers]")).toHaveClass("bottom-0");
-  });
-
-  it("renders short full-duration silence markers", () => {
-    renderControls({
-      durationMs: 5_000,
-      activityDensity: [
-        { kind: "silence", startMs: 0, endMs: 5_000, count: 0, eventSeqs: [] },
-      ],
-    });
-
-    expect(screen.getByLabelText("活动：静默 00:00-00:05")).toBeInTheDocument();
+    expect(screen.getAllByRole("slider", { name: "播放进度" })).toHaveLength(1);
+    expect(container.querySelector("[data-replay-activity-markers]")).not.toBeInTheDocument();
   });
 
   it.each(["loading", "seeking", "error"] as const)(


### PR DESCRIPTION
Fixes #277

## Summary

Fixes the replay UI showing two progress-like bars. The duplicate came from `ReplayControls` rendering the optional activity-density marker rail directly under the real seek slider, which visually read as a second playback progress bar.

## Changes

- Removed the activity marker rail from `ReplayControls` so the playback controls expose only one seek progress slider.
- Kept the `activityDensity` prop in the component API for compatibility, but no longer render it in the controls.
- Added a regression test that passes `activityDensity` and asserts there is exactly one `播放进度` slider and no replay activity marker rail.

## GitNexus impact

- Risk: MEDIUM
- Changed skeleton: `apps/web/src/features/player/ReplayControls.tsx`
- `detect_changes`: 2 files, 1 symbol (`ReplayControls`), 2 affected flows.
- `context ReplayControls`: incoming usage is from `ReplayPage`; outgoing dependencies are UI/time/volume helpers only. No scheduler, package, or schema impact found.

## Verification

- `npm run quality:predev`
- `npm run agent:bootstrap`
- `npm run test -w apps/web -- ReplayControls.test.tsx`
- `npm run test -w apps/web -- ReplayControls.test.tsx ReplayPage.test.tsx replayIndex.test.ts`
- `npm run lint:web`
- `git diff --check`
- `npm run contract:local`
- `npx --yes --prefer-offline gitnexus@1.6.5 detect_changes --repo code-tape`
- `npx --yes --prefer-offline gitnexus@1.6.5 context ReplayControls --repo code-tape`
- `npm run build -w apps/web`
- Visual Playwright check on `npm run dev`: 1 playback progress slider, 0 replay activity marker rails.
- Pre-commit `quality:precommit` passed.
- Pre-push `quality:local` passed, including 7/7 web e2e tests.
