### PR TITLE
[codex] preserve web language documents

### DIFF
--- a/apps/web/e2e/editor-shortcuts.spec.ts
+++ b/apps/web/e2e/editor-shortcuts.spec.ts
@@ -6,6 +6,7 @@ test("primary slash comments the current editor line", async ({ page }) => {
   await openRecorder(page);
 
   await page.keyboard.type("const commented = true;");
+  await expect(editorLines(page)).toContainText(/const[\s\u00a0]+commented[\s\u00a0]*=[\s\u00a0]*true;/);
   await page.keyboard.press(`${PRIMARY_MODIFIER}+/`);
 
   await expect(editorLines(page)).toContainText(/\/\/[\s\u00a0]*const[\s\u00a0]+commented[\s\u00a0]*=[\s\u00a0]*true;/);

--- a/apps/web/src/features/capture/__tests__/editorProducer.test.ts
+++ b/apps/web/src/features/capture/__tests__/editorProducer.test.ts
@@ -306,6 +306,42 @@ describe("createEditorProducer", () => {
     });
   });
 
+  it("does not emit editor events while running a programmatic restore", () => {
+    const env = setup();
+    const mounted = editor("before");
+    env.setEditor(mounted);
+
+    const producer = env.producer as typeof env.producer & {
+      runWithoutCapturingChanges(callback: () => void): void;
+    };
+    producer.runWithoutCapturingChanges(() => {
+      mounted.changeContent("restored", { changes: [{ text: "restored", rangeLength: 6 }] });
+      mounted.changeSelection({ lineNumber: 1, column: 5 }, {
+        startLineNumber: 1,
+        startColumn: 1,
+        endLineNumber: 1,
+        endColumn: 5,
+      });
+      mounted.changeScroll(120, 8);
+    });
+    vi.advanceTimersByTime(1_000);
+
+    expect(env.bus.drain()).toEqual([]);
+
+    mounted.changeContent("restored!", { changes: [{ text: "!" }] });
+    vi.advanceTimersByTime(300);
+
+    expect(env.bus.drain()).toEqual([
+      expect.objectContaining({
+        type: "content-change",
+        payload: expect.objectContaining({
+          code: "restored!",
+          changeReason: "input",
+        }),
+      }),
+    ]);
+  });
+
   it("flushes paste, undo, redo, pause, stop, and snapshot boundaries immediately", async () => {
     const env = setup();
     const mounted = editor("old");
@@ -552,6 +588,47 @@ describe("createEditorProducer", () => {
     env.producer.dispose();
     second.changeContent("disposed", { changes: [{ text: "disposed" }] });
     vi.advanceTimersByTime(300);
+    expect(env.bus.drain()).toEqual([]);
+  });
+
+  it("uses a caller-supplied reason when flushing pending content", () => {
+    const env = setup();
+    const mounted = editor();
+    env.setEditor(mounted);
+
+    mounted.changeContent("pending before language switch", { changes: [{ text: "pending before language switch" }] });
+    mounted.changeScroll(80, 2);
+    env.producer.flushPending("snapshot");
+
+    expect(env.bus.drain()).toEqual([
+      expect.objectContaining({
+        type: "content-change",
+        payload: expect.objectContaining({
+          code: "pending before language switch",
+          flushedBy: "snapshot",
+        }),
+      }),
+      expect.objectContaining({
+        type: "editor-scroll",
+        payload: { scrollTop: 80, scrollLeft: 2 },
+      }),
+    ]);
+  });
+
+  it("cancels queued scroll before running a programmatic restore", () => {
+    const env = setup();
+    const mounted = editor();
+    env.setEditor(mounted);
+
+    mounted.changeScroll(120, 8);
+    env.producer.runWithoutCapturingChanges(() => {
+      mounted.changeContent("restored", { changes: [{ text: "restored" }] });
+      mounted.changeScroll(4, 1);
+    });
+    vi.advanceTimersByTime(1_000);
+
+    expect(env.bus.drain()).toEqual([]);
+    env.producer.flushPending("snapshot");
     expect(env.bus.drain()).toEqual([]);
   });
 });

--- a/apps/web/src/features/capture/__tests__/runtimeProducer.test.ts
+++ b/apps/web/src/features/capture/__tests__/runtimeProducer.test.ts
@@ -133,6 +133,56 @@ describe("createRuntimeProducer", () => {
     expect(result.status).toBe("complete");
   });
 
+  it("combines stored HTML and CSS with the active JavaScript document for iframe runs", async () => {
+    const { compile, producer } = setup();
+
+    await producer.trigger({
+      language: "javascript",
+      source: "console.log(1);",
+      documents: {
+        html: '<div id="app">hi</div>',
+        css: "#app { color: red; }",
+        javascript: "console.log(1);",
+        typescript: "console.log('ts');",
+        python: "print('py')",
+      },
+      activeScriptLanguage: "javascript",
+    } as never);
+
+    const compiledSource = compile.mock.calls[0]?.[0] as string;
+    expect(compiledSource).toContain("document.body.innerHTML =");
+    expect(compiledSource).toContain('\\u003Cdiv id=\\"app\\"\\u003Ehi\\u003C/div\\u003E');
+    expect(compiledSource).toContain("#app { color: red; }");
+    expect(compiledSource).toContain("console.log(1);");
+    expect(compiledSource).not.toContain("console.log('ts');");
+    expect(compiledSource).not.toContain("print('py')");
+  });
+
+  it("escapes HTML script-data boundaries when composing web documents", async () => {
+    const { compile, producer } = setup();
+
+    await producer.trigger({
+      language: "javascript",
+      source: "console.log('ok');",
+      documents: {
+        html: "<div></script><!--\u2028</div>",
+        css: 'body::before { content: "</style></script>\u2029"; }',
+        javascript: "console.log('ok');",
+      },
+      activeScriptLanguage: "javascript",
+    } as never);
+
+    const compiledSource = compile.mock.calls[0]?.[0] as string;
+    expect(compiledSource).not.toMatch(/<\/script/i);
+    expect(compiledSource).not.toContain("<!--");
+    expect(compiledSource).not.toContain("\u2028");
+    expect(compiledSource).not.toContain("\u2029");
+    expect(compiledSource).toContain("\\u003C/script");
+    expect(compiledSource).toContain("\\u003C!--");
+    expect(compiledSource).toContain("\\u2028");
+    expect(compiledSource).toContain("\\u2029");
+  });
+
   it("emits run-error if HTML render throws", async () => {
     const { bus, producer } = setup({
       renderDocument: async () => {

--- a/apps/web/src/features/capture/editorProducer.ts
+++ b/apps/web/src/features/capture/editorProducer.ts
@@ -53,6 +53,7 @@ export const createEditorProducer: CreateEditorProducer = (deps): EditorProducer
   let pasteSignalPending = false;
   let formatSignalPending = false;
   let formatSignalToken = 0;
+  let suppressEditorChangeDepth = 0;
   let lastContentHash: string | null = null;
   let version = 0;
   let pausedState: ReplayStableState | null = null;
@@ -62,6 +63,7 @@ export const createEditorProducer: CreateEditorProducer = (deps): EditorProducer
   let disposed = false;
 
   const isListening = () => active && !paused && !stopped && !disposed;
+  const isCapturingEditorChanges = () => isListening() && suppressEditorChangeDepth === 0;
 
   const clearContentTimers = () => {
     if (debounceTimer) clearTimeout(debounceTimer);
@@ -136,7 +138,7 @@ export const createEditorProducer: CreateEditorProducer = (deps): EditorProducer
   };
 
   const emitSelection = (editor: MonacoEditor.IStandaloneCodeEditor) => {
-    if (!isListening()) return;
+    if (!isCapturingEditorChanges()) return;
     bus.emit({
       type: "selection-change",
       source: "editor",
@@ -150,7 +152,7 @@ export const createEditorProducer: CreateEditorProducer = (deps): EditorProducer
 
   const emitScroll = () => {
     scrollTimer = null;
-    if (!pendingScroll || !isListening()) {
+    if (!pendingScroll || !isCapturingEditorChanges()) {
       pendingScroll = null;
       return;
     }
@@ -164,8 +166,15 @@ export const createEditorProducer: CreateEditorProducer = (deps): EditorProducer
     });
   };
 
+  const emitPendingScroll = () => {
+    if (!pendingScroll) return;
+    if (scrollTimer) clearTimeout(scrollTimer);
+    scrollTimer = null;
+    emitScroll();
+  };
+
   const scheduleScroll = (editor: MonacoEditor.IStandaloneCodeEditor) => {
-    if (!isListening()) return;
+    if (!isCapturingEditorChanges()) return;
     pendingScroll = {
       scrollTop: editor.getScrollTop(),
       scrollLeft: editor.getScrollLeft(),
@@ -178,6 +187,12 @@ export const createEditorProducer: CreateEditorProducer = (deps): EditorProducer
     event: ContentChangedEvent,
   ) => {
     if (!isListening()) return;
+    if (suppressEditorChangeDepth > 0) {
+      pendingContent = null;
+      clearContentTimers();
+      lastContentHash = hashContent(getEditorValue(editor));
+      return;
+    }
     const changeReason = formatSignalPending
       ? "format"
       : pasteSignalPending
@@ -203,7 +218,7 @@ export const createEditorProducer: CreateEditorProducer = (deps): EditorProducer
   };
 
   const handlePasteSignal = () => {
-    if (!isListening()) return;
+    if (!isCapturingEditorChanges()) return;
     if (pendingContent) {
       pendingContent = { ...pendingContent, changeReason: "paste" };
       emitContent("paste");
@@ -216,7 +231,7 @@ export const createEditorProducer: CreateEditorProducer = (deps): EditorProducer
   };
 
   const handleFormatSignal = () => {
-    if (!isListening()) return () => {};
+    if (!isCapturingEditorChanges()) return () => {};
     const token = formatSignalToken + 1;
     formatSignalToken = token;
     formatSignalPending = true;
@@ -355,12 +370,24 @@ export const createEditorProducer: CreateEditorProducer = (deps): EditorProducer
       disposeEditorListeners();
       stopRebindPolling();
     },
-    flushPending() {
+    flushPending(reason = "run") {
       if (!isListening()) return;
-      emitContent("run");
+      emitContent(reason);
+      emitPendingScroll();
     },
     markNextChangeAsFormat() {
       return handleFormatSignal();
+    },
+    runWithoutCapturingChanges(callback) {
+      clearScrollTimer();
+      suppressEditorChangeDepth += 1;
+      try {
+        callback();
+      } finally {
+        suppressEditorChangeDepth -= 1;
+        pasteSignalPending = false;
+        formatSignalPending = false;
+      }
     },
     async takeSnapshot(): Promise<RecordingSnapshot | null> {
       syncEditor();
@@ -379,6 +406,7 @@ export const createEditorProducer: CreateEditorProducer = (deps): EditorProducer
       const from = readLanguage();
       if (from === next) return;
       emitContent("snapshot");
+      emitPendingScroll();
       const model = currentEditor.getModel();
       if (model) {
         deps.setModelLanguage?.(model, next);

--- a/apps/web/src/features/capture/runtimeProducer.ts
+++ b/apps/web/src/features/capture/runtimeProducer.ts
@@ -1,5 +1,6 @@
 import type {
   CreateRuntimeProducer,
+  RuntimeProducerRunInput,
   RuntimeProducerHandle,
   RuntimeProducerRunResult,
 } from "./types";
@@ -33,6 +34,43 @@ function buildRenderDocument(language: "html" | "css", source: string): string {
     "</main>",
     "</body>",
   ].join("");
+}
+
+function hasWebDocuments(input: RuntimeProducerRunInput): boolean {
+  return Boolean(input.documents);
+}
+
+function scriptSafeJson(value: string): string {
+  return JSON.stringify(value)
+    .replace(/</g, "\\u003C")
+    .replace(/>/g, "\\u003E")
+    .replace(/&/g, "\\u0026")
+    .replace(/\u2028/g, "\\u2028")
+    .replace(/\u2029/g, "\\u2029");
+}
+
+function composeWebDocumentScript(input: RuntimeProducerRunInput): {
+  language: "javascript" | "typescript";
+  source: string;
+} {
+  const documents = input.documents ?? {};
+  const activeScriptLanguage = input.activeScriptLanguage ?? (
+    input.language === "typescript" ? "typescript" : "javascript"
+  );
+  const html = documents.html ?? (input.language === "html" ? input.source : "");
+  const css = documents.css ?? (input.language === "css" ? input.source : "");
+  const scriptSource = documents[activeScriptLanguage] ?? (
+    input.language === activeScriptLanguage ? input.source : ""
+  );
+  const source = [
+    `document.body.innerHTML = ${scriptSafeJson(html)};`,
+    "const __codeTapeStyle = document.getElementById('code-tape-user-style') ?? document.createElement('style');",
+    "__codeTapeStyle.id = 'code-tape-user-style';",
+    `__codeTapeStyle.textContent = ${scriptSafeJson(css)};`,
+    "if (!__codeTapeStyle.parentElement) document.head.appendChild(__codeTapeStyle);",
+    scriptSource,
+  ].join("\n");
+  return { language: activeScriptLanguage, source };
 }
 
 export const createRuntimeProducer: CreateRuntimeProducer = (deps): RuntimeProducerHandle => {
@@ -135,8 +173,10 @@ export const createRuntimeProducer: CreateRuntimeProducer = (deps): RuntimeProdu
           },
         });
 
-        // HTML/CSS：渲染到只读（no-script）sandbox，不走 JS 编译/执行链路。
-        if (input.language === "html" || input.language === "css") {
+        // Legacy single-document HTML/CSS: render to a read-only sandbox.
+        // Multi-document web runs go through the script path so JS/TS can operate
+        // on the composed HTML/CSS document in the same iframe.
+        if (!hasWebDocuments(input) && (input.language === "html" || input.language === "css")) {
           let previewHtml: string;
           try {
             previewHtml = await runtime.renderDocument(buildRenderDocument(input.language, input.source));
@@ -158,9 +198,12 @@ export const createRuntimeProducer: CreateRuntimeProducer = (deps): RuntimeProdu
           };
         }
 
+        const compileInput = hasWebDocuments(input)
+          ? composeWebDocumentScript(input)
+          : { language: input.language as "javascript" | "typescript", source: input.source };
         let compiled: CompileResult;
         try {
-          compiled = await compiler.compile(input.source, input.language);
+          compiled = await compiler.compile(compileInput.source, compileInput.language);
         } catch (err) {
           return emitCompileError(runId, { ok: false, phase: "transpile", ...errorInfo(err) });
         }

--- a/apps/web/src/features/capture/types.ts
+++ b/apps/web/src/features/capture/types.ts
@@ -11,12 +11,14 @@
  */
 import type { editor as MonacoEditor } from "monaco-editor";
 import type {
+  ContentChangePayload,
   EventBus,
   EventProducer,
   MediaCapability,
   MediaDevicesController,
   RecordingClock,
   RecordingLanguage,
+  RecordingScriptLanguage,
   RecordingSnapshot,
 } from "@/shared/recording-schema";
 import type { IframeRunResult, IframeRuntime, PreviewCompiler } from "@/shared/recording-schema";
@@ -43,10 +45,12 @@ export type EditorProducerDeps = ProducerCommonDeps & {
 };
 
 export type EditorProducerHandle = EventProducer & {
-  /** Force-flush any pending content-change before the controller stops or pauses. */
-  flushPending(): void;
+  /** Force-flush any pending content-change at an explicit recorder boundary. */
+  flushPending(reason?: ContentChangePayload["flushedBy"]): void;
   /** Mark the next Monaco content-change as a format operation. Returns a cancel callback. */
   markNextChangeAsFormat(): () => void;
+  /** Run a programmatic editor update without recording content, selection, or scroll events. */
+  runWithoutCapturingChanges(callback: () => void): void;
   /** Take a stable-state snapshot of the editor for packageBuilder / resume-baseline. */
   takeSnapshot(): Promise<RecordingSnapshot | null>;
   /** Imperatively change the language (also emits the language-change event). */
@@ -128,16 +132,20 @@ export type RuntimeProducerRunResult =
       previewHtml: null;
     };
 
+export type RuntimeProducerRunInput = {
+  language: "javascript" | "typescript" | "html" | "css";
+  source: string;
+  documents?: Partial<Record<RecordingLanguage, string>>;
+  activeScriptLanguage?: RecordingScriptLanguage;
+};
+
 export type RuntimeProducerHandle = EventProducer & {
   /**
    * Compile + execute the user's source. Emits `run-start`, then exactly one of
    * `run-output` / `run-error` on completion. Returns the underlying iframe
    * result so the page UI can render console output during the run.
    */
-  trigger(input: {
-    language: "javascript" | "typescript" | "html" | "css";
-    source: string;
-  }): Promise<RuntimeProducerRunResult>;
+  trigger(input: RuntimeProducerRunInput): Promise<RuntimeProducerRunResult>;
 };
 
 export type CreateRuntimeProducer = (deps: RuntimeProducerDeps) => RuntimeProducerHandle;

--- a/apps/web/src/features/interview/interviewRealtimeReceiver.ts
+++ b/apps/web/src/features/interview/interviewRealtimeReceiver.ts
@@ -324,7 +324,13 @@ function isSelection(value: unknown): value is ReplayStableState["editor"]["sele
 }
 
 function isRecordingLanguage(value: unknown): value is ReplayStableState["editor"]["language"] {
-  return value === "javascript" || value === "typescript" || value === "python";
+  return (
+    value === "javascript"
+    || value === "typescript"
+    || value === "python"
+    || value === "html"
+    || value === "css"
+  );
 }
 
 function isRecordingTheme(value: unknown): value is ReplayStableState["editor"]["theme"] {

--- a/apps/web/src/features/recorder/RecorderPage.tsx
+++ b/apps/web/src/features/recorder/RecorderPage.tsx
@@ -34,10 +34,13 @@ import type {
   OpenStreamResult,
   RecordingControllerState,
   RecordingControllerStatus,
+  RecordingDocumentState,
+  RecordingEditorDocuments,
   RecordingLanguage,
   PackageBuildInput,
   RecordStartPayload,
   RunStartPayload,
+  RecordingScriptLanguage,
 } from "@/shared/recording-schema";
 
 const INITIAL_CONTROLLER_STATE: RecordingControllerState = {
@@ -66,6 +69,13 @@ const FONT_SIZE_OPTIONS = [12, 14, 16, 18, 20] as const;
 const AUTO_RUN_IDLE_MS = 2_000;
 const IDLE_CLEANUP_GRACE_MS = 50;
 const LIVE_DURATION_REFRESH_MS = 1000;
+const RECORDING_LANGUAGES: readonly RecordingLanguage[] = [
+  "javascript",
+  "typescript",
+  "python",
+  "html",
+  "css",
+];
 
 type DeviceOptions = {
   audio: DeviceInfo[];
@@ -81,6 +91,18 @@ type RecorderRuntimeState = {
   stderr: string[];
   errorMessage: string | null;
 };
+type EditorStateReader = {
+  getValue(): string;
+  setValue?(value: string): void;
+  getPosition?(): RecordingDocumentState["cursor"];
+  setPosition?(cursor: NonNullable<RecordingDocumentState["cursor"]>): void;
+  getSelection?(): RecordingDocumentState["selection"];
+  setSelection?(selection: NonNullable<RecordingDocumentState["selection"]>): void;
+  getScrollTop?(): number;
+  setScrollTop?(scrollTop: number): void;
+  getScrollLeft?(): number;
+  setScrollLeft?(scrollLeft: number): void;
+};
 
 /**
  * RecorderPage — wires the recording core (clock + bus + producers + builder
@@ -94,6 +116,8 @@ export function RecorderPage({ onEventBusReady }: RecorderPageProps = {}) {
   const navigate = useNavigate();
   const theme = useTheme();
   const editorRef = useRef<CodeEditorHandle | null>(null);
+  const editorDocumentsRef = useRef<RecordingEditorDocuments>(createEmptyEditorDocuments());
+  const activeScriptLanguageRef = useRef<RecordingScriptLanguage>("javascript");
   const mediaRecorderRef = useRef<ReturnType<typeof createMediaRecorderWrapper> | null>(null);
   const mountedRef = useRef(true);
   const startInFlightRef = useRef(false);
@@ -136,6 +160,7 @@ export function RecorderPage({ onEventBusReady }: RecorderPageProps = {}) {
       getCurrentLanguage: () => currentEditorLanguage,
       setModelLanguage: (_model, language) => {
         currentEditorLanguage = language;
+        if (isScriptLanguage(language)) activeScriptLanguageRef.current = language;
         editorRef.current?.setModelLanguage(language);
       },
     });
@@ -210,6 +235,7 @@ export function RecorderPage({ onEventBusReady }: RecorderPageProps = {}) {
       },
       setCurrentEditorLanguage: (language: RecordingLanguage) => {
         currentEditorLanguage = language;
+        if (isScriptLanguage(language)) activeScriptLanguageRef.current = language;
         editorRef.current?.setModelLanguage(language);
       },
       getCurrentEditorLanguage: () => currentEditorLanguage,
@@ -455,9 +481,12 @@ export function RecorderPage({ onEventBusReady }: RecorderPageProps = {}) {
       setMicrophoneEnabled(hasAudioTrack);
       setCameraEnabled(hasCameraTrack);
       stack.setCurrentMediaCapability(media.capability);
+      captureCurrentEditorDocument();
 
       const payload: RecordStartPayload = {
         initialLanguage: stack.getCurrentEditorLanguage(),
+        initialActiveScriptLanguage: activeScriptLanguageRef.current,
+        initialDocuments: cloneEditorDocuments(),
         initialFontSize: editorFontSize,
         initialTheme: theme.resolved,
         selectedAudioDeviceId: media.capability.selectedAudioDeviceId,
@@ -563,6 +592,61 @@ export function RecorderPage({ onEventBusReady }: RecorderPageProps = {}) {
     autoRunTimerRef.current = null;
   };
 
+  const captureCurrentEditorDocument = (
+    language: RecordingLanguage = stack.getCurrentEditorLanguage(),
+  ): RecordingDocumentState => {
+    const current = editorDocumentsRef.current[language];
+    const editor = editorRef.current?.getEditor() as EditorStateReader | null;
+    const next: RecordingDocumentState = editor
+      ? {
+          code: editor.getValue(),
+          cursor: editor.getPosition?.() ?? current.cursor,
+          selection: editor.getSelection?.() ?? current.selection,
+          scrollTop: editor.getScrollTop?.() ?? current.scrollTop,
+          scrollLeft: editor.getScrollLeft?.() ?? current.scrollLeft,
+        }
+      : current;
+    editorDocumentsRef.current = {
+      ...editorDocumentsRef.current,
+      [language]: next,
+    };
+    return next;
+  };
+
+  const editorDocumentsAsSources = (): Record<RecordingLanguage, string> => {
+    return RECORDING_LANGUAGES.reduce((documents, language) => {
+      documents[language] = editorDocumentsRef.current[language].code;
+      return documents;
+    }, {} as Record<RecordingLanguage, string>);
+  };
+
+  const cloneEditorDocuments = (): RecordingEditorDocuments => {
+    return RECORDING_LANGUAGES.reduce((documents, language) => {
+      const document = editorDocumentsRef.current[language];
+      documents[language] = {
+        code: document.code,
+        cursor: document.cursor ? { ...document.cursor } : null,
+        selection: document.selection ? { ...document.selection } : null,
+        scrollTop: document.scrollTop,
+        scrollLeft: document.scrollLeft,
+      };
+      return documents;
+    }, {} as RecordingEditorDocuments);
+  };
+
+  const restoreEditorDocument = (editor: EditorStateReader, document: RecordingDocumentState) => {
+    if (editor.getValue() !== document.code) {
+      editor.setValue?.(document.code);
+    }
+    if (document.selection) {
+      editor.setSelection?.(document.selection);
+    } else if (document.cursor) {
+      editor.setPosition?.(document.cursor);
+    }
+    editor.setScrollTop?.(document.scrollTop);
+    editor.setScrollLeft?.(document.scrollLeft);
+  };
+
   const isRuntimeRunLocked = () => {
     const status = stack.controller.state.status;
     return status === "paused" || status === "requestingPermission" || status === "stopping" || status === "processing";
@@ -576,12 +660,15 @@ export function RecorderPage({ onEventBusReady }: RecorderPageProps = {}) {
     if (runtimeLanguage === null) return;
     const editor = editorRef.current?.getEditor();
     if (!editor) return;
+    const activeDocument = captureCurrentEditorDocument();
     stack.editorProducer.flushPending();
     setRuntimeState({ status: "running", stdout: [], stderr: [], errorMessage: null });
     try {
       const result = await stack.runtimeProducer.trigger({
         language: runtimeLanguage,
-        source: editor.getValue(),
+        source: activeDocument.code,
+        documents: editorDocumentsAsSources(),
+        activeScriptLanguage: activeScriptLanguageRef.current,
       });
       if (result.status === "complete") {
         setRuntimeState({
@@ -626,11 +713,32 @@ export function RecorderPage({ onEventBusReady }: RecorderPageProps = {}) {
   };
 
   const handleLanguageChange = (next: RecordingLanguage) => {
-    setEditorLanguage(next);
-    stack.setCurrentEditorLanguage(next);
-    if (stack.controller.state.status === "recording") {
-      stack.editorProducer.setLanguage(next);
+    captureCurrentEditorDocument();
+    const nextDocument = editorDocumentsRef.current[next];
+    const isRecording = stack.controller.state.status === "recording";
+    if (isRecording) {
+      stack.editorProducer.flushPending("snapshot");
     }
+    setEditorLanguage(next);
+    if (isRecording) {
+      stack.editorProducer.setLanguage(next);
+    } else {
+      stack.setCurrentEditorLanguage(next);
+    }
+    const editor = editorRef.current?.getEditor() as EditorStateReader | null;
+    if (editor) {
+      if (isRecording) {
+        stack.editorProducer.runWithoutCapturingChanges(() => {
+          restoreEditorDocument(editor, nextDocument);
+        });
+      } else {
+        restoreEditorDocument(editor, nextDocument);
+      }
+    }
+  };
+  const handleEditorChange = () => {
+    captureCurrentEditorDocument();
+    scheduleAutoRun();
   };
   const displayControllerState = useMemo(
     () => ({ ...controllerState, durationMs: displayDurationMs }),
@@ -700,7 +808,7 @@ export function RecorderPage({ onEventBusReady }: RecorderPageProps = {}) {
               theme={theme.resolved}
               minHeight="compact"
               readOnly={controllerState.status === "paused"}
-              onChange={scheduleAutoRun}
+              onChange={handleEditorChange}
               onCommand={(command) => {
                 if (command === "run") void handleRun();
               }}
@@ -902,6 +1010,27 @@ function eventOnlyMedia(warnings: OpenStreamResult["warnings"] = []): OpenStream
     warnings,
     capability: INITIAL_CONTROLLER_STATE.mediaCapability,
   };
+}
+
+function isScriptLanguage(language: RecordingLanguage): language is RecordingScriptLanguage {
+  return language === "javascript" || language === "typescript";
+}
+
+function createEmptyEditorDocument(): RecordingDocumentState {
+  return {
+    code: "",
+    cursor: null,
+    selection: null,
+    scrollTop: 0,
+    scrollLeft: 0,
+  };
+}
+
+function createEmptyEditorDocuments(): RecordingEditorDocuments {
+  return RECORDING_LANGUAGES.reduce((documents, language) => {
+    documents[language] = createEmptyEditorDocument();
+    return documents;
+  }, {} as RecordingEditorDocuments);
 }
 
 function formatPermissionNotice(audio: PermissionStatus, camera: PermissionStatus): string {

--- a/apps/web/src/features/recorder/__tests__/RecorderPage.test.tsx
+++ b/apps/web/src/features/recorder/__tests__/RecorderPage.test.tsx
@@ -24,8 +24,37 @@ import type * as ReactRouterDom from "react-router-dom";
 const recorderPageMock = vi.hoisted(() => {
   const editorModel = {};
   const editorValue = { current: "" };
+  const editorPosition = { current: { lineNumber: 1, column: 1 } };
+  const editorSelection = {
+    current: {
+      startLineNumber: 1,
+      startColumn: 1,
+      endLineNumber: 1,
+      endColumn: 1,
+    },
+  };
+  const editorScroll = { top: 0, left: 0 };
   const editor = {
     getValue: vi.fn(() => editorValue.current),
+    setValue: vi.fn((next: string) => {
+      editorValue.current = next;
+    }),
+    getPosition: vi.fn(() => editorPosition.current),
+    setPosition: vi.fn((next: typeof editorPosition.current) => {
+      editorPosition.current = next;
+    }),
+    getSelection: vi.fn(() => editorSelection.current),
+    setSelection: vi.fn((next: typeof editorSelection.current) => {
+      editorSelection.current = next;
+    }),
+    getScrollTop: vi.fn(() => editorScroll.top),
+    setScrollTop: vi.fn((next: number) => {
+      editorScroll.top = next;
+    }),
+    getScrollLeft: vi.fn(() => editorScroll.left),
+    setScrollLeft: vi.fn((next: number) => {
+      editorScroll.left = next;
+    }),
     getModel: vi.fn(() => editorModel),
   };
   const audioTrack = { kind: "audio" } as MediaStreamTrack;
@@ -44,6 +73,7 @@ const recorderPageMock = vi.hoisted(() => {
   }));
   const flushPending = vi.fn();
   const markNextChangeAsFormat = vi.fn(() => vi.fn());
+  const runWithoutCapturingChanges = vi.fn((callback: () => void) => callback());
   const editorProducer = {
     start: vi.fn(),
     pause: vi.fn(),
@@ -52,6 +82,7 @@ const recorderPageMock = vi.hoisted(() => {
     dispose: vi.fn(),
     flushPending,
     markNextChangeAsFormat,
+    runWithoutCapturingChanges,
     takeSnapshot: vi.fn(async () => null),
     setLanguage: vi.fn((next: RecordingLanguage) => {
       editorProducerDeps?.setModelLanguage?.(editorModel as never, next);
@@ -166,6 +197,7 @@ const recorderPageMock = vi.hoisted(() => {
     navigate,
     trigger,
     flushPending,
+    runWithoutCapturingChanges,
     editorProducer,
     mediaProducer,
     pointerProducer,
@@ -198,12 +230,31 @@ const recorderPageMock = vi.hoisted(() => {
     },
     reset() {
       editorValue.current = "";
+      editorPosition.current = { lineNumber: 1, column: 1 };
+      editorSelection.current = {
+        startLineNumber: 1,
+        startColumn: 1,
+        endLineNumber: 1,
+        endColumn: 1,
+      };
+      editorScroll.top = 0;
+      editorScroll.left = 0;
       editor.getValue.mockClear();
+      editor.setValue.mockClear();
+      editor.getPosition.mockClear();
+      editor.setPosition.mockClear();
+      editor.getSelection.mockClear();
+      editor.setSelection.mockClear();
+      editor.getScrollTop.mockClear();
+      editor.setScrollTop.mockClear();
+      editor.getScrollLeft.mockClear();
+      editor.setScrollLeft.mockClear();
       editor.getModel.mockClear();
       setModelLanguage.mockClear();
       navigate.mockClear();
       trigger.mockClear();
       flushPending.mockClear();
+      runWithoutCapturingChanges.mockClear();
       getTracks.mockClear();
       getAudioTracks.mockClear();
       getVideoTracks.mockClear();
@@ -416,14 +467,130 @@ describe("RecorderPage", () => {
     fireEvent.click(screen.getByRole("button", { name: "运行代码" }));
 
     await waitFor(() =>
-      expect(recorderPageMock.trigger).toHaveBeenCalledWith({
+      expect(recorderPageMock.trigger).toHaveBeenCalledWith(expect.objectContaining({
+        activeScriptLanguage: "typescript",
         language: "typescript",
         source: "const value: number = 1;",
-      }),
+      })),
     );
     expect(recorderPageMock.flushPending).toHaveBeenCalledTimes(1);
     expect(recorderPageMock.flushPending.mock.invocationCallOrder[0]).toBeLessThan(
       recorderPageMock.trigger.mock.invocationCallOrder[0],
+    );
+  });
+
+  it("restores the last document content when switching back to a language", async () => {
+    const { RecorderPage } = await import("../RecorderPage");
+
+    render(<RecorderPage />);
+    const languageSelect = await screen.findByRole("combobox", { name: "语言" });
+
+    recorderPageMock.editorValue.current = "console.log(1);";
+    act(() => {
+      recorderPageMock.codeEditorProps?.onChange?.();
+    });
+    fireEvent.change(languageSelect, { target: { value: "html" } });
+
+    await waitFor(() =>
+      expect(recorderPageMock.codeEditorProps).toEqual(expect.objectContaining({ language: "html" })),
+    );
+    expect(recorderPageMock.editor.setValue).toHaveBeenLastCalledWith("");
+
+    recorderPageMock.editorValue.current = "<div>hi</div>";
+    act(() => {
+      recorderPageMock.codeEditorProps?.onChange?.();
+    });
+    fireEvent.change(languageSelect, { target: { value: "javascript" } });
+
+    await waitFor(() =>
+      expect(recorderPageMock.codeEditorProps).toEqual(expect.objectContaining({ language: "javascript" })),
+    );
+    expect(recorderPageMock.editor.setValue).toHaveBeenLastCalledWith("console.log(1);");
+  });
+
+  it("restores the last document view state when switching back to a language", async () => {
+    const { RecorderPage } = await import("../RecorderPage");
+
+    render(<RecorderPage />);
+    const languageSelect = await screen.findByRole("combobox", { name: "语言" });
+
+    recorderPageMock.editorValue.current = "console.log(1);\nconsole.log(2);";
+    recorderPageMock.editor.setPosition({ lineNumber: 2, column: 5 });
+    recorderPageMock.editor.setSelection({
+      startLineNumber: 2,
+      startColumn: 1,
+      endLineNumber: 2,
+      endColumn: 15,
+    });
+    recorderPageMock.editor.setScrollTop(128);
+    recorderPageMock.editor.setScrollLeft(24);
+    act(() => {
+      recorderPageMock.codeEditorProps?.onChange?.();
+    });
+
+    fireEvent.change(languageSelect, { target: { value: "html" } });
+    await waitFor(() =>
+      expect(recorderPageMock.codeEditorProps).toEqual(expect.objectContaining({ language: "html" })),
+    );
+
+    recorderPageMock.editorValue.current = "<main>\n  <div>hi</div>\n</main>";
+    recorderPageMock.editor.setPosition({ lineNumber: 3, column: 7 });
+    recorderPageMock.editor.setSelection({
+      startLineNumber: 2,
+      startColumn: 3,
+      endLineNumber: 2,
+      endColumn: 15,
+    });
+    recorderPageMock.editor.setScrollTop(256);
+    recorderPageMock.editor.setScrollLeft(8);
+    act(() => {
+      recorderPageMock.codeEditorProps?.onChange?.();
+    });
+
+    fireEvent.change(languageSelect, { target: { value: "javascript" } });
+    await waitFor(() =>
+      expect(recorderPageMock.codeEditorProps).toEqual(expect.objectContaining({ language: "javascript" })),
+    );
+
+    expect(recorderPageMock.editor.setSelection).toHaveBeenLastCalledWith({
+      startLineNumber: 2,
+      startColumn: 1,
+      endLineNumber: 2,
+      endColumn: 15,
+    });
+    expect(recorderPageMock.editor.setScrollTop).toHaveBeenLastCalledWith(128);
+    expect(recorderPageMock.editor.setScrollLeft).toHaveBeenLastCalledWith(24);
+  });
+
+  it("switches the recording producer before restoring a language document", async () => {
+    const { RecorderPage } = await import("../RecorderPage");
+
+    render(<RecorderPage />);
+    const languageSelect = await screen.findByRole("combobox", { name: "语言" });
+    fireEvent.click(screen.getByRole("button", { name: "开始录制" }));
+    await waitFor(() => expect(recorderPageMock.editorProducer.start).toHaveBeenCalledTimes(1));
+
+    recorderPageMock.editorValue.current = "console.log(1);";
+    act(() => {
+      recorderPageMock.codeEditorProps?.onChange?.();
+    });
+
+    fireEvent.change(languageSelect, { target: { value: "html" } });
+
+    await waitFor(() =>
+      expect(recorderPageMock.codeEditorProps).toEqual(expect.objectContaining({ language: "html" })),
+    );
+    expect(recorderPageMock.flushPending).toHaveBeenCalledWith("snapshot");
+    expect(recorderPageMock.flushPending.mock.invocationCallOrder[0]).toBeLessThan(
+      vi.mocked(recorderPageMock.editorProducer.setLanguage).mock.invocationCallOrder[0],
+    );
+    expect(recorderPageMock.editorProducer.setLanguage).toHaveBeenCalledWith("html");
+    expect(vi.mocked(recorderPageMock.editorProducer.setLanguage).mock.invocationCallOrder[0]).toBeLessThan(
+      recorderPageMock.editor.setValue.mock.invocationCallOrder[0],
+    );
+    expect(recorderPageMock.runWithoutCapturingChanges).toHaveBeenCalledTimes(1);
+    expect(recorderPageMock.runWithoutCapturingChanges.mock.invocationCallOrder[0]).toBeLessThan(
+      recorderPageMock.editor.setValue.mock.invocationCallOrder[0],
     );
   });
 
@@ -477,10 +644,10 @@ describe("RecorderPage", () => {
     });
 
     await waitFor(() =>
-      expect(recorderPageMock.trigger).toHaveBeenCalledWith({
+      expect(recorderPageMock.trigger).toHaveBeenCalledWith(expect.objectContaining({
         language: "javascript",
         source: "console.log('shortcut-run');",
-      }),
+      })),
     );
     expect(recorderPageMock.flushPending).toHaveBeenCalledTimes(1);
   });
@@ -526,10 +693,10 @@ describe("RecorderPage", () => {
         await flushAsyncWork();
       });
 
-      expect(recorderPageMock.trigger).toHaveBeenCalledWith({
+      expect(recorderPageMock.trigger).toHaveBeenCalledWith(expect.objectContaining({
         language: "javascript",
         source: "console.log('second-auto-run');",
-      });
+      }));
       expect(recorderPageMock.flushPending).toHaveBeenCalledTimes(1);
     } finally {
       vi.useRealTimers();
@@ -559,10 +726,10 @@ describe("RecorderPage", () => {
       });
 
       expect(recorderPageMock.trigger).toHaveBeenCalledTimes(1);
-      expect(recorderPageMock.trigger).toHaveBeenCalledWith({
+      expect(recorderPageMock.trigger).toHaveBeenCalledWith(expect.objectContaining({
         language: "javascript",
         source: "console.log('manual-run');",
-      });
+      }));
     } finally {
       vi.useRealTimers();
     }
@@ -632,10 +799,10 @@ describe("RecorderPage", () => {
     fireEvent.click(screen.getByRole("button", { name: "运行代码" }));
 
     await waitFor(() =>
-      expect(recorderPageMock.trigger).toHaveBeenCalledWith({
+      expect(recorderPageMock.trigger).toHaveBeenCalledWith(expect.objectContaining({
         language: "javascript",
         source: "console.log('strict-mode-ready');",
-      }),
+      })),
     );
   });
 

--- a/apps/web/src/features/recorder/__tests__/recordingController.test.ts
+++ b/apps/web/src/features/recorder/__tests__/recordingController.test.ts
@@ -6,6 +6,8 @@ import { createRecordingController } from "../recordingController";
 import type {
   EventProducer,
   PackageBuildInput,
+  RecordingEditorDocuments,
+  RecordingLanguage,
   RecordingPackageV1,
   RecordingRepository,
   RecordStartPayload,
@@ -67,6 +69,23 @@ function makeStartPayload(): RecordStartPayload {
       selectedCameraDeviceId: null,
     },
   };
+}
+
+function makeDocuments(
+  overrides: Partial<Record<RecordingLanguage, Partial<RecordingEditorDocuments[RecordingLanguage]>>> = {},
+): RecordingEditorDocuments {
+  const languages: RecordingLanguage[] = ["javascript", "typescript", "python", "html", "css"];
+  return languages.reduce((documents, language) => {
+    documents[language] = {
+      code: "",
+      cursor: null,
+      selection: null,
+      scrollTop: 0,
+      scrollLeft: 0,
+      ...overrides[language],
+    };
+    return documents;
+  }, {} as RecordingEditorDocuments);
 }
 
 function setup(
@@ -159,6 +178,41 @@ describe("createRecordingController", () => {
     await controller.stop("user");
     expect(repository.drafts.length).toBe(1);
     expect(repository.commits.length).toBe(1);
+  });
+
+  it("persists initial editor documents from the start payload into package metadata and snapshots", async () => {
+    const { controller, repository } = setup();
+    const initialDocuments = makeDocuments({
+      javascript: { code: "console.log('prepared');" },
+      html: { code: "<main>prepared</main>", scrollTop: 64 },
+      css: { code: "main { color: red; }" },
+    });
+
+    await controller.start({
+      ...makeStartPayload(),
+      initialLanguage: "html",
+      initialDocuments,
+      initialActiveScriptLanguage: "javascript",
+    } as RecordStartPayload);
+    const pkg = await controller.stop("user");
+
+    expect(pkg.meta).toMatchObject({
+      initialLanguage: "html",
+      initialActiveScriptLanguage: "javascript",
+      initialDocuments: {
+        javascript: expect.objectContaining({ code: "console.log('prepared');" }),
+        html: expect.objectContaining({ code: "<main>prepared</main>", scrollTop: 64 }),
+        css: expect.objectContaining({ code: "main { color: red; }" }),
+      },
+    });
+    expect(repository.drafts[0].snapshots[0].state.editor).toMatchObject({
+      code: "<main>prepared</main>",
+      language: "html",
+      documents: {
+        javascript: expect.objectContaining({ code: "console.log('prepared');" }),
+        css: expect.objectContaining({ code: "main { color: red; }" }),
+      },
+    });
   });
 
   it("saves recorder-side snapshots that include runtime and media state", async () => {

--- a/apps/web/src/features/recorder/recordingController.ts
+++ b/apps/web/src/features/recorder/recordingController.ts
@@ -182,6 +182,8 @@ export function createRecordingController(options: RecordingControllerOptions): 
               ownerId: null,
               creatorInfo: null,
               initialLanguage: startPayload.initialLanguage,
+              initialActiveScriptLanguage: startPayload.initialActiveScriptLanguage,
+              initialDocuments: startPayload.initialDocuments,
               initialFontSize: startPayload.initialFontSize,
               initialTheme: startPayload.initialTheme,
               mediaCapability: startPayload.mediaCapability,

--- a/apps/web/src/shared/recording-schema/__tests__/replayState.test.ts
+++ b/apps/web/src/shared/recording-schema/__tests__/replayState.test.ts
@@ -8,6 +8,8 @@ import {
   replayReducer,
   STABLE_EVENT_TYPES,
   type RecordingEvent,
+  type RecordingEditorDocuments,
+  type RecordingLanguage,
   type RecordingPackageV1,
 } from "@/shared/recording-schema";
 
@@ -37,6 +39,50 @@ describe("replay stable state contract", () => {
       cameraPosition: { x: 0, y: 0 },
     });
     expect(fromPackage.runtime.status).toBe("idle");
+  });
+
+  it("hydrates initial editor documents from package metadata and record-start payload", () => {
+    const initialDocuments = makeDocuments({
+      javascript: { code: "console.log('js');" },
+      typescript: { code: "const value: number = 1;" },
+      html: {
+        code: "<div>ready</div>",
+        cursor: { lineNumber: 1, column: 6 },
+        scrollTop: 32,
+      },
+      css: { code: "div { color: red; }" },
+    });
+    const pkg = makePackage();
+    pkg.meta = {
+      ...pkg.meta,
+      initialLanguage: "html",
+      initialDocuments,
+      initialActiveScriptLanguage: "typescript",
+    } as typeof pkg.meta;
+
+    const fromPackage = buildInitialReplayStateFromPackage(pkg);
+    const fromRecordStart = buildInitialReplayStateFromRecordStart({
+      initialLanguage: "html",
+      initialTheme: pkg.meta.initialTheme,
+      initialFontSize: pkg.meta.initialFontSize,
+      selectedAudioDeviceId: null,
+      selectedCameraDeviceId: null,
+      mediaCapability: pkg.meta.mediaCapability,
+      initialDocuments,
+      initialActiveScriptLanguage: "typescript",
+    } as Parameters<typeof buildInitialReplayStateFromRecordStart>[0]);
+
+    expect(fromRecordStart.editor).toEqual(fromPackage.editor);
+    expect(fromPackage.editor).toMatchObject({
+      code: "<div>ready</div>",
+      language: "html",
+      activeScriptLanguage: "typescript",
+      cursor: { lineNumber: 1, column: 6 },
+      scrollTop: 32,
+    });
+    expect(fromPackage.editor.documents?.javascript.code).toBe("console.log('js');");
+    expect(fromPackage.editor.documents?.typescript.code).toBe("const value: number = 1;");
+    expect(fromPackage.editor.documents?.css.code).toBe("div { color: red; }");
   });
 
   it("folds stable events while leaving transient events out of the stable contract", () => {
@@ -84,6 +130,67 @@ describe("replay stable state contract", () => {
     expect(state.editor.code).toBe("console.log('final frame');");
     expect(state.runtime.previewHtml).toBe("<main>P0</main>");
   });
+
+  it("preserves independent document contents when switching languages", () => {
+    const initial = buildInitialReplayStateFromPackage(makePackage());
+    const withJs = replayReducer(
+      initial,
+      contentChangeEvent(1, "console.log(1);", "javascript"),
+    );
+    const viewingHtml = replayReducer(withJs, languageChangeEvent(2, "javascript", "html"));
+    const withHtml = replayReducer(viewingHtml, contentChangeEvent(3, "<div>hi</div>", "html"));
+    const backToJs = replayReducer(withHtml, languageChangeEvent(4, "html", "javascript"));
+
+    expect(backToJs.editor.language).toBe("javascript");
+    expect(backToJs.editor.code).toBe("console.log(1);");
+    expect(backToJs.editor.activeScriptLanguage).toBe("javascript");
+    expect(backToJs.editor.documents?.javascript.code).toBe("console.log(1);");
+    expect(backToJs.editor.documents?.html.code).toBe("<div>hi</div>");
+  });
+
+  it("folds selection and scroll state into the active language document", () => {
+    const initial = buildInitialReplayStateFromPackage(makePackage());
+    const jsSelected = replayReducer(
+      initial,
+      selectionChangeEvent(
+        1,
+        { lineNumber: 2, column: 4 },
+        { startLineNumber: 2, startColumn: 1, endLineNumber: 2, endColumn: 12 },
+      ),
+    );
+    const jsScrolled = replayReducer(jsSelected, editorScrollEvent(2, 120, 8));
+    const viewingHtml = replayReducer(jsScrolled, languageChangeEvent(3, "javascript", "html"));
+    const htmlSelected = replayReducer(
+      viewingHtml,
+      selectionChangeEvent(
+        4,
+        { lineNumber: 1, column: 6 },
+        { startLineNumber: 1, startColumn: 1, endLineNumber: 1, endColumn: 15 },
+      ),
+    );
+    const htmlScrolled = replayReducer(htmlSelected, editorScrollEvent(5, 42, 0));
+    const backToJs = replayReducer(htmlScrolled, languageChangeEvent(6, "html", "javascript"));
+
+    expect(backToJs.editor).toMatchObject({
+      language: "javascript",
+      cursor: { lineNumber: 2, column: 4 },
+      selection: { startLineNumber: 2, startColumn: 1, endLineNumber: 2, endColumn: 12 },
+      scrollTop: 120,
+      scrollLeft: 8,
+    });
+    expect(backToJs.editor.documents?.javascript).toMatchObject({
+      cursor: { lineNumber: 2, column: 4 },
+      selection: { startLineNumber: 2, startColumn: 1, endLineNumber: 2, endColumn: 12 },
+      scrollTop: 120,
+      scrollLeft: 8,
+    });
+    expect(backToJs.editor.documents?.html).toMatchObject({
+      cursor: { lineNumber: 1, column: 6 },
+      selection: { startLineNumber: 1, startColumn: 1, endLineNumber: 1, endColumn: 15 },
+      scrollTop: 42,
+      scrollLeft: 0,
+    });
+  });
 });
 
 function makePackage(): RecordingPackageV1 {
@@ -121,7 +228,28 @@ function makePackage(): RecordingPackageV1 {
   };
 }
 
-function contentChangeEvent(seq: number, code: string): RecordingEvent {
+function makeDocuments(
+  overrides: Partial<Record<RecordingLanguage, Partial<RecordingEditorDocuments[RecordingLanguage]>>> = {},
+): RecordingEditorDocuments {
+  const languages: RecordingLanguage[] = ["javascript", "typescript", "python", "html", "css"];
+  return languages.reduce((documents, language) => {
+    documents[language] = {
+      code: "",
+      cursor: null,
+      selection: null,
+      scrollTop: 0,
+      scrollLeft: 0,
+      ...overrides[language],
+    };
+    return documents;
+  }, {} as RecordingEditorDocuments);
+}
+
+function contentChangeEvent(
+  seq: number,
+  code: string,
+  language: RecordingLanguage = "javascript",
+): RecordingEvent {
   return {
     id: `e-${seq}`,
     seq,
@@ -134,11 +262,60 @@ function contentChangeEvent(seq: number, code: string): RecordingEvent {
       version: seq,
       code,
       contentHash: `hash-${seq}`,
-      language: "javascript",
+      language,
       changeReason: "input",
       changeCount: 1,
       flushedBy: "debounce",
     },
+  };
+}
+
+function languageChangeEvent(
+  seq: number,
+  from: RecordingLanguage,
+  to: RecordingLanguage,
+): RecordingEvent {
+  return {
+    id: `e-${seq}`,
+    seq,
+    timestampMs: seq * 100,
+    source: "editor",
+    track: "main",
+    type: "language-change",
+    payload: { from, to },
+  };
+}
+
+function selectionChangeEvent(
+  seq: number,
+  cursor: { lineNumber: number; column: number },
+  selection: {
+    startLineNumber: number;
+    startColumn: number;
+    endLineNumber: number;
+    endColumn: number;
+  },
+): RecordingEvent {
+  return {
+    id: `e-${seq}`,
+    seq,
+    timestampMs: seq * 100,
+    source: "editor",
+    track: "main",
+    type: "selection-change",
+    payload: { cursor, selection },
+  };
+}
+
+function editorScrollEvent(seq: number, scrollTop: number, scrollLeft: number): RecordingEvent {
+  return {
+    id: `e-${seq}`,
+    seq,
+    timestampMs: seq * 100,
+    source: "editor",
+    track: "main",
+    type: "editor-scroll",
+    payload: { scrollTop, scrollLeft },
   };
 }
 

--- a/apps/web/src/shared/recording-schema/__tests__/validators.test.ts
+++ b/apps/web/src/shared/recording-schema/__tests__/validators.test.ts
@@ -69,6 +69,52 @@ describe("validateRecordingPackageV1", () => {
     expect(result.ok).toBe(false);
   });
 
+  it("rejects malformed initial editor document view state", () => {
+    const pkg = makePackage();
+    const initialDocuments = makeInitialDocuments();
+    initialDocuments.javascript.cursor = {} as never;
+    initialDocuments.html.selection = {
+      startLineNumber: "1",
+      startColumn: 1,
+      endLineNumber: 1,
+      endColumn: 1,
+    } as never;
+    pkg.meta.initialDocuments = initialDocuments;
+    pkg.events = [
+      {
+        id: "e-1",
+        seq: 1,
+        timestampMs: 0,
+        source: "recorder",
+        track: "main",
+        type: "record-start",
+        payload: {
+          initialLanguage: "javascript",
+          initialDocuments,
+          initialTheme: "dark",
+          initialFontSize: 14,
+          selectedAudioDeviceId: null,
+          selectedCameraDeviceId: null,
+          mediaCapability: pkg.meta.mediaCapability,
+        },
+      },
+    ];
+
+    const result = validateRecordingPackageV1(pkg);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.errors.map((error) => error.path)).toEqual(
+        expect.arrayContaining([
+          "meta.initialDocuments.javascript.cursor.lineNumber",
+          "meta.initialDocuments.html.selection.startLineNumber",
+          "events[0].payload.initialDocuments.javascript.cursor.lineNumber",
+          "events[0].payload.initialDocuments.html.selection.startLineNumber",
+        ]),
+      );
+    }
+  });
+
   it("rejects non-object inputs", () => {
     const result = validateRecordingPackageV1("not a package");
     expect(result.ok).toBe(false);
@@ -240,6 +286,20 @@ function mockContentChangeEvent(seq: number): RecordingEvent {
       flushedBy: "debounce",
     },
   };
+}
+
+function makeInitialDocuments(): NonNullable<RecordingPackageV1["meta"]["initialDocuments"]> {
+  const languages = ["javascript", "typescript", "python", "html", "css"] as const;
+  return languages.reduce((documents, language) => {
+    documents[language] = {
+      code: "",
+      cursor: null,
+      selection: null,
+      scrollTop: 0,
+      scrollLeft: 0,
+    };
+    return documents;
+  }, {} as NonNullable<RecordingPackageV1["meta"]["initialDocuments"]>);
 }
 
 describe("migrateRecordingPackage", () => {

--- a/docs/superpowers/specs/2026-06-01-web-language-documents-design.md
+++ b/docs/superpowers/specs/2026-06-01-web-language-documents-design.md
@@ -1,0 +1,160 @@
+# Web Language Documents Design
+
+## Context
+
+The recorder currently exposes a single language selector with JavaScript,
+TypeScript, HTML, CSS, and Python. The UI already allows choosing HTML and CSS,
+but the underlying editor behaves like one mutable document whose Monaco
+language changes over time. CSS preview is also limited because CSS is wrapped
+around a generated sample HTML scaffold instead of applying to the user's HTML.
+
+The product requirement is to keep the visible language list and switching
+entry unchanged while making each language preserve its own editor page state.
+
+## Goals
+
+- Keep the existing language choices: JavaScript, TypeScript, HTML, CSS, Python.
+- Keep the existing language selector as the switching entry.
+- Preserve independent content and editor view state per language.
+- Map HTML, CSS, and the active script language into one iframe preview.
+- Continue recording and replaying language switches with stable behavior.
+
+## Non-Goals
+
+- Do not replace the language selector with tabs.
+- Do not remove TypeScript or Python from the language list.
+- Do not execute Python in the iframe.
+- Do not change the visible recorder layout as part of this design.
+
+## Product Behavior
+
+Each language has its own editor page. When a user writes `console.log(1)` in
+JavaScript, switches to HTML, writes `<div>hi</div>`, then switches back to
+JavaScript, the editor restores the JavaScript document with `console.log(1)`
+and its last known cursor, selection, and scroll state.
+
+Running the preview combines the stored documents:
+
+- HTML is written into the iframe body.
+- CSS is written into a style element in the iframe head.
+- JavaScript is written into a module script.
+- TypeScript is transpiled, then written into a module script.
+- Python remains editable, recordable, and replayable, but does not execute.
+
+If both JavaScript and TypeScript contain content, only the most recently
+selected script language is executed. Switching to HTML, CSS, or Python does not
+change the selected script language.
+
+## Data Model
+
+Introduce a multi-document editor state for recorder and replay logic:
+
+```ts
+type RecordingDocumentLanguage =
+  | "javascript"
+  | "typescript"
+  | "python"
+  | "html"
+  | "css";
+
+type RecordingDocumentState = {
+  code: string;
+  cursor: ReplayStableState["editor"]["cursor"];
+  selection: ReplayStableState["editor"]["selection"];
+  scrollTop: number;
+  scrollLeft: number;
+};
+
+type RecordingEditorState = {
+  activeLanguage: RecordingDocumentLanguage;
+  activeScriptLanguage: "javascript" | "typescript";
+  documents: Record<RecordingDocumentLanguage, RecordingDocumentState>;
+  fontSize: number;
+  theme: RecordingTheme;
+};
+```
+
+The existing single-document fields can remain as a compatibility projection
+while the package format is migrated, but the replay source of truth should be
+the per-language document map once events are updated.
+
+## Recording Flow
+
+Before a language switch, the recorder saves the current Monaco value and view
+state into the current language's document state. It then loads the target
+language's stored state into the same Monaco editor instance and updates the
+Monaco model language.
+
+Content changes are emitted for the active language only. Language changes
+record the active language transition; switching to JavaScript or TypeScript
+also updates `activeScriptLanguage`.
+
+Before a run, the recorder flushes pending content for the active language, then
+passes the complete document map and `activeScriptLanguage` to the runtime
+producer.
+
+## Runtime Flow
+
+The runtime producer builds a single preview document:
+
+```html
+<!doctype html>
+<html>
+  <head>
+    <style>/* user CSS */</style>
+  </head>
+  <body>
+    <!-- user HTML -->
+    <script type="module">
+      // user JavaScript or transpiled TypeScript
+    </script>
+  </body>
+</html>
+```
+
+The implementation must avoid raw string interpolation for style and script
+contents where escaping matters. At minimum, it must prevent `</style>` and
+`</script>` from breaking out of their containers. A DOM-based assembly path is
+preferred when practical.
+
+Runtime output remains persisted as `run-output.previewHtml`. Replay continues
+to restore the historical iframe snapshot rather than re-running user code.
+
+## Replay Flow
+
+The replay reducer maintains all language document states and active language.
+The visible editor renders `documents[activeLanguage]`. Runtime preview restores
+the persisted `previewHtml` from run events.
+
+Seeking must restore:
+
+- active language
+- active script language
+- each language's last known code
+- the active language's cursor, selection, and scroll state
+- runtime output and preview snapshot
+
+## Compatibility And Documentation
+
+`docs/PRD.md` already requires frontend execution for JS/TS/CSS/HTML. Parts of
+`docs/技术方案.md` still describe the runtime and event payloads as JS/TS-only or
+JS/TS/Python-only. Before implementation changes are merged, the technical
+solution must be updated or the discrepancy must be raised through the
+repository discussion process required by `AGENTS.md`.
+
+## Test Plan
+
+- Unit test language switching preserves separate content and view state.
+- Unit test content events include the active document language.
+- Unit test JavaScript and TypeScript selection updates `activeScriptLanguage`.
+- Unit test runtime assembly maps HTML to body, CSS to style, and JS/TS to module
+  script.
+- Unit test Python remains non-executable.
+- Replay reducer tests cover seeking across content changes and language
+  changes.
+- Recorder page integration test covers JS to HTML back to JS restoration.
+
+## Open Decisions
+
+There are no open product decisions from this design. The confirmed behavior is
+that language kinds, switching entry, and switching method remain unchanged.

--- a/docs/技术方案.md
+++ b/docs/技术方案.md
@@ -290,6 +290,24 @@ export type RecordingManifest = {
   };
 };
 
+export type RecordingDocumentState = {
+  code: string;
+  cursor: { lineNumber: number; column: number } | null;
+  selection: {
+    startLineNumber: number;
+    startColumn: number;
+    endLineNumber: number;
+    endColumn: number;
+  } | null;
+  scrollTop: number;
+  scrollLeft: number;
+};
+
+export type RecordingEditorDocuments = Record<
+  "javascript" | "typescript" | "python" | "html" | "css",
+  RecordingDocumentState
+>;
+
 export type RecordingMeta = {
   id: string;
   title: string;
@@ -298,7 +316,9 @@ export type RecordingMeta = {
   appVersion: string;
   ownerId: string | null;
   creatorInfo: { displayName: string; source: "local" | "account" } | null;
-  initialLanguage: "javascript" | "typescript" | "python";
+  initialLanguage: "javascript" | "typescript" | "python" | "html" | "css";
+  initialActiveScriptLanguage?: "javascript" | "typescript";
+  initialDocuments?: RecordingEditorDocuments;
   initialFontSize: number;
   initialTheme: "light" | "dark";
   mediaCapability: MediaCapability;
@@ -427,7 +447,9 @@ export type RecordingEventTrack = "main" | "media" | "runtime" | "ui";
 
 ```ts
 export type RecordStartPayload = {
-  initialLanguage: "javascript" | "typescript" | "python";
+  initialLanguage: "javascript" | "typescript" | "python" | "html" | "css";
+  initialActiveScriptLanguage?: "javascript" | "typescript";
+  initialDocuments?: RecordingEditorDocuments;
   initialTheme: "light" | "dark";
   initialFontSize: number;
   selectedAudioDeviceId: string | null;
@@ -455,7 +477,7 @@ export type ContentChangePayload = {
   version: number;
   code: string;
   contentHash: string;
-  language: "javascript" | "typescript" | "python";
+  language: "javascript" | "typescript" | "python" | "html" | "css";
   changeReason: "input" | "paste" | "format" | "undo" | "redo" | "programmatic";
   changeCount: number;
   flushedBy:
@@ -472,8 +494,8 @@ export type ContentChangePayload = {
 };
 
 export type LanguageChangePayload = {
-  from: "javascript" | "typescript" | "python";
-  to: "javascript" | "typescript" | "python";
+  from: "javascript" | "typescript" | "python" | "html" | "css";
+  to: "javascript" | "typescript" | "python" | "html" | "css";
 };
 
 export type SelectionChangePayload = {
@@ -515,7 +537,7 @@ export type MediaWarningPayload = {
 };
 export type CameraPositionPayload = { x: number; y: number };
 export type RunStartPayload = {
-  language: "javascript" | "typescript";
+  language: "javascript" | "typescript" | "html" | "css";
   runtime: "iframe";
   runId: string;
 };
@@ -542,7 +564,7 @@ export type ChapterMarkerPayload = { title: string; note?: string };
 
 | 类型               | source     | 是否影响稳定状态  | payload                                                                       |
 | ------------------ | ---------- | ----------------- | ----------------------------------------------------------------------------- |
-| `record-start`     | recorder   | 是                | 初始语言、主题、字号、设备与媒体能力                                          |
+| `record-start`     | recorder   | 是                | 初始语言、初始多文档、最近活跃脚本语言、主题、字号、设备与媒体能力            |
 | `record-pause`     | recorder   | 是                | 暂停点                                                                        |
 | `record-resume`    | recorder   | 是                | 继续点                                                                        |
 | `resume-baseline`  | recorder   | 是                | 暂停期间状态变化后的完整稳定状态                                              |
@@ -1232,7 +1254,15 @@ function acceptRuntimeMessage(
 - P1+ 若需要运行不可信长任务，再评估独立 origin iframe 或后端/容器沙箱，避免把 P0 Demo 扩成安全沙箱项目。
 - 任何 `previewHtml` 回放都只能写入新的 sandbox iframe，不能 `innerHTML` 到宿主 DOM。
 
-`previewCompiler` 把源码转成可注入 iframe 的脚本字符串。P0 只识别 JS/TS，TS 走懒加载 transpile：
+录制页的语言入口保持为单个语言选择器，但编辑状态按语言分文档保存：
+
+- `javascript`、`typescript`、`html`、`css`、`python` 各自保留最后一次编辑内容、光标、选择区和滚动位置。
+- 切换语言时先保存当前语言文档，再恢复目标语言文档；UI 不改成 tab。
+- 点击运行时会把 `html` 文档映射到 iframe `body`，`css` 文档映射到 `style`，最近选择过的 `javascript` 或 `typescript` 文档作为脚本执行。
+- 如果 JS 和 TS 都有内容，只执行最近选择过的脚本语言；切到 HTML/CSS/Python 不改变该脚本语言选择。
+- Python 只参与编辑、录制和回放，不进入 iframe 执行。
+
+`previewCompiler` 把脚本文档转成可注入 iframe 的脚本字符串。P0 对 JS 透传，对 TS 走懒加载 transpile；HTML/CSS 由 runtime producer 组合成脚本前置的 DOM/style 注入逻辑：
 
 ```ts
 export type CompileLanguage = "javascript" | "typescript";
@@ -1280,6 +1310,10 @@ export type IframeRuntime = {
   run(input: IframeRunInput): Promise<IframeRunResult>;
   // Replay an existing previewHtml into a read-only sandbox iframe. Never writes to host DOM.
   renderPreview(previewHtml: string): Promise<void>;
+  // Render static HTML/CSS preview markup into a no-script sandbox and return sanitized markup.
+  renderDocument(html: string): Promise<string>;
+  // Sync host theme defaults into the sandbox preview/runtime.
+  setTheme(theme: "light" | "dark"): void;
   // Tears down the current iframe and clears pending run state; safe to call repeatedly.
   reset(): void;
   destroy(): void;
@@ -1950,7 +1984,7 @@ export type CloudRecording = {
   deletedAt: string | null;
   purgedAt: string | null;
   durationMs: number;
-  initialLanguage: "javascript" | "typescript" | "python";
+  initialLanguage: "javascript" | "typescript" | "python" | "html" | "css";
   hasAudio: boolean;
   hasCamera: boolean;
   mediaSizeBytes: number;
@@ -2357,7 +2391,7 @@ export type CreateUploadSessionRequest = {
   title: string;
   schemaVersion: string;
   durationMs: number;
-  initialLanguage: "javascript" | "typescript" | "python";
+  initialLanguage: "javascript" | "typescript" | "python" | "html" | "css";
   hasAudio: boolean;
   hasCamera: boolean;
   assets: Array<{

--- a/packages/recording-schema/src/replayState.ts
+++ b/packages/recording-schema/src/replayState.ts
@@ -2,15 +2,89 @@ import type {
   RecordingEvent,
   RecordingPackageV1,
   RecordStartPayload,
+  RecordingDocumentState,
+  RecordingEditorDocuments,
+  RecordingLanguage,
+  RecordingScriptLanguage,
   ReplayReducer,
   ReplayStableState,
 } from "./types.js";
 
 type InitialReplayStateInput = {
   initialLanguage: ReplayStableState["editor"]["language"];
+  initialActiveScriptLanguage?: RecordingScriptLanguage;
+  initialDocuments?: RecordingEditorDocuments;
   initialFontSize: number;
   initialTheme: ReplayStableState["editor"]["theme"];
 };
+
+const RECORDING_LANGUAGES: readonly RecordingLanguage[] = [
+  "javascript",
+  "typescript",
+  "python",
+  "html",
+  "css",
+];
+
+function isScriptLanguage(language: RecordingLanguage): language is RecordingScriptLanguage {
+  return language === "javascript" || language === "typescript";
+}
+
+function emptyDocumentState(): RecordingDocumentState {
+  return {
+    code: "",
+    cursor: null,
+    selection: null,
+    scrollTop: 0,
+    scrollLeft: 0,
+  };
+}
+
+function buildEmptyDocuments(): RecordingEditorDocuments {
+  return RECORDING_LANGUAGES.reduce((documents, language) => {
+    documents[language] = emptyDocumentState();
+    return documents;
+  }, {} as RecordingEditorDocuments);
+}
+
+function cloneDocumentState(document: RecordingDocumentState): RecordingDocumentState {
+  return {
+    code: document.code,
+    cursor: document.cursor ? { ...document.cursor } : null,
+    selection: document.selection ? { ...document.selection } : null,
+    scrollTop: document.scrollTop,
+    scrollLeft: document.scrollLeft,
+  };
+}
+
+function buildInitialDocuments(documents?: RecordingEditorDocuments): RecordingEditorDocuments {
+  const empty = buildEmptyDocuments();
+  if (!documents) return empty;
+  return RECORDING_LANGUAGES.reduce((nextDocuments, language) => {
+    nextDocuments[language] = documents[language]
+      ? cloneDocumentState(documents[language])
+      : emptyDocumentState();
+    return nextDocuments;
+  }, {} as RecordingEditorDocuments);
+}
+
+function ensureDocuments(editor: ReplayStableState["editor"]): RecordingEditorDocuments {
+  if (editor.documents) return editor.documents;
+  return {
+    ...buildEmptyDocuments(),
+    [editor.language]: {
+      code: editor.code,
+      cursor: editor.cursor,
+      selection: editor.selection,
+      scrollTop: editor.scrollTop,
+      scrollLeft: editor.scrollLeft,
+    },
+  };
+}
+
+function activeScriptLanguageFor(language: RecordingLanguage): RecordingScriptLanguage {
+  return isScriptLanguage(language) ? language : "javascript";
+}
 
 export function buildInitialReplayStateFromPackage(pkg: RecordingPackageV1): ReplayStableState {
   return buildInitialReplayState(pkg.meta);
@@ -50,38 +124,93 @@ export const replayReducer: ReplayReducer = (
   event: RecordingEvent,
 ): ReplayStableState => {
   switch (event.type) {
-    case "content-change":
-      return {
-        ...state,
-        editor: {
-          ...state.editor,
+    case "content-change": {
+      const documents = ensureDocuments(state.editor);
+      const language = event.payload.language;
+      const currentDocument = documents[language] ?? emptyDocumentState();
+      const nextDocuments = {
+        ...documents,
+        [language]: {
+          ...currentDocument,
           code: event.payload.code,
-          language: event.payload.language,
         },
       };
-    case "language-change":
-      return {
-        ...state,
-        editor: { ...state.editor, language: event.payload.to },
-      };
-    case "selection-change":
       return {
         ...state,
         editor: {
           ...state.editor,
+          documents: nextDocuments,
+          code: event.payload.code,
+          language,
+          activeScriptLanguage: isScriptLanguage(language)
+            ? language
+            : state.editor.activeScriptLanguage ?? activeScriptLanguageFor(state.editor.language),
+        },
+      };
+    }
+    case "language-change": {
+      const documents = ensureDocuments(state.editor);
+      const nextLanguage = event.payload.to;
+      const nextDocument = documents[nextLanguage] ?? emptyDocumentState();
+      return {
+        ...state,
+        editor: {
+          ...state.editor,
+          documents,
+          language: nextLanguage,
+          code: nextDocument.code,
+          cursor: nextDocument.cursor,
+          selection: nextDocument.selection,
+          scrollTop: nextDocument.scrollTop,
+          scrollLeft: nextDocument.scrollLeft,
+          activeScriptLanguage: isScriptLanguage(nextLanguage)
+            ? nextLanguage
+            : state.editor.activeScriptLanguage ?? activeScriptLanguageFor(state.editor.language),
+        },
+      };
+    }
+    case "selection-change": {
+      const documents = ensureDocuments(state.editor);
+      const currentDocument = documents[state.editor.language] ?? emptyDocumentState();
+      const nextDocuments = {
+        ...documents,
+        [state.editor.language]: {
+          ...currentDocument,
           cursor: event.payload.cursor,
           selection: event.payload.selection,
         },
       };
-    case "editor-scroll":
       return {
         ...state,
         editor: {
           ...state.editor,
+          documents: nextDocuments,
+          cursor: event.payload.cursor,
+          selection: event.payload.selection,
+        },
+      };
+    }
+    case "editor-scroll": {
+      const documents = ensureDocuments(state.editor);
+      const currentDocument = documents[state.editor.language] ?? emptyDocumentState();
+      const nextDocuments = {
+        ...documents,
+        [state.editor.language]: {
+          ...currentDocument,
           scrollTop: event.payload.scrollTop,
           scrollLeft: event.payload.scrollLeft,
         },
       };
+      return {
+        ...state,
+        editor: {
+          ...state.editor,
+          documents: nextDocuments,
+          scrollTop: event.payload.scrollTop,
+          scrollLeft: event.payload.scrollLeft,
+        },
+      };
+    }
     case "media-toggle":
       return {
         ...state,
@@ -158,14 +287,18 @@ export const STABLE_EVENT_TYPES = new Set<RecordingEvent["type"]>([
 ]);
 
 function buildInitialReplayState(input: InitialReplayStateInput): ReplayStableState {
+  const documents = buildInitialDocuments(input.initialDocuments);
+  const initialDocument = documents[input.initialLanguage] ?? emptyDocumentState();
   return {
     editor: {
-      code: "",
+      code: initialDocument.code,
       language: input.initialLanguage,
-      cursor: null,
-      selection: null,
-      scrollTop: 0,
-      scrollLeft: 0,
+      activeScriptLanguage: input.initialActiveScriptLanguage ?? activeScriptLanguageFor(input.initialLanguage),
+      documents,
+      cursor: initialDocument.cursor,
+      selection: initialDocument.selection,
+      scrollTop: initialDocument.scrollTop,
+      scrollLeft: initialDocument.scrollLeft,
       fontSize: input.initialFontSize,
       theme: input.initialTheme,
     },

--- a/packages/recording-schema/src/types.ts
+++ b/packages/recording-schema/src/types.ts
@@ -16,7 +16,23 @@ export type RecordingSchemaVersion = typeof RECORDING_SCHEMA_VERSION;
 // ─────────────────────────────────────────────────────────────────────────────
 
 export type RecordingLanguage = "javascript" | "typescript" | "python" | "html" | "css";
+export type RecordingScriptLanguage = "javascript" | "typescript";
 export type RecordingTheme = "light" | "dark";
+export type EditorCursor = { lineNumber: number; column: number } | null;
+export type EditorSelection = {
+  startLineNumber: number;
+  startColumn: number;
+  endLineNumber: number;
+  endColumn: number;
+} | null;
+export type RecordingDocumentState = {
+  code: string;
+  cursor: EditorCursor;
+  selection: EditorSelection;
+  scrollTop: number;
+  scrollLeft: number;
+};
+export type RecordingEditorDocuments = Record<RecordingLanguage, RecordingDocumentState>;
 
 export type MediaCapability = {
   audio: "available" | "denied" | "not-found" | "busy" | "unsupported";
@@ -34,6 +50,8 @@ export type RecordingMeta = {
   ownerId: string | null;
   creatorInfo: { displayName: string; source: "local" | "account" } | null;
   initialLanguage: RecordingLanguage;
+  initialActiveScriptLanguage?: RecordingScriptLanguage;
+  initialDocuments?: RecordingEditorDocuments;
   initialFontSize: number;
   initialTheme: RecordingTheme;
   mediaCapability: MediaCapability;
@@ -118,6 +136,8 @@ export type BaseRecordingEvent<
 
 export type RecordStartPayload = {
   initialLanguage: RecordingLanguage;
+  initialActiveScriptLanguage?: RecordingScriptLanguage;
+  initialDocuments?: RecordingEditorDocuments;
   initialTheme: RecordingTheme;
   initialFontSize: number;
   selectedAudioDeviceId: string | null;
@@ -146,13 +166,8 @@ export type ContentChangePayload = {
 export type LanguageChangePayload = { from: RecordingLanguage; to: RecordingLanguage };
 
 export type SelectionChangePayload = {
-  cursor: { lineNumber: number; column: number } | null;
-  selection: {
-    startLineNumber: number;
-    startColumn: number;
-    endLineNumber: number;
-    endColumn: number;
-  } | null;
+  cursor: EditorCursor;
+  selection: EditorSelection;
 };
 
 export type EditorScrollPayload = { scrollTop: number; scrollLeft: number };
@@ -241,13 +256,10 @@ export type ReplayStableState = {
   editor: {
     code: string;
     language: RecordingLanguage;
-    cursor: { lineNumber: number; column: number } | null;
-    selection: {
-      startLineNumber: number;
-      startColumn: number;
-      endLineNumber: number;
-      endColumn: number;
-    } | null;
+    activeScriptLanguage?: RecordingScriptLanguage;
+    documents?: RecordingEditorDocuments;
+    cursor: EditorCursor;
+    selection: EditorSelection;
     scrollTop: number;
     scrollLeft: number;
     fontSize: number;

--- a/packages/recording-schema/src/validators.ts
+++ b/packages/recording-schema/src/validators.ts
@@ -121,6 +121,12 @@ function validateMeta(value: unknown, errors: SchemaValidationIssue[]): void {
       "initialLanguage must be one of javascript|typescript|python|html|css",
     );
   }
+  if ("initialActiveScriptLanguage" in value && typeof value.initialActiveScriptLanguage !== "undefined") {
+    expectOneOf(value.initialActiveScriptLanguage, ["javascript", "typescript"], "meta.initialActiveScriptLanguage", errors);
+  }
+  if ("initialDocuments" in value && typeof value.initialDocuments !== "undefined") {
+    validateEditorDocuments(value.initialDocuments, "meta.initialDocuments", errors);
+  }
   expectNumber(value.initialFontSize, "meta.initialFontSize", errors);
   if (value.initialTheme !== "light" && value.initialTheme !== "dark") {
     pushIssue(errors, "meta.initialTheme", "initialTheme must be light or dark");
@@ -168,6 +174,12 @@ function validateEventPayload(
   switch (type) {
     case "record-start":
       expectLanguage(payload.initialLanguage, `${path}.initialLanguage`, errors);
+      if ("initialActiveScriptLanguage" in payload && typeof payload.initialActiveScriptLanguage !== "undefined") {
+        expectOneOf(payload.initialActiveScriptLanguage, ["javascript", "typescript"], `${path}.initialActiveScriptLanguage`, errors);
+      }
+      if ("initialDocuments" in payload && typeof payload.initialDocuments !== "undefined") {
+        validateEditorDocuments(payload.initialDocuments, `${path}.initialDocuments`, errors);
+      }
       expectTheme(payload.initialTheme, `${path}.initialTheme`, errors);
       expectNumber(payload.initialFontSize, `${path}.initialFontSize`, errors);
       expectNullableString(payload.selectedAudioDeviceId, `${path}.selectedAudioDeviceId`, errors);
@@ -297,6 +309,48 @@ function expectLiteral<T extends string | number>(value: unknown, expected: T, p
 
 function expectOneOf<T extends string | number>(value: unknown, allowed: readonly T[], path: string, errors: SchemaValidationIssue[]): void {
   if (!allowed.includes(value as T)) pushIssue(errors, path, `expected one of ${allowed.join("|")}`);
+}
+
+function validateEditorDocuments(value: unknown, path: string, errors: SchemaValidationIssue[]): void {
+  if (!isPlainObject(value)) {
+    pushIssue(errors, path, "initialDocuments must be an object");
+    return;
+  }
+  for (const language of LANGUAGES) {
+    const document = value[language];
+    const documentPath = `${path}.${language}`;
+    if (!isPlainObject(document)) {
+      pushIssue(errors, documentPath, "document must be an object");
+      continue;
+    }
+    expectString(document.code, `${documentPath}.code`, errors);
+    validateEditorCursor(document.cursor, `${documentPath}.cursor`, errors);
+    validateEditorSelection(document.selection, `${documentPath}.selection`, errors);
+    expectNumber(document.scrollTop, `${documentPath}.scrollTop`, errors);
+    expectNumber(document.scrollLeft, `${documentPath}.scrollLeft`, errors);
+  }
+}
+
+function validateEditorCursor(value: unknown, path: string, errors: SchemaValidationIssue[]): void {
+  if (value === null) return;
+  if (!isPlainObject(value)) {
+    pushIssue(errors, path, "expected object or null");
+    return;
+  }
+  expectNumber(value.lineNumber, `${path}.lineNumber`, errors);
+  expectNumber(value.column, `${path}.column`, errors);
+}
+
+function validateEditorSelection(value: unknown, path: string, errors: SchemaValidationIssue[]): void {
+  if (value === null) return;
+  if (!isPlainObject(value)) {
+    pushIssue(errors, path, "expected object or null");
+    return;
+  }
+  expectNumber(value.startLineNumber, `${path}.startLineNumber`, errors);
+  expectNumber(value.startColumn, `${path}.startColumn`, errors);
+  expectNumber(value.endLineNumber, `${path}.endLineNumber`, errors);
+  expectNumber(value.endColumn, `${path}.endColumn`, errors);
 }
 
 function validateSnapshot(value: unknown, index: number, errors: SchemaValidationIssue[]): void {

--- a/scripts/tests/workflow-rules.test.mjs
+++ b/scripts/tests/workflow-rules.test.mjs
@@ -679,6 +679,17 @@ test('technical plan owns P1 plus WebRTC interview architecture and jitter recov
   assert.match(technicalPlan, /远端媒体保存扩展属于完整方案，需要产品确认后再实现/u);
 });
 
+test('technical plan keeps web language documents mapped to the iframe runtime', () => {
+  const technicalPlan = readFileSync('docs/技术方案.md', 'utf8');
+
+  assert.match(technicalPlan, /`javascript`、`typescript`、`html`、`css`、`python` 各自保留最后一次编辑内容/u);
+  assert.match(technicalPlan, /`html` 文档映射到 iframe `body`/u);
+  assert.match(technicalPlan, /`css` 文档映射到 `style`/u);
+  assert.match(technicalPlan, /最近选择过的 `javascript` 或 `typescript` 文档作为脚本执行/u);
+  assert.match(technicalPlan, /JS 和 TS 都有内容，只执行最近选择过的脚本语言/u);
+  assert.match(technicalPlan, /Python 只参与编辑、录制和回放，不进入 iframe 执行/u);
+});
+
 test('repository text does not reference the standalone cloud plan path', () => {
   const trackedFiles = execFileSync('git', ['ls-files'], {
     encoding: 'utf8',


### PR DESCRIPTION
## 关联

Closes #279

Refs #2（总控 issue，不在本 PR 中关闭）

## 改动点

- 为录制/回放 schema 增加按语言拆分的 editor documents，并记录 JS/TS 最近活跃脚本语言。
- 语言选择器保持不变，但切换语言时会恢复该语言上次编辑内容、cursor、selection 和 scroll；HTML/CSS/JS/TS/Python 各自保留独立文档。
- 运行时将 HTML 映射到 iframe body、CSS 映射到 style、JS/TS 映射到 script；Python 仍只编辑/录制/回放，不执行。
- 若 JS 和 TS 同时有内容，运行最近一次选择过的脚本语言。
- 录制开始时把完整初始 documents 和 activeScriptLanguage 写入 record-start/meta/snapshot，避免录制前准备好的 HTML/CSS/另一脚本语言在回放中丢失。
- 录制态切换语言时先 flush 当前 pending content/scroll，再切换 producer 语言，并抑制 programmatic restore 的编辑事件，避免恢复内容或旧滚动污染事件流。
- runtime 对进入内联 script-data 上下文的 HTML/CSS 字符串做额外转义，覆盖 `</script>`、`</style>`、`<!--`、U+2028/U+2029 等边界。
- 为 `initialDocuments` 增加严格 cursor/selection 字段校验，拒绝缺字段或非数字坐标。
- 更新实时接收语言校验、技术方案文档和相关单元/e2e 覆盖。

## 影响范围

- RecorderPage 的语言切换、录制开始 payload、运行按钮和自动运行输入源。
- editorProducer 的 pending content/scroll flush 与 programmatic restore suppression 时序。
- recordingController/package meta/snapshot 初始 editor state 保存链路。
- runtimeProducer 的 HTML/CSS 兼容渲染、多文档 web 组合执行路径和 script-data 转义。
- replayReducer/buildInitialReplayState 的 content/language/selection/scroll/initial documents 状态折叠逻辑。
- recording-schema validators 对多文档 editor state 的公共契约校验。
- interview realtime receiver 对 HTML/CSS editor state 的接受范围。

## GitNexus 影响分析摘要

- 风险等级: HIGH
- 关键骨架变更: 涉及 recording-schema、replay 初始状态、RecorderPage、recordingController、editorProducer、runtimeProducer 与 authority-docs。
- GitNexus 影响面: 已运行 detect_changes(scope=all)，并使用 context/impact 查看 `buildInitialReplayState`、`createRecordingController`、`runWithoutCapturingChanges`、`composeWebDocumentScript` 与 `validateEditorDocuments` 等触达符号；影响集中在 `ReplayStableState.editor.documents`/`activeScriptLanguage`、record-start/meta initial documents、语言切换事件边界、iframe runtime 多文档组合执行和 validators 公共契约。
- 验证结果: `npm run quality:predev`、`npm run agent:bootstrap`、`npm run quality:local`、`npm run test:web -- validators replayState runtimeProducer editorProducer recordingController RecorderPage packageBuilder snapshotBuilder`、`npm run lint:web`、`git diff --check`、`node --test scripts/tests/workflow-rules.test.mjs` 均通过。
- 最新增量分析: 修复 runtime script-data 转义、cursor/selection validator 与 stale scroll flush 后，GitNexus detect_changes(scope=all) 对该增量报告风险 LOW，影响集中在 `composeWebDocumentScript` 与 `validateEditorDocuments`。
- 已按 repo-guard 反馈补齐: view state restore、programmatic restore suppression、语言切换前 pending content/scroll flush、录制包初始 documents、runtime escaping、严格 validators、restore 后 stale scroll 清理。

## 验证

- `npm run quality:predev`
- `npm run agent:bootstrap`
- `npm run quality:local`
- `npm run test:web -- validators replayState runtimeProducer editorProducer recordingController RecorderPage packageBuilder snapshotBuilder`
- `npm run lint:web`
- `git diff --check`
- `node --test scripts/tests/workflow-rules.test.mjs`

## 自检

- [x] 未修改 `docs/progress.json` 或 `docs/progress.md`
- [x] 已运行 `npm run quality:local`，或说明无法运行的原因
- [x] 涉及 AI 字幕时，已记录一次 `npm run subtitle:postprocess:evaluate` 的“纠错并生成章节”效果验证结果，包含 `representativeOutputSource`、`overallEvaluationDurationMs`，并区分输出校验耗时与真实端到端耗时（不涉及 AI 字幕）
- [x] 涉及 AI 字幕点击链路、LLM worker、模型加载或性能时，已记录一次 `npm run subtitle:postprocess:runtime-benchmark` 结果，包含 `postprocessClickToResultReadyDurationMs`、`postProcessTimeoutBudgetMs` 和 `playbackProbeResponsiveDuringPostprocess`（不涉及 AI 字幕）
- [x] 已说明改动点和影响范围
- [x] 如果改动关键骨架，已补充契约测试并填写 GitNexus 影响分析摘要
- [ ] 已等待 repo-guard、codex 和 Copilot 评论，并完成必要审查
