### PR TITLE
[codex] Fix library row vertical alignment

### DIFF
--- a/apps/web/src/features/library/RecordingLibraryPage.tsx
+++ b/apps/web/src/features/library/RecordingLibraryPage.tsx
@@ -435,7 +435,7 @@ export function RecordingLibraryPage() {
             </thead>
             <tbody className="divide-y divide-border">
               {items.map((item) => (
-                <tr key={item.id} className="align-top">
+                <tr key={item.id} className="align-middle">
                   <td className="px-4 py-3">
                     <RecordingThumbnail
                       title={item.title}

--- a/apps/web/src/features/library/__tests__/RecordingLibraryPage.test.tsx
+++ b/apps/web/src/features/library/__tests__/RecordingLibraryPage.test.tsx
@@ -184,10 +184,12 @@ describe("RecordingLibraryPage", () => {
     renderPage();
     await waitForElementToBeRemoved(() => screen.queryByRole("status"));
 
-    expect(screen.getByRole("link", { name: BASE_TITLE })).toHaveAttribute(
+    const replayLink = screen.getByRole("link", { name: BASE_TITLE });
+    expect(replayLink).toHaveAttribute(
       "href",
       expect.stringContaining("/replay/rec-1"),
     );
+    expect(replayLink.closest("tr")).toHaveClass("align-middle");
     expect(screen.getByText(/TypeScript/)).toBeInTheDocument();
     expect(screen.getByText(/\u97f3\u9891/)).toBeInTheDocument();
     expect(screen.getByText(/\u65e0\u6444\u50cf\u5934/)).toBeInTheDocument();


### PR DESCRIPTION
## Summary
- Change recording-library table rows from top-aligned to vertically centered.
- Add a regression assertion so rendered recording rows keep `align-middle`.

## Root Cause
Rows in `RecordingLibraryPage` used `align-top`, so text and action controls sat at the top of rows with taller thumbnails.

## GitNexus 影响分析摘要
- 风险等级: MEDIUM（GitNexus detect_changes 标记；实际 diff 仅限列表 UI 对齐类和测试断言）
- 关键骨架变更: 否
- GitNexus 影响面: `detect_changes --repo code-tape` found 2 files, 1 symbol (`RecordingLibraryPage`) and 5 affected flows; `context RecordingLibraryPage --repo code-tape --file apps/web/src/features/library/RecordingLibraryPage.tsx` confirmed the component is routed from `apps/web/src/app/routes.tsx` and calls existing list/upload/share helpers, with no schema or controller surface changes.
- 验证结果: `npm run quality:predev`, targeted `RecordingLibraryPage` test red/green, browser geometry check, `npm run lint:web`, commit hook `quality:precommit`, and push hook `quality:local` passed.

## Test Plan
- [x] `npm run quality:predev`
- [x] `npm run test -w apps/web -- RecordingLibraryPage --run`
- [x] Browser visual/geometry check on `http://127.0.0.1:5174/`
- [x] `npm run lint:web`
- [x] `quality:precommit` via `git commit`
- [x] `quality:local` via `git push`