### PR TITLE
fix: 导入导出的封面

### DIFF
--- a/apps/web/src/features/library/__tests__/recordingStore.test.ts
+++ b/apps/web/src/features/library/__tests__/recordingStore.test.ts
@@ -504,6 +504,30 @@ describe("createRecordingStore — two-phase commit", () => {
     expect(list[0].id).toBe("rec-export");
   });
 
+  it("exportZip then importZip preserves the stored thumbnail", async () => {
+    replayThumbnailMock.mockResolvedValueOnce(new Blob(["exported-thumbnail"], { type: "image/webp" }));
+    const source = createRecordingStore({ databaseName: uniqueDbName() });
+    const input = makeInput("rec-export-thumbnail");
+    input.mediaBlob = null;
+    await source.saveDraft(input);
+    await source.commit("rec-export-thumbnail");
+    const sourceItem = await waitForListedRecordingWithThumbnail(source, "rec-export-thumbnail");
+    expect(sourceItem?.thumbnailBlobId).toMatch(/^thumbnail-/);
+
+    const zipBlob = await source.exportZip("rec-export-thumbnail");
+    const sink = createRecordingStore({
+      databaseName: uniqueDbName(),
+      replayThumbnailGenerator: null,
+    });
+    const imported = await sink.importZip(zipBlob);
+
+    if (!imported.ok) throw new Error(imported.message);
+    const importedItem = await waitForListedRecordingWithThumbnail(sink, "rec-export-thumbnail");
+    expect(importedItem?.thumbnailBlobId).toBeTruthy();
+    const thumbnail = await sink.loadThumbnail(importedItem!.thumbnailBlobId!);
+    expect(new TextDecoder().decode(await thumbnail!.arrayBuffer())).toBe("exported-thumbnail");
+  });
+
   it("importZip generates a thumbnail for imported video media", async () => {
     const source = createRecordingStore({ databaseName: uniqueDbName() });
     const input = makeInput("rec-import-thumbnail");

--- a/apps/web/src/features/library/recordingArchive.ts
+++ b/apps/web/src/features/library/recordingArchive.ts
@@ -4,6 +4,7 @@ import type { RecordingPackageV1 } from "@/shared/recording-schema";
 export async function buildRecordingZip(
   pkg: RecordingPackageV1,
   mediaBlob: Blob | null,
+  thumbnailBlob?: Blob | null,
 ): Promise<Blob> {
   const zip = new JSZip();
   zip.file("manifest.json", JSON.stringify(pkg.manifest, null, 2));
@@ -16,6 +17,10 @@ export async function buildRecordingZip(
     const mime = pkg.media?.mimeType ?? mediaBlob.type ?? "";
     zip.file(`media${extensionFor(mime)}`, await mediaBlob.arrayBuffer());
   }
+  if (thumbnailBlob) {
+    const mime = thumbnailBlob.type || "image/webp";
+    zip.file(`thumbnail${extensionFor(mime)}`, await thumbnailBlob.arrayBuffer());
+  }
   return zip.generateAsync({ type: "blob" });
 }
 
@@ -24,5 +29,8 @@ function extensionFor(mimeType: string | undefined | null): string {
   if (mimeType.includes("webm")) return ".webm";
   if (mimeType.includes("mp4")) return ".mp4";
   if (mimeType.includes("ogg")) return ".ogg";
+  if (mimeType.includes("webp")) return ".webp";
+  if (mimeType.includes("png")) return ".png";
+  if (mimeType.includes("jpeg") || mimeType.includes("jpg")) return ".jpg";
   return ".bin";
 }

--- a/apps/web/src/features/library/recordingStore.ts
+++ b/apps/web/src/features/library/recordingStore.ts
@@ -351,6 +351,9 @@ export function createRecordingStore(options: RecordingStoreOptions = {}): Recor
       const stored = await readRecording(recordingId);
       if (!stored) throw new Error(`recording ${recordingId} not found`);
       const mediaBlob = stored.blobId ? await readBlob(stored.blobId) : null;
+      const thumbnailBlob = stored.thumbnailBlobId
+        ? await readStoredBlob(STORE_THUMBNAILS, stored.thumbnailBlobId)
+        : null;
       return buildRecordingZip(
         {
           schemaVersion: RECORDING_SCHEMA_VERSION,
@@ -362,6 +365,7 @@ export function createRecordingStore(options: RecordingStoreOptions = {}): Recor
           indexes: stored.indexes,
         },
         mediaBlob,
+        thumbnailBlob,
       );
     },
 
@@ -396,6 +400,8 @@ export function createRecordingStore(options: RecordingStoreOptions = {}): Recor
         const mediaBlob = mediaBuffer
           ? new Blob([mediaBuffer], { type: mediaFromJson?.mimeType ?? "application/octet-stream" })
           : null;
+        const thumbnailEntry = Object.keys(archive.files).find((n) => n.startsWith("thumbnail."));
+        const thumbnailBuffer = thumbnailEntry ? await archive.file(thumbnailEntry)!.async("arraybuffer") : null;
         const media = mediaFromJson ?? (mediaBlob && manifest.checksums.mediaSha256
             ? {
                 blobId: generateId("blob"),
@@ -430,7 +436,16 @@ export function createRecordingStore(options: RecordingStoreOptions = {}): Recor
         }
         const saved = await this.saveDraft({ meta, events, snapshots, indexes, mediaBlob });
         if (!saved.ok) return saved;
-        return this.commit(saved.recordingId);
+        const committed = await this.commit(saved.recordingId);
+        if (!committed.ok) return committed;
+        if (thumbnailBuffer) {
+          const db = await getDb();
+          await persistThumbnail(db, saved.recordingId, generateId("thumbnail"), {
+            dataBase64: arrayBufferToBase64(thumbnailBuffer),
+            mimeType: mimeTypeForArchiveEntry(thumbnailEntry),
+          });
+        }
+        return committed;
       } catch (err) {
         return { ok: false, reason: "unknown", message: (err as Error).message };
       }
@@ -562,6 +577,14 @@ async function prepareThumbnailPayload(
 
 function isVideoBlob(blob: Blob): boolean {
   return blob.type.toLowerCase().startsWith("video/");
+}
+
+function mimeTypeForArchiveEntry(entryName: string | undefined): string {
+  const lower = entryName?.toLowerCase() ?? "";
+  if (lower.endsWith(".webp")) return "image/webp";
+  if (lower.endsWith(".png")) return "image/png";
+  if (lower.endsWith(".jpg") || lower.endsWith(".jpeg")) return "image/jpeg";
+  return DEFAULT_VIDEO_THUMBNAIL_OPTIONS.mimeType;
 }
 
 function arrayBufferToBase64(buffer: ArrayBuffer): string {


### PR DESCRIPTION
## 关联

Refs #2（总控 issue，不在本 PR 中关闭）

## 改动点

-

## 影响范围

-

## GitNexus 影响分析摘要

- 风险等级: -
- 关键骨架变更: -
- GitNexus 影响面: -
- 验证结果: -

## 自检

- [ ] 未修改 `docs/progress.json` 或 `docs/progress.md`
- [ ] 已运行 `npm run quality:local`，或说明无法运行的原因
- [ ] 涉及 AI 字幕时，已记录一次 `npm run subtitle:postprocess:evaluate` 的“纠错并生成章节”效果验证结果，包含 `representativeOutputSource`、`overallEvaluationDurationMs`，并区分输出校验耗时与真实端到端耗时
- [ ] 涉及 AI 字幕点击链路、LLM worker、模型加载或性能时，已记录一次 `npm run subtitle:postprocess:runtime-benchmark` 结果，包含 `postprocessClickToResultReadyDurationMs`、`postProcessTimeoutBudgetMs` 和 `playbackProbeResponsiveDuringPostprocess`
- [ ] 已说明改动点和影响范围
- [ ] 如果改动关键骨架，已补充契约测试并填写 GitNexus 影响分析摘要
- [ ] 已等待 repo-guard、codex 和 Copilot 评论，并完成必要审查
