### PR TITLE
feat: add external ASR fallback

### DIFF
--- a/apps/web/src/features/subtitles/SubtitleAsrConfigButton.tsx
+++ b/apps/web/src/features/subtitles/SubtitleAsrConfigButton.tsx
@@ -1,0 +1,157 @@
+import { Mic } from "lucide-react";
+import { useEffect, useId, useState } from "react";
+import { Popover } from "@/shared/ui/Popover";
+import { cn } from "@/shared/ui/utils/cn";
+import {
+  clearExternalAsrConfig,
+  isExternalAsrConfigured,
+  loadExternalAsrConfig,
+  saveExternalAsrConfig,
+  type ExternalAsrConfig,
+} from "./subtitleAsrConfig";
+
+export type SubtitleAsrConfigButtonProps = {
+  configured: boolean;
+  onConfigChange(): void;
+};
+
+const EMPTY_DRAFT: ExternalAsrConfig = {
+  provider: "openai-compatible",
+  baseURL: "",
+  apiKey: "",
+  model: "",
+  language: "zh",
+};
+
+const inputClassName = cn(
+  "w-full rounded-md border border-border bg-surface px-2 py-1 text-xs text-foreground",
+  "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus",
+);
+
+export function SubtitleAsrConfigButton({
+  configured,
+  onConfigChange,
+}: SubtitleAsrConfigButtonProps) {
+  const [open, setOpen] = useState(false);
+  const [draft, setDraft] = useState<ExternalAsrConfig>(EMPTY_DRAFT);
+  const fieldId = useId();
+
+  useEffect(() => {
+    if (open) setDraft(loadExternalAsrConfig() ?? EMPTY_DRAFT);
+  }, [open]);
+
+  const update = (patch: Partial<ExternalAsrConfig>) => setDraft((prev) => ({ ...prev, ...patch }));
+
+  const handleSave = () => {
+    if (!isExternalAsrConfigured(draft)) return;
+    saveExternalAsrConfig(draft);
+    onConfigChange();
+    setOpen(false);
+  };
+
+  const handleClear = () => {
+    clearExternalAsrConfig();
+    setDraft(EMPTY_DRAFT);
+    onConfigChange();
+    setOpen(false);
+  };
+
+  const canSave = isExternalAsrConfigured(draft);
+
+  return (
+    <Popover
+      open={open}
+      onOpenChange={setOpen}
+      align="end"
+      width={280}
+      trigger={
+        <button
+          type="button"
+          aria-label={configured ? "外部 ASR 已配置，点击编辑" : "配置外部 ASR"}
+          aria-pressed={configured}
+          className={cn(
+            "inline-flex h-8 w-8 items-center justify-center rounded-md border border-border transition-colors",
+            "hover:bg-surface focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus",
+            configured ? "text-primary" : "text-muted",
+          )}
+        >
+          <Mic aria-hidden size={15} />
+        </button>
+      }
+    >
+      <div className="flex flex-col gap-2 text-xs">
+        <p className="font-medium text-foreground">外部 ASR（语音转字幕）</p>
+        <p className="text-[11px] leading-4 text-muted">
+          配置后优先请求 OpenAI-compatible /audio/transcriptions，失败时回退本地 ASR。API Key
+          仅保存在本机浏览器；请填支持浏览器跨域（CORS）的请求地址。
+        </p>
+        <label className="flex flex-col gap-1" htmlFor={`${fieldId}-base`}>
+          <span className="text-muted">请求地址</span>
+          <input
+            id={`${fieldId}-base`}
+            type="url"
+            inputMode="url"
+            placeholder="https://api.openai.com/v1"
+            value={draft.baseURL}
+            onChange={(event) => update({ baseURL: event.target.value })}
+            className={inputClassName}
+          />
+        </label>
+        <label className="flex flex-col gap-1" htmlFor={`${fieldId}-key`}>
+          <span className="text-muted">API Key</span>
+          <input
+            id={`${fieldId}-key`}
+            type="password"
+            autoComplete="off"
+            value={draft.apiKey}
+            onChange={(event) => update({ apiKey: event.target.value })}
+            className={inputClassName}
+          />
+        </label>
+        <label className="flex flex-col gap-1" htmlFor={`${fieldId}-model`}>
+          <span className="text-muted">Model</span>
+          <input
+            id={`${fieldId}-model`}
+            type="text"
+            placeholder="gpt-4o-mini-transcribe"
+            value={draft.model}
+            onChange={(event) => update({ model: event.target.value })}
+            className={inputClassName}
+          />
+        </label>
+        <label className="flex flex-col gap-1" htmlFor={`${fieldId}-language`}>
+          <span className="text-muted">语言</span>
+          <input
+            id={`${fieldId}-language`}
+            type="text"
+            placeholder="zh"
+            value={draft.language}
+            onChange={(event) => update({ language: event.target.value })}
+            className={inputClassName}
+          />
+        </label>
+        <div className="mt-1 flex items-center justify-between gap-2">
+          <button
+            type="button"
+            onClick={handleClear}
+            className="rounded-md px-2 py-1 text-muted transition-colors hover:text-danger focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus"
+          >
+            清除
+          </button>
+          <button
+            type="button"
+            onClick={handleSave}
+            disabled={!canSave}
+            className={cn(
+              "rounded-md bg-primary px-3 py-1 font-medium text-primary-foreground transition-opacity",
+              "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus",
+              canSave ? "hover:opacity-90" : "cursor-not-allowed opacity-50",
+            )}
+          >
+            保存
+          </button>
+        </div>
+      </div>
+    </Popover>
+  );
+}

--- a/apps/web/src/features/subtitles/SubtitlePanel.tsx
+++ b/apps/web/src/features/subtitles/SubtitlePanel.tsx
@@ -1,12 +1,16 @@
 import { Captions, Loader2, WandSparkles } from "lucide-react";
 import { useEffect, useMemo, useRef, useState, type MutableRefObject } from "react";
+import { SubtitleAsrConfigButton } from "./SubtitleAsrConfigButton";
 import { SubtitleChapterList } from "./SubtitleChapterList";
 import { SubtitleLlmConfigButton } from "./SubtitleLlmConfigButton";
 import { applySubtitleCorrection } from "./subtitleCorrection";
+import { createExternalAsrSubtitleTranscriber } from "./externalAsrSubtitleTranscriber";
 import { createExternalLlmSubtitlePostProcessor } from "./externalLlmSubtitlePostProcessor";
 import { createFallbackSubtitlePostProcessor } from "./fallbackSubtitlePostProcessor";
+import { createFallbackSubtitleTranscriber } from "./fallbackSubtitleTranscriber";
 import { resolveEffectivePostProcessTimeoutMs } from "./subtitlePostProcessTimeout";
 import { isExternalLlmConfigured, loadExternalLlmConfig } from "./subtitleLlmConfig";
+import { isExternalAsrConfigured, loadExternalAsrConfig } from "./subtitleAsrConfig";
 import { resolveSubtitlePostProcessorModel } from "./subtitlePostProcessorConfig";
 import { createWorkerBackedHuggingFaceSubtitlePostProcessor } from "./subtitlePostProcessorWorkerClient";
 import { createSubtitleStore } from "./subtitleStore";
@@ -22,6 +26,7 @@ import type {
   SubtitleStore,
   SubtitleTrack,
   SubtitleTranscriber,
+  SubtitleTranscriptionStatus,
 } from "./types";
 import { cn } from "@/shared/ui/utils/cn";
 
@@ -42,6 +47,8 @@ export type SubtitlePanelProps = {
 };
 
 type GenerationStatus = "idle" | "loading" | "generating" | "post-processing" | "ready" | "error";
+
+type AsrRuntimeStatus = "idle" | "warming" | "warm" | "warm-error" | SubtitleTranscriptionStatus;
 
 type PostProcessorWarmUpState = {
   recordingId: string;
@@ -64,9 +71,25 @@ export function SubtitlePanel({
   postProcessTimeoutMs = DEFAULT_SUBTITLE_POSTPROCESS_TIMEOUT_MS,
 }: SubtitlePanelProps) {
   const store = useMemo(() => injectedStore ?? createSubtitleStore(), [injectedStore]);
-  const transcriber = useMemo(
-    () => injectedTranscriber ?? createHuggingFaceSubtitleTranscriber(),
-    [injectedTranscriber],
+  const [asrConfigVersion, setAsrConfigVersion] = useState(0);
+  const transcriber = useMemo(() => {
+    if (injectedTranscriber) return injectedTranscriber;
+    const localTranscriber = createHuggingFaceSubtitleTranscriber();
+    const externalConfig = loadExternalAsrConfig();
+    if (!isExternalAsrConfigured(externalConfig)) return localTranscriber;
+    const externalTranscriber = createExternalAsrSubtitleTranscriber({ config: externalConfig });
+    return createFallbackSubtitleTranscriber(externalTranscriber, localTranscriber, {
+      onFallback: () =>
+        console.warn("[code-tape] external subtitle ASR failed; falling back to local model"),
+    });
+    // asrConfigVersion bumps when the user saves/clears the external ASR config.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [injectedTranscriber, asrConfigVersion]);
+  const externalAsrConfigured = useMemo(
+    () => isExternalAsrConfigured(loadExternalAsrConfig()),
+    // Recompute when the user saves/clears the config (version bump).
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [asrConfigVersion],
   );
   const [llmConfigVersion, setLlmConfigVersion] = useState(0);
   const postProcessor = useMemo(
@@ -101,12 +124,13 @@ export function SubtitlePanel({
   const [chapters, setChapters] = useState<SubtitleChapter[]>([]);
   const [warnings, setWarnings] = useState<SubtitleCorrectionWarning[]>([]);
   const [status, setStatus] = useState<GenerationStatus>("idle");
+  const [asrStatus, setAsrStatus] = useState<AsrRuntimeStatus>("idle");
   const [error, setError] = useState<string | null>(null);
   const activeSegment = findActiveSegment(track?.segments ?? [], currentTimeMs);
   const activeSegmentRef = useRef<HTMLButtonElement | null>(null);
   const requestVersionRef = useRef(0);
   const generationAbortRef = useRef<AbortController | null>(null);
-  const warmUpRequestRef = useRef<{ recordingId: string; mediaBlob: Blob } | null>(null);
+  const warmUpTranscriberRef = useRef<SubtitleTranscriber | null>(null);
   const postProcessorWarmUpRef = useRef<PostProcessorWarmUpState | null>(null);
 
   useEffect(() => {
@@ -162,17 +186,19 @@ export function SubtitlePanel({
   }, [activeSegment?.id]);
 
   useEffect(() => {
-    if (!recordingId || !mediaBlob || !hasAudio || !transcriber.warmUp) {
-      warmUpRequestRef.current = null;
-      return;
-    }
-    const lastWarmUpRequest = warmUpRequestRef.current;
-    if (lastWarmUpRequest?.recordingId === recordingId && lastWarmUpRequest.mediaBlob === mediaBlob) {
-      return;
-    }
-    warmUpRequestRef.current = { recordingId, mediaBlob };
-    void transcriber.warmUp().catch(() => undefined);
-  }, [hasAudio, mediaBlob, recordingId, transcriber]);
+    if (!transcriber.warmUp) return;
+    if (warmUpTranscriberRef.current === transcriber) return;
+    warmUpTranscriberRef.current = transcriber;
+    setAsrStatus("warming");
+    void transcriber
+      .warmUp()
+      .then(() => {
+        if (warmUpTranscriberRef.current === transcriber) setAsrStatus("warm");
+      })
+      .catch(() => {
+        if (warmUpTranscriberRef.current === transcriber) setAsrStatus("warm-error");
+      });
+  }, [transcriber]);
 
   useEffect(() => {
     if (
@@ -206,7 +232,8 @@ export function SubtitlePanel({
     warmUpState.cancel = scheduleIdleWarmUp(() => {
       if (cancelled) return;
       warmUpState.status = "running";
-      void postProcessor.warmUp?.()
+      void postProcessor
+        .warmUp?.()
         .catch(() => undefined)
         .finally(() => {
           if (postProcessorWarmUpRef.current === warmUpState) {
@@ -222,20 +249,20 @@ export function SubtitlePanel({
 
   const canGenerate = Boolean(
     recordingId &&
-      mediaBlob &&
-      hasAudio &&
-      status !== "loading" &&
-      status !== "generating" &&
-      status !== "post-processing",
+    mediaBlob &&
+    hasAudio &&
+    status !== "loading" &&
+    status !== "generating" &&
+    status !== "post-processing",
   );
   const canPostProcess = Boolean(
     recordingId &&
-      track &&
-      track.segments.length > 0 &&
-      postProcessor &&
-      status !== "loading" &&
-      status !== "generating" &&
-      status !== "post-processing",
+    track &&
+    track.segments.length > 0 &&
+    postProcessor &&
+    status !== "loading" &&
+    status !== "generating" &&
+    status !== "post-processing",
   );
   const shouldGenerateBeforePostProcess = Boolean(postProcessor && canGenerate);
   const primaryActionLabel = shouldGenerateBeforePostProcess
@@ -265,12 +292,17 @@ export function SubtitlePanel({
         }),
         {
           abortController,
-          timeoutMs: resolveEffectivePostProcessTimeoutMs(postProcessTimeoutMs, externalLlmConfigured),
+          timeoutMs: resolveEffectivePostProcessTimeoutMs(
+            postProcessTimeoutMs,
+            externalLlmConfigured,
+          ),
         },
       );
       if (!isCurrentGeneration(requestVersionRef, requestVersion, abortController)) return;
       const result = applySubtitleCorrection(baseTrack, correction, { durationMs });
-      const hasInvalidCorrection = result.warnings.some((warning) => warning.code === "invalid-correction");
+      const hasInvalidCorrection = result.warnings.some(
+        (warning) => warning.code === "invalid-correction",
+      );
       if (hasInvalidCorrection) {
         setWarnings(result.warnings);
         setStatus("ready");
@@ -284,7 +316,11 @@ export function SubtitlePanel({
       setStatus("ready");
     } catch (err) {
       if (isPostProcessTimeoutError(err)) {
-        if (requestVersionRef.current !== requestVersion || generationAbortRef.current !== abortController) return;
+        if (
+          requestVersionRef.current !== requestVersion ||
+          generationAbortRef.current !== abortController
+        )
+          return;
         setError(formatSubtitleError(err));
         setStatus("error");
         return;
@@ -308,10 +344,12 @@ export function SubtitlePanel({
     setError(null);
     setWarnings([]);
     try {
+      setAsrStatus("transcribing");
       const draft = await transcriber.transcribe({
         mediaBlob,
         durationMs,
         signal: abortController.signal,
+        onStatus: setAsrStatus,
       });
       if (!isCurrentGeneration(requestVersionRef, requestVersion, abortController)) return;
       const nextTrack: SubtitleTrack = {
@@ -323,6 +361,7 @@ export function SubtitlePanel({
       if (!isCurrentGeneration(requestVersionRef, requestVersion, abortController)) return;
       setTrack(nextTrack);
       setChapters([]);
+      setAsrStatus("warm");
       if (postProcessor) {
         await postProcessTrack(nextTrack, requestVersion, abortController);
         return;
@@ -331,6 +370,7 @@ export function SubtitlePanel({
     } catch (err) {
       if (abortController.signal.aborted || requestVersionRef.current !== requestVersion) return;
       if (requestStaleTransformersImportRecovery(err)) return;
+      setAsrStatus("warm-error");
       setError(formatSubtitleError(err));
       setStatus("error");
     } finally {
@@ -366,12 +406,10 @@ export function SubtitlePanel({
     }
     void generateSubtitles();
   };
+  const statusMessage = formatAsrStatusMessage(status, asrStatus);
 
   return (
-    <section
-      aria-label="字幕"
-      className="shrink-0 border-t border-border bg-background px-3 py-2"
-    >
+    <section aria-label="字幕" className="shrink-0 border-t border-border bg-background px-3 py-2">
       <div className="mb-2 flex min-h-9 flex-wrap items-center justify-between gap-2">
         <div className="flex min-w-0 items-center gap-2 text-sm font-medium text-foreground">
           <Captions aria-hidden size={17} className="shrink-0 text-primary" />
@@ -384,6 +422,10 @@ export function SubtitlePanel({
           <SubtitleLlmConfigButton
             configured={externalLlmConfigured}
             onConfigChange={() => setLlmConfigVersion((version) => version + 1)}
+          />
+          <SubtitleAsrConfigButton
+            configured={externalAsrConfigured}
+            onConfigChange={() => setAsrConfigVersion((version) => version + 1)}
           />
           <button
             type="button"
@@ -411,15 +453,12 @@ export function SubtitlePanel({
           {warnings[0]?.message}
         </p>
       ) : null}
+      {statusMessage ? <p className="mb-2 text-xs text-muted">{statusMessage}</p> : null}
       {!hasAudio ? (
         <p className="text-xs text-muted">无音频轨道</p>
       ) : track && track.segments.length > 0 ? (
         <>
-          <SubtitleChapterList
-            chapters={chapters}
-            currentTimeMs={currentTimeMs}
-            onSeek={onSeek}
-          />
+          <SubtitleChapterList chapters={chapters} currentTimeMs={currentTimeMs} onSeek={onSeek} />
           <div className="flex max-h-32 min-h-0 flex-col gap-1 overflow-y-auto overscroll-contain pr-1">
             {track.segments.map((segment) => {
               const isActive = activeSegment?.id === segment.id;
@@ -438,21 +477,17 @@ export function SubtitlePanel({
                     isActive ? "bg-surface-raised text-foreground" : "text-muted",
                   )}
                 >
-                  <span className="font-mono tabular-nums">{formatSubtitleTime(segment.startMs)}</span>
+                  <span className="font-mono tabular-nums">
+                    {formatSubtitleTime(segment.startMs)}
+                  </span>
                   <span className="text-foreground">{segment.text}</span>
                 </button>
               );
             })}
           </div>
         </>
-      ) : (
-        <p className="text-xs text-muted">
-          {status === "generating"
-            ? "正在生成字幕..."
-            : status === "post-processing"
-              ? "正在纠错并生成章节..."
-              : "暂无字幕"}
-        </p>
+      ) : status === "generating" || status === "post-processing" ? null : (
+        <p className="text-xs text-muted">暂无字幕</p>
       )}
     </section>
   );
@@ -492,6 +527,22 @@ function formatSubtitleTime(ms: number): string {
 
 function formatSubtitleError(error: unknown): string {
   return error instanceof Error ? error.message : "字幕生成失败";
+}
+
+function formatAsrStatusMessage(
+  generationStatus: GenerationStatus,
+  asrStatus: AsrRuntimeStatus,
+): string | null {
+  if (generationStatus === "post-processing") return "ASR 完成，正在纠错并生成章节...";
+  if (generationStatus === "generating") {
+    if (asrStatus === "loading-local-model") return "正在加载本地 ASR 模型...";
+    if (asrStatus === "requesting-external-asr") return "正在请求外部 ASR...";
+    if (asrStatus === "transcribing") return "正在识别音频...";
+    return "正在生成字幕...";
+  }
+  if (asrStatus === "warming") return "正在加载本地 ASR 模型...";
+  if (asrStatus === "warm-error") return "本地 ASR 模型预热失败，点击生成时会重试。";
+  return null;
 }
 
 class PostProcessTimeoutError extends Error {

--- a/apps/web/src/features/subtitles/__tests__/SubtitleAsrConfigButton.test.tsx
+++ b/apps/web/src/features/subtitles/__tests__/SubtitleAsrConfigButton.test.tsx
@@ -1,0 +1,60 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { SubtitleAsrConfigButton } from "../SubtitleAsrConfigButton";
+import { SUBTITLE_ASR_CONFIG_STORAGE_KEY, loadExternalAsrConfig } from "../subtitleAsrConfig";
+
+describe("SubtitleAsrConfigButton", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  afterEach(() => {
+    window.localStorage.clear();
+  });
+
+  it("saves a complete external ASR config and notifies the parent", () => {
+    const onConfigChange = vi.fn();
+    render(<SubtitleAsrConfigButton configured={false} onConfigChange={onConfigChange} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "配置外部 ASR" }));
+    fireEvent.change(screen.getByLabelText("请求地址"), {
+      target: { value: "https://api.example.com/v1" },
+    });
+    fireEvent.change(screen.getByLabelText("API Key"), { target: { value: "sk-test" } });
+    fireEvent.change(screen.getByLabelText("Model"), {
+      target: { value: "gpt-4o-mini-transcribe" },
+    });
+    fireEvent.change(screen.getByLabelText("语言"), { target: { value: "zh" } });
+    fireEvent.click(screen.getByRole("button", { name: "保存" }));
+
+    expect(onConfigChange).toHaveBeenCalledTimes(1);
+    expect(loadExternalAsrConfig()).toEqual({
+      provider: "openai-compatible",
+      baseURL: "https://api.example.com/v1",
+      apiKey: "sk-test",
+      model: "gpt-4o-mini-transcribe",
+      language: "zh",
+    });
+  });
+
+  it("clears an existing config", () => {
+    window.localStorage.setItem(
+      SUBTITLE_ASR_CONFIG_STORAGE_KEY,
+      JSON.stringify({
+        provider: "openai-compatible",
+        baseURL: "https://x",
+        apiKey: "k",
+        model: "m",
+        language: "",
+      }),
+    );
+    const onConfigChange = vi.fn();
+    render(<SubtitleAsrConfigButton configured onConfigChange={onConfigChange} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "外部 ASR 已配置，点击编辑" }));
+    fireEvent.click(screen.getByRole("button", { name: "清除" }));
+
+    expect(loadExternalAsrConfig()).toBeNull();
+    expect(onConfigChange).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/src/features/subtitles/__tests__/SubtitlePanel.test.tsx
+++ b/apps/web/src/features/subtitles/__tests__/SubtitlePanel.test.tsx
@@ -162,6 +162,7 @@ describe("SubtitlePanel", () => {
 
     expect(screen.getByText("use state hook")).toBeInTheDocument();
     expect(screen.getByText("render result")).toBeInTheDocument();
+    expect(screen.getByText("ASR 完成，正在纠错并生成章节...")).toBeInTheDocument();
     expect(postProcessor.process).toHaveBeenCalledWith(
       expect.objectContaining({
         track: expect.objectContaining({
@@ -399,7 +400,9 @@ describe("SubtitlePanel", () => {
     fireEvent.click(screen.getByRole("button", { name: GENERATE_AND_OPTIMIZE_LABEL }));
     await waitFor(() => expect(screen.getByText("use state hook")).toBeInTheDocument());
 
-    await waitFor(() => expect(screen.getByRole("alert")).toHaveTextContent("LLM JSON parse failed"));
+    await waitFor(() =>
+      expect(screen.getByRole("alert")).toHaveTextContent("LLM JSON parse failed"),
+    );
     expect(screen.getByText("use state hook")).toBeInTheDocument();
 
     const retryButton = screen.getByRole("button", { name: GENERATE_AND_OPTIMIZE_LABEL });
@@ -456,7 +459,9 @@ describe("SubtitlePanel", () => {
     fireEvent.click(screen.getByRole("button", { name: GENERATE_AND_OPTIMIZE_LABEL }));
 
     await waitFor(() => expect(screen.getByText("new ASR subtitle")).toBeInTheDocument());
-    await waitFor(() => expect(screen.getByRole("alert")).toHaveTextContent("LLM JSON parse failed"));
+    await waitFor(() =>
+      expect(screen.getByRole("alert")).toHaveTextContent("LLM JSON parse failed"),
+    );
     expect(screen.queryByRole("button", { name: /旧章节/ })).not.toBeInTheDocument();
     await expect(store.loadChapters("recording-1")).resolves.toEqual([]);
     await expect(store.load("recording-1")).resolves.toEqual(
@@ -627,7 +632,9 @@ describe("SubtitlePanel", () => {
       />,
     );
 
-    await waitFor(() => expect(screen.getByRole("button", { name: /已有章节/ })).toBeInTheDocument());
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: /已有章节/ })).toBeInTheDocument(),
+    );
 
     fireEvent.click(screen.getByRole("button", { name: OPTIMIZE_SUBTITLES_LABEL }));
 
@@ -694,7 +701,9 @@ describe("SubtitlePanel", () => {
       />,
     );
 
-    await waitFor(() => expect(screen.getByRole("button", { name: /已有章节/ })).toBeInTheDocument());
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: /已有章节/ })).toBeInTheDocument(),
+    );
 
     vi.useFakeTimers();
     try {
@@ -739,10 +748,14 @@ describe("SubtitlePanel", () => {
       generatedAt: "2026-05-28T00:00:01.000Z",
       model: "onnx-community/whisper-tiny",
       source: "huggingface-local",
-      segments: [{ id: "subtitle-2", startMs: 0, endMs: 1_000, text: "current recording subtitle" }],
+      segments: [
+        { id: "subtitle-2", startMs: 0, endMs: 1_000, text: "current recording subtitle" },
+      ],
     };
     const store = createMemorySubtitleStore();
-    await store.saveWithChapters(firstTrack, [{ id: "chapter-1", title: "旧章节", startMs: 0, endMs: 1_000 }]);
+    await store.saveWithChapters(firstTrack, [
+      { id: "chapter-1", title: "旧章节", startMs: 0, endMs: 1_000 },
+    ]);
     await store.saveWithChapters(secondTrack, [
       { id: "chapter-2", title: "当前章节", startMs: 0, endMs: 1_000 },
     ]);
@@ -948,7 +961,9 @@ describe("SubtitlePanel", () => {
       />,
     );
 
-    await waitFor(() => expect(screen.getByRole("button", { name: GENERATE_SUBTITLES_LABEL })).not.toBeDisabled());
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: GENERATE_SUBTITLES_LABEL })).not.toBeDisabled(),
+    );
 
     fireEvent.click(screen.getByRole("button", { name: GENERATE_SUBTITLES_LABEL }));
 
@@ -1003,6 +1018,84 @@ describe("SubtitlePanel", () => {
     );
 
     await waitFor(() => expect(warmUp).toHaveBeenCalledTimes(1));
+  });
+
+  it("warms up the transcriber as soon as the panel mounts even before audio is available", async () => {
+    const warmUp = vi.fn(async () => undefined);
+
+    render(
+      <SubtitlePanel
+        recordingId={null}
+        mediaBlob={null}
+        hasAudio={false}
+        durationMs={0}
+        currentTimeMs={0}
+        onSeek={vi.fn()}
+        store={createMemorySubtitleStore()}
+        transcriber={{
+          warmUp,
+          transcribe: vi.fn(async () => ({
+            model: "onnx-community/whisper-tiny",
+            source: "huggingface-local" as const,
+            segments: [],
+          })),
+        }}
+        postProcessor={null}
+      />,
+    );
+
+    await waitFor(() => expect(warmUp).toHaveBeenCalledTimes(1));
+  });
+
+  it("shows the active ASR stage while generating subtitles", async () => {
+    const transcription = createDeferred<SubtitleTrackDraft>();
+    const transcriber: SubtitleTranscriber = {
+      warmUp: vi.fn(async () => undefined),
+      transcribe: vi.fn((input) => {
+        input.onStatus?.("loading-local-model");
+        return transcription.promise;
+      }),
+    };
+
+    render(
+      <SubtitlePanel
+        recordingId="recording-1"
+        mediaBlob={new Blob(["webm"], { type: "video/webm" })}
+        hasAudio
+        durationMs={3_000}
+        currentTimeMs={0}
+        onSeek={vi.fn()}
+        store={createMemorySubtitleStore()}
+        transcriber={transcriber}
+        postProcessor={null}
+      />,
+    );
+
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: GENERATE_SUBTITLES_LABEL })).not.toBeDisabled(),
+    );
+    fireEvent.click(screen.getByRole("button", { name: GENERATE_SUBTITLES_LABEL }));
+
+    expect(screen.getByText("正在加载本地 ASR 模型...")).toBeInTheDocument();
+
+    act(() => {
+      const input = vi.mocked(transcriber.transcribe).mock.calls[0]?.[0];
+      input?.onStatus?.("transcribing");
+    });
+
+    expect(screen.getByText("正在识别音频...")).toBeInTheDocument();
+
+    await act(async () => {
+      transcription.resolve({
+        model: "onnx-community/whisper-tiny",
+        source: "huggingface-local",
+        segments: [{ id: "subtitle-1", startMs: 0, endMs: 1_000, text: "done" }],
+      });
+      await flushPromises();
+    });
+
+    expect(screen.queryByText("正在识别音频...")).not.toBeInTheDocument();
+    expect(screen.getByText("done")).toBeInTheDocument();
   });
 
   it("does not warm up the local LLM before subtitles exist", async () => {
@@ -1082,7 +1175,9 @@ describe("SubtitlePanel", () => {
       />,
     );
 
-    await waitFor(() => expect(screen.getByText("onnx-community/whisper-tiny")).toBeInTheDocument());
+    await waitFor(() =>
+      expect(screen.getByText("onnx-community/whisper-tiny")).toBeInTheDocument(),
+    );
     expect(screen.getByText("无音频轨道")).toBeInTheDocument();
     expect(requestIdleCallback).not.toHaveBeenCalled();
     expect(postProcessorWarmUp).not.toHaveBeenCalled();
@@ -1753,7 +1848,7 @@ describe("SubtitlePanel", () => {
     await waitFor(() => expect(secondWarmUp).toHaveBeenCalledTimes(1));
   });
 
-  it("does not repeat warm-up for the same recording media when transcriber identity changes", async () => {
+  it("warms up a new transcriber identity immediately", async () => {
     const mediaBlob = new Blob(["webm"], { type: "video/webm" });
     const firstWarmUp = vi.fn(async () => undefined);
     const secondWarmUp = vi.fn(async () => undefined);
@@ -1797,6 +1892,6 @@ describe("SubtitlePanel", () => {
     });
 
     expect(firstWarmUp).toHaveBeenCalledTimes(1);
-    expect(secondWarmUp).not.toHaveBeenCalled();
+    expect(secondWarmUp).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/web/src/features/subtitles/__tests__/externalAsrSubtitleTranscriber.test.ts
+++ b/apps/web/src/features/subtitles/__tests__/externalAsrSubtitleTranscriber.test.ts
@@ -1,0 +1,116 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createExternalAsrSubtitleTranscriber } from "../externalAsrSubtitleTranscriber";
+import type { ExternalAsrConfig } from "../subtitleAsrConfig";
+
+const config: ExternalAsrConfig = {
+  provider: "openai-compatible",
+  baseURL: "https://api.example.com/v1",
+  apiKey: "sk-test",
+  model: "gpt-4o-mini-transcribe",
+  language: "zh",
+};
+
+describe("createExternalAsrSubtitleTranscriber", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("requests OpenAI-compatible audio transcriptions with the recording blob", async () => {
+    const fetchImpl: typeof fetch = vi.fn(async () =>
+      Response.json({
+        language: "zh",
+        segments: [
+          { start: 0.25, end: 1.5, text: "  use state hook  " },
+          { start: 1.5, end: 3, text: "render result" },
+        ],
+      }),
+    );
+    const mediaBlob = new Blob(["webm"], { type: "video/webm" });
+    const transcriber = createExternalAsrSubtitleTranscriber({ config, fetchImpl });
+
+    await expect(transcriber.transcribe({ mediaBlob, durationMs: 4_000 })).resolves.toEqual({
+      model: "gpt-4o-mini-transcribe",
+      source: "external-asr",
+      language: "zh",
+      segments: [
+        { id: "subtitle-1", startMs: 250, endMs: 1_500, text: "use state hook" },
+        { id: "subtitle-2", startMs: 1_500, endMs: 3_000, text: "render result" },
+      ],
+    });
+
+    expect(fetchImpl).toHaveBeenCalledWith(
+      "https://api.example.com/v1/audio/transcriptions",
+      expect.objectContaining({
+        method: "POST",
+        headers: { authorization: "Bearer sk-test" },
+        body: expect.any(FormData),
+      }),
+    );
+    const body = vi.mocked(fetchImpl).mock.calls[0]?.[1]?.body as FormData;
+    expect(body.get("file")).toBeInstanceOf(File);
+    expect(body.get("model")).toBe("gpt-4o-mini-transcribe");
+    expect(body.get("language")).toBe("zh");
+    expect(body.get("response_format")).toBe("verbose_json");
+  });
+
+  it("falls back to one full-duration segment when the endpoint only returns text", async () => {
+    const fetchImpl: typeof fetch = vi.fn(async () => Response.json({ text: "plain transcript" }));
+    const transcriber = createExternalAsrSubtitleTranscriber({
+      config: { ...config, language: "" },
+      fetchImpl,
+    });
+
+    await expect(
+      transcriber.transcribe({
+        mediaBlob: new Blob(["webm"], { type: "video/webm" }),
+        durationMs: 2_500,
+      }),
+    ).resolves.toMatchObject({
+      language: "zh",
+      segments: [{ id: "subtitle-1", startMs: 0, endMs: 2_500, text: "plain transcript" }],
+    });
+
+    const body = vi.mocked(fetchImpl).mock.calls[0]?.[1]?.body as FormData;
+    expect(body.has("language")).toBe(false);
+  });
+
+  it("surfaces external ASR HTTP failures without leaking the response body", async () => {
+    const fetchImpl: typeof fetch = vi.fn(
+      async () => new Response("secret echo", { status: 401, statusText: "Unauthorized" }),
+    );
+    const transcriber = createExternalAsrSubtitleTranscriber({ config, fetchImpl });
+
+    await expect(
+      transcriber.transcribe({
+        mediaBlob: new Blob(["webm"], { type: "video/webm" }),
+        durationMs: 1_000,
+      }),
+    ).rejects.toThrow("外部 ASR 返回 HTTP 401 Unauthorized");
+  });
+
+  it("times out a hanging external ASR request as a fallback-eligible failure", async () => {
+    vi.useFakeTimers();
+    const fetchImpl: typeof fetch = vi.fn(
+      async (_url, init) =>
+        new Promise<Response>((_resolve, reject) => {
+          init?.signal?.addEventListener("abort", () => {
+            reject(new DOMException("aborted", "AbortError"));
+          });
+        }),
+    );
+    const transcriber = createExternalAsrSubtitleTranscriber({
+      config,
+      fetchImpl,
+      requestTimeoutMs: 1_000,
+    });
+
+    const result = transcriber.transcribe({
+      mediaBlob: new Blob(["webm"], { type: "video/webm" }),
+      durationMs: 1_000,
+    });
+    const assertion = expect(result).rejects.toThrow("外部 ASR 请求超时");
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    await assertion;
+  });
+});

--- a/apps/web/src/features/subtitles/__tests__/fallbackSubtitleTranscriber.test.ts
+++ b/apps/web/src/features/subtitles/__tests__/fallbackSubtitleTranscriber.test.ts
@@ -1,0 +1,161 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createExternalAsrSubtitleTranscriber } from "../externalAsrSubtitleTranscriber";
+import { createFallbackSubtitleTranscriber } from "../fallbackSubtitleTranscriber";
+import type { ExternalAsrConfig } from "../subtitleAsrConfig";
+import type { SubtitleTrackDraft, SubtitleTranscriber } from "../types";
+
+const externalResult: SubtitleTrackDraft = {
+  model: "gpt-4o-mini-transcribe",
+  source: "external-asr",
+  segments: [{ id: "subtitle-1", startMs: 0, endMs: 1_000, text: "external" }],
+};
+
+const localResult: SubtitleTrackDraft = {
+  model: "onnx-community/whisper-tiny",
+  source: "huggingface-local",
+  segments: [{ id: "subtitle-1", startMs: 0, endMs: 1_000, text: "local" }],
+};
+
+const externalConfig: ExternalAsrConfig = {
+  provider: "openai-compatible",
+  baseURL: "https://api.example.com/v1",
+  apiKey: "sk-test",
+  model: "gpt-4o-mini-transcribe",
+  language: "zh",
+};
+
+function transcriber(partial: Partial<SubtitleTranscriber>): SubtitleTranscriber {
+  return {
+    transcribe: vi.fn(async () => localResult),
+    ...partial,
+  };
+}
+
+describe("createFallbackSubtitleTranscriber", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("uses the external transcriber first and skips local transcription when it succeeds", async () => {
+    const primary = transcriber({ transcribe: vi.fn(async () => externalResult) });
+    const fallback = transcriber({ transcribe: vi.fn(async () => localResult) });
+    const wrapped = createFallbackSubtitleTranscriber(primary, fallback);
+
+    await expect(
+      wrapped.transcribe({
+        mediaBlob: new Blob(["webm"], { type: "video/webm" }),
+        durationMs: 1_000,
+      }),
+    ).resolves.toBe(externalResult);
+    expect(fallback.transcribe).not.toHaveBeenCalled();
+  });
+
+  it("always warms up the local ASR fallback even when an external transcriber exists", async () => {
+    const primary = transcriber({ warmUp: vi.fn(async () => undefined) });
+    const fallback = transcriber({ warmUp: vi.fn(async () => undefined) });
+    const wrapped = createFallbackSubtitleTranscriber(primary, fallback);
+
+    await wrapped.warmUp?.();
+
+    expect(fallback.warmUp).toHaveBeenCalledTimes(1);
+    expect(primary.warmUp).not.toHaveBeenCalled();
+  });
+
+  it("falls back to local ASR when external ASR fails", async () => {
+    const onFallback = vi.fn();
+    const primary = transcriber({
+      transcribe: vi.fn(async () => {
+        throw new Error("network down");
+      }),
+    });
+    const fallback = transcriber({ transcribe: vi.fn(async () => localResult) });
+    const wrapped = createFallbackSubtitleTranscriber(primary, fallback, { onFallback });
+
+    await expect(
+      wrapped.transcribe({
+        mediaBlob: new Blob(["webm"], { type: "video/webm" }),
+        durationMs: 1_000,
+      }),
+    ).resolves.toBe(localResult);
+    expect(onFallback).toHaveBeenCalledWith(expect.any(Error));
+  });
+
+  it("does not fallback after a user cancellation", async () => {
+    const abortController = new AbortController();
+    abortController.abort();
+    const primary = transcriber({
+      transcribe: vi.fn(async () => {
+        throw new DOMException("字幕生成已取消", "AbortError");
+      }),
+    });
+    const fallback = transcriber({ transcribe: vi.fn(async () => localResult) });
+    const wrapped = createFallbackSubtitleTranscriber(primary, fallback);
+
+    await expect(
+      wrapped.transcribe({
+        mediaBlob: new Blob(["webm"], { type: "video/webm" }),
+        durationMs: 1_000,
+        signal: abortController.signal,
+      }),
+    ).rejects.toMatchObject({ name: "AbortError" });
+    expect(fallback.transcribe).not.toHaveBeenCalled();
+  });
+
+  it("falls back to local ASR when an external ASR request times out", async () => {
+    vi.useFakeTimers();
+    const fetchImpl: typeof fetch = vi.fn(
+      async (_url, init) =>
+        new Promise<Response>((_resolve, reject) => {
+          init?.signal?.addEventListener("abort", () => {
+            reject(new DOMException("aborted", "AbortError"));
+          });
+        }),
+    );
+    const primary = createExternalAsrSubtitleTranscriber({
+      config: externalConfig,
+      fetchImpl,
+      requestTimeoutMs: 1_000,
+    });
+    const fallback = transcriber({ transcribe: vi.fn(async () => localResult) });
+    const wrapped = createFallbackSubtitleTranscriber(primary, fallback);
+
+    const result = wrapped.transcribe({
+      mediaBlob: new Blob(["webm"], { type: "video/webm" }),
+      durationMs: 1_000,
+    });
+    const assertion = expect(result).resolves.toBe(localResult);
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    await assertion;
+    expect(fallback.transcribe).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not fallback when the user aborts a pending external ASR request", async () => {
+    const abortController = new AbortController();
+    const fetchImpl: typeof fetch = vi.fn(
+      async (_url, init) =>
+        new Promise<Response>((_resolve, reject) => {
+          init?.signal?.addEventListener("abort", () => {
+            reject(new DOMException("aborted", "AbortError"));
+          });
+        }),
+    );
+    const primary = createExternalAsrSubtitleTranscriber({
+      config: externalConfig,
+      fetchImpl,
+      requestTimeoutMs: 1_000,
+    });
+    const fallback = transcriber({ transcribe: vi.fn(async () => localResult) });
+    const wrapped = createFallbackSubtitleTranscriber(primary, fallback);
+
+    const result = wrapped.transcribe({
+      mediaBlob: new Blob(["webm"], { type: "video/webm" }),
+      durationMs: 1_000,
+      signal: abortController.signal,
+    });
+    abortController.abort();
+
+    await expect(result).rejects.toMatchObject({ name: "AbortError" });
+    expect(fallback.transcribe).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/features/subtitles/__tests__/subtitleAsrConfig.test.ts
+++ b/apps/web/src/features/subtitles/__tests__/subtitleAsrConfig.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from "vitest";
+import {
+  SUBTITLE_ASR_CONFIG_STORAGE_KEY,
+  clearExternalAsrConfig,
+  isExternalAsrConfigured,
+  loadExternalAsrConfig,
+  saveExternalAsrConfig,
+  type ExternalAsrConfig,
+} from "../subtitleAsrConfig";
+
+function createMemoryStorage(initial: Record<string, string> = {}) {
+  const map = new Map<string, string>(Object.entries(initial));
+  return {
+    map,
+    getItem: (key: string) => map.get(key) ?? null,
+    setItem: (key: string, value: string) => {
+      map.set(key, value);
+    },
+    removeItem: (key: string) => {
+      map.delete(key);
+    },
+  };
+}
+
+const validConfig: ExternalAsrConfig = {
+  provider: "openai-compatible",
+  baseURL: "https://api.example.com/v1",
+  apiKey: "sk-test",
+  model: "gpt-4o-mini-transcribe",
+  language: "zh",
+};
+
+describe("subtitleAsrConfig", () => {
+  it("round-trips a saved OpenAI-compatible ASR config", () => {
+    const storage = createMemoryStorage();
+    saveExternalAsrConfig(validConfig, storage);
+
+    expect(loadExternalAsrConfig(storage)).toEqual(validConfig);
+    expect(storage.map.has(SUBTITLE_ASR_CONFIG_STORAGE_KEY)).toBe(true);
+  });
+
+  it("trims fields and keeps language optional", () => {
+    const storage = createMemoryStorage({
+      [SUBTITLE_ASR_CONFIG_STORAGE_KEY]: JSON.stringify({
+        provider: "openai-compatible",
+        baseURL: "  https://api.example.com/v1  ",
+        apiKey: "  sk-test  ",
+        model: "  whisper-1  ",
+        language: "   ",
+      }),
+    });
+
+    expect(loadExternalAsrConfig(storage)).toEqual({
+      provider: "openai-compatible",
+      baseURL: "https://api.example.com/v1",
+      apiKey: "sk-test",
+      model: "whisper-1",
+      language: "",
+    });
+  });
+
+  it("rejects corrupted or unknown persisted providers", () => {
+    expect(loadExternalAsrConfig(createMemoryStorage())).toBeNull();
+    expect(
+      loadExternalAsrConfig(
+        createMemoryStorage({ [SUBTITLE_ASR_CONFIG_STORAGE_KEY]: "{not json" }),
+      ),
+    ).toBeNull();
+    expect(
+      loadExternalAsrConfig(
+        createMemoryStorage({
+          [SUBTITLE_ASR_CONFIG_STORAGE_KEY]: JSON.stringify({ ...validConfig, provider: "other" }),
+        }),
+      ),
+    ).toBeNull();
+  });
+
+  it("treats only complete configs as configured", () => {
+    expect(isExternalAsrConfigured(validConfig)).toBe(true);
+    expect(isExternalAsrConfigured({ ...validConfig, language: "" })).toBe(true);
+    expect(isExternalAsrConfigured(null)).toBe(false);
+    expect(isExternalAsrConfigured({ ...validConfig, baseURL: "" })).toBe(false);
+    expect(isExternalAsrConfigured({ ...validConfig, apiKey: "   " })).toBe(false);
+    expect(isExternalAsrConfigured({ ...validConfig, model: "" })).toBe(false);
+  });
+
+  it("clears a stored config and degrades when storage throws", () => {
+    const storage = createMemoryStorage();
+    saveExternalAsrConfig(validConfig, storage);
+    clearExternalAsrConfig(storage);
+    expect(loadExternalAsrConfig(storage)).toBeNull();
+
+    const throwingStorage = {
+      getItem: () => {
+        throw new Error("blocked");
+      },
+      setItem: () => {
+        throw new Error("blocked");
+      },
+      removeItem: () => {
+        throw new Error("blocked");
+      },
+    };
+    expect(loadExternalAsrConfig(throwingStorage)).toBeNull();
+    expect(() => saveExternalAsrConfig(validConfig, throwingStorage)).not.toThrow();
+    expect(() => clearExternalAsrConfig(throwingStorage)).not.toThrow();
+  });
+});

--- a/apps/web/src/features/subtitles/externalAsrSubtitleTranscriber.ts
+++ b/apps/web/src/features/subtitles/externalAsrSubtitleTranscriber.ts
@@ -1,0 +1,192 @@
+import type { ExternalAsrConfig } from "./subtitleAsrConfig";
+import type { SubtitleSegment, SubtitleTrackDraft, SubtitleTranscriber } from "./types";
+
+const DEFAULT_TRANSCRIPTION_LANGUAGE = "zh";
+const AUDIO_TRANSCRIPTIONS_PATH = "audio/transcriptions";
+export const DEFAULT_EXTERNAL_ASR_REQUEST_TIMEOUT_MS = 30_000;
+
+export class ExternalAsrTimeoutError extends Error {
+  constructor(readonly timeoutMs: number) {
+    super(`外部 ASR 请求超时（${Math.round(timeoutMs / 1000)} 秒）`);
+    this.name = "ExternalAsrTimeoutError";
+  }
+}
+
+type ExternalAsrResult = {
+  text?: unknown;
+  language?: unknown;
+  segments?: unknown;
+};
+
+type ExternalAsrSegment = {
+  start?: unknown;
+  end?: unknown;
+  text?: unknown;
+};
+
+export type ExternalAsrSubtitleTranscriberOptions = {
+  config: ExternalAsrConfig;
+  fetchImpl?: typeof fetch;
+  requestTimeoutMs?: number;
+};
+
+export function createExternalAsrSubtitleTranscriber(
+  options: ExternalAsrSubtitleTranscriberOptions,
+): SubtitleTranscriber {
+  const { config } = options;
+  const fetchImpl = options.fetchImpl ?? globalThis.fetch.bind(globalThis);
+  const requestTimeoutMs = options.requestTimeoutMs ?? DEFAULT_EXTERNAL_ASR_REQUEST_TIMEOUT_MS;
+
+  return {
+    async transcribe({ mediaBlob, durationMs, signal, onStatus }): Promise<SubtitleTrackDraft> {
+      if (signal?.aborted) throw new DOMException("字幕生成已取消", "AbortError");
+      onStatus?.("requesting-external-asr");
+      const body = new FormData();
+      body.append("file", mediaBlob, buildAudioFileName(mediaBlob));
+      body.append("model", config.model);
+      body.append("response_format", "verbose_json");
+      if (config.language.trim()) body.append("language", config.language.trim());
+
+      let response: Response;
+      const attempt = createExternalAsrAttemptSignal(signal, requestTimeoutMs);
+      try {
+        response = await fetchImpl(joinUrl(config.baseURL, AUDIO_TRANSCRIPTIONS_PATH), {
+          method: "POST",
+          headers: {
+            authorization: `Bearer ${config.apiKey}`,
+          },
+          body,
+          signal: attempt.signal,
+        });
+      } catch (error) {
+        if (attempt.didTimeout && !signal?.aborted) throw new ExternalAsrTimeoutError(requestTimeoutMs);
+        if (isAbortError(error)) throw error;
+        throw new Error(
+          `外部 ASR 请求失败：${error instanceof Error ? error.message : String(error)}`,
+        );
+      } finally {
+        attempt.dispose();
+      }
+      if (!response.ok) {
+        throw new Error(
+          `外部 ASR 返回 HTTP ${response.status}${response.statusText ? ` ${response.statusText}` : ""}`,
+        );
+      }
+      const payload = (await response.json().catch(() => {
+        throw new Error("外部 ASR 响应不是合法 JSON");
+      })) as ExternalAsrResult;
+
+      return {
+        model: config.model,
+        source: "external-asr",
+        language: readLanguage(payload),
+        segments: normalizeExternalAsrResult(payload, durationMs),
+      };
+    },
+  };
+}
+
+type ExternalAsrAttempt = {
+  signal: AbortSignal;
+  didTimeout: boolean;
+  dispose(): void;
+};
+
+function createExternalAsrAttemptSignal(
+  callerSignal: AbortSignal | undefined,
+  timeoutMs: number,
+): ExternalAsrAttempt {
+  const controller = new AbortController();
+  const attempt: ExternalAsrAttempt = {
+    signal: controller.signal,
+    didTimeout: false,
+    dispose: () => {},
+  };
+  const onCallerAbort = () => controller.abort();
+  if (callerSignal) {
+    if (callerSignal.aborted) controller.abort();
+    else callerSignal.addEventListener("abort", onCallerAbort, { once: true });
+  }
+  const timeoutId =
+    Number.isFinite(timeoutMs) && timeoutMs > 0
+      ? setTimeout(() => {
+          attempt.didTimeout = true;
+          controller.abort();
+        }, timeoutMs)
+      : null;
+  attempt.dispose = () => {
+    if (timeoutId !== null) clearTimeout(timeoutId);
+    callerSignal?.removeEventListener("abort", onCallerAbort);
+  };
+  return attempt;
+}
+
+export function normalizeExternalAsrResult(
+  result: ExternalAsrResult,
+  durationMs: number,
+): SubtitleSegment[] {
+  const rawSegments = Array.isArray(result.segments) ? result.segments : [];
+  const segments = rawSegments
+    .map((segment, index) => segmentFromExternalValue(segment, index, durationMs))
+    .filter((segment): segment is SubtitleSegment => Boolean(segment));
+  if (segments.length > 0)
+    return segments.map((segment, index) => ({ ...segment, id: `subtitle-${index + 1}` }));
+
+  const text = typeof result.text === "string" ? result.text.trim() : "";
+  if (!text) return [];
+  return [{ id: "subtitle-1", startMs: 0, endMs: Math.max(0, durationMs), text }];
+}
+
+function segmentFromExternalValue(
+  value: unknown,
+  index: number,
+  durationMs: number,
+): SubtitleSegment | null {
+  if (!isPlainObject(value)) return null;
+  const segment = value as ExternalAsrSegment;
+  const text = typeof segment.text === "string" ? segment.text.trim() : "";
+  if (!text) return null;
+  const startMs = clampMs(secondsToMs(readNumber(segment.start) ?? 0), durationMs);
+  const endMs = clampMs(secondsToMs(readNumber(segment.end) ?? durationMs / 1000), durationMs);
+  if (endMs <= startMs) return null;
+  return { id: `subtitle-${index + 1}`, startMs, endMs, text };
+}
+
+function readLanguage(result: ExternalAsrResult): string {
+  return typeof result.language === "string" && result.language.trim()
+    ? result.language.trim()
+    : DEFAULT_TRANSCRIPTION_LANGUAGE;
+}
+
+function buildAudioFileName(blob: Blob): string {
+  if (blob.type.includes("mp4")) return "recording.mp4";
+  if (blob.type.includes("mpeg") || blob.type.includes("mp3")) return "recording.mp3";
+  if (blob.type.includes("wav")) return "recording.wav";
+  return "recording.webm";
+}
+
+function joinUrl(baseURL: string, path: string): string {
+  return `${baseURL.replace(/\/+$/, "")}/${path.replace(/^\/+/, "")}`;
+}
+
+function readNumber(value: unknown): number | null {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+function secondsToMs(value: number): number {
+  return Math.round(value * 1000);
+}
+
+function clampMs(value: number, durationMs: number): number {
+  return Math.max(0, Math.min(Math.max(0, durationMs), value));
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isAbortError(error: unknown): boolean {
+  return error instanceof DOMException
+    ? error.name === "AbortError"
+    : error instanceof Error && error.name === "AbortError";
+}

--- a/apps/web/src/features/subtitles/fallbackSubtitleTranscriber.ts
+++ b/apps/web/src/features/subtitles/fallbackSubtitleTranscriber.ts
@@ -1,0 +1,36 @@
+import type { SubtitleTrackDraft, SubtitleTranscriber, SubtitleTranscriberInput } from "./types";
+
+export type FallbackSubtitleTranscriberOptions = {
+  onFallback?: (error: unknown) => void;
+};
+
+export function createFallbackSubtitleTranscriber(
+  primary: SubtitleTranscriber,
+  fallback: SubtitleTranscriber,
+  options: FallbackSubtitleTranscriberOptions = {},
+): SubtitleTranscriber {
+  return {
+    async warmUp() {
+      await fallback.warmUp?.();
+    },
+    async transcribe(input: SubtitleTranscriberInput): Promise<SubtitleTrackDraft> {
+      try {
+        return await primary.transcribe(input);
+      } catch (error) {
+        if (isAbortError(error) || input.signal?.aborted) throw error;
+        options.onFallback?.(error);
+        return fallback.transcribe(input);
+      }
+    },
+    dispose() {
+      primary.dispose?.();
+      fallback.dispose?.();
+    },
+  };
+}
+
+function isAbortError(error: unknown): boolean {
+  return error instanceof DOMException
+    ? error.name === "AbortError"
+    : error instanceof Error && error.name === "AbortError";
+}

--- a/apps/web/src/features/subtitles/subtitleAsrConfig.ts
+++ b/apps/web/src/features/subtitles/subtitleAsrConfig.ts
@@ -1,0 +1,98 @@
+export type ExternalAsrProvider = "openai-compatible";
+
+export type ExternalAsrConfig = {
+  provider: ExternalAsrProvider;
+  baseURL: string;
+  apiKey: string;
+  model: string;
+  language: string;
+};
+
+export const SUBTITLE_ASR_CONFIG_STORAGE_KEY = "code-tape:subtitle-asr";
+
+const VALID_PROVIDERS: ReadonlySet<string> = new Set<ExternalAsrProvider>(["openai-compatible"]);
+
+export function loadExternalAsrConfig(
+  storage: Pick<Storage, "getItem"> | undefined = safeStorage(),
+): ExternalAsrConfig | null {
+  if (!storage) return null;
+  let raw: string | null;
+  try {
+    raw = storage.getItem(SUBTITLE_ASR_CONFIG_STORAGE_KEY);
+  } catch {
+    return null;
+  }
+  if (!raw) return null;
+  try {
+    return normalizeConfig(JSON.parse(raw));
+  } catch {
+    return null;
+  }
+}
+
+export function saveExternalAsrConfig(
+  config: ExternalAsrConfig,
+  storage: Pick<Storage, "setItem"> | undefined = safeStorage(),
+): void {
+  if (!storage) return;
+  try {
+    storage.setItem(SUBTITLE_ASR_CONFIG_STORAGE_KEY, JSON.stringify(normalizeConfigStrict(config)));
+  } catch {
+    // localStorage can be unavailable; the app simply keeps using local ASR.
+  }
+}
+
+export function clearExternalAsrConfig(
+  storage: Pick<Storage, "removeItem"> | undefined = safeStorage(),
+): void {
+  if (!storage) return;
+  try {
+    storage.removeItem(SUBTITLE_ASR_CONFIG_STORAGE_KEY);
+  } catch {
+    // ignore
+  }
+}
+
+export function isExternalAsrConfigured(
+  config: ExternalAsrConfig | null,
+): config is ExternalAsrConfig {
+  if (!config) return false;
+  return (
+    VALID_PROVIDERS.has(config.provider) &&
+    config.baseURL.trim().length > 0 &&
+    config.apiKey.trim().length > 0 &&
+    config.model.trim().length > 0
+  );
+}
+
+function normalizeConfig(value: unknown): ExternalAsrConfig | null {
+  if (typeof value !== "object" || value === null) return null;
+  const record = value as Record<string, unknown>;
+  const provider = record.provider;
+  if (typeof provider !== "string" || !VALID_PROVIDERS.has(provider)) return null;
+  return {
+    provider: provider as ExternalAsrProvider,
+    baseURL: typeof record.baseURL === "string" ? record.baseURL.trim() : "",
+    apiKey: typeof record.apiKey === "string" ? record.apiKey.trim() : "",
+    model: typeof record.model === "string" ? record.model.trim() : "",
+    language: typeof record.language === "string" ? record.language.trim() : "",
+  };
+}
+
+function normalizeConfigStrict(config: ExternalAsrConfig): ExternalAsrConfig {
+  return {
+    provider: config.provider,
+    baseURL: config.baseURL.trim(),
+    apiKey: config.apiKey.trim(),
+    model: config.model.trim(),
+    language: config.language.trim(),
+  };
+}
+
+function safeStorage(): Storage | undefined {
+  try {
+    return typeof globalThis !== "undefined" ? globalThis.localStorage : undefined;
+  } catch {
+    return undefined;
+  }
+}

--- a/apps/web/src/features/subtitles/subtitleTranscriber.ts
+++ b/apps/web/src/features/subtitles/subtitleTranscriber.ts
@@ -70,9 +70,10 @@ export function createHuggingFaceSubtitleTranscriber(
   let pipelinePromise: Promise<AsrPipeline> | null = null;
   const getPipeline = () => {
     if (!pipelinePromise) {
-      pipelinePromise = (options.pipelineFactory
-        ? options.pipelineFactory("automatic-speech-recognition", model, pipelineOptions)
-        : loadDefaultPipeline("automatic-speech-recognition", model, pipelineOptions)
+      pipelinePromise = (
+        options.pipelineFactory
+          ? options.pipelineFactory("automatic-speech-recognition", model, pipelineOptions)
+          : loadDefaultPipeline("automatic-speech-recognition", model, pipelineOptions)
       ).catch((error: unknown) => {
         pipelinePromise = null;
         throw error;
@@ -85,10 +86,12 @@ export function createHuggingFaceSubtitleTranscriber(
     async warmUp() {
       await getPipeline();
     },
-    async transcribe({ mediaBlob, durationMs, signal }) {
+    async transcribe({ mediaBlob, durationMs, signal, onStatus }) {
       if (signal?.aborted) throw new DOMException("字幕生成已取消", "AbortError");
+      onStatus?.("loading-local-model");
       const pipeline = await getPipeline();
       if (signal?.aborted) throw new DOMException("字幕生成已取消", "AbortError");
+      onStatus?.("transcribing");
       const url = URL.createObjectURL(mediaBlob);
       try {
         const result = await pipeline(url, TRANSCRIPTION_OPTIONS);
@@ -110,9 +113,15 @@ async function loadDefaultPipeline(
   model: string,
   options: AsrPipelineOptions,
 ): Promise<AsrPipeline> {
-  return loadTransformersPipeline<AsrPipeline>(task, model, options, {}, {
-    vendored: model === DEFAULT_TRANSCRIPTION_MODEL,
-  });
+  return loadTransformersPipeline<AsrPipeline>(
+    task,
+    model,
+    options,
+    {},
+    {
+      vendored: model === DEFAULT_TRANSCRIPTION_MODEL,
+    },
+  );
 }
 
 function segmentFromChunk(

--- a/apps/web/src/features/subtitles/types.ts
+++ b/apps/web/src/features/subtitles/types.ts
@@ -9,7 +9,7 @@ export type SubtitleTrack = {
   recordingId: string;
   generatedAt: string;
   model: string;
-  source: "huggingface-local" | "backend-job";
+  source: "huggingface-local" | "external-asr" | "backend-job";
   language?: string;
   segments: SubtitleSegment[];
 };
@@ -73,12 +73,19 @@ export type SubtitleTranscriberInput = {
   mediaBlob: Blob;
   durationMs: number;
   signal?: AbortSignal;
+  onStatus?: (status: SubtitleTranscriptionStatus) => void;
 };
 
 export type SubtitleTranscriber = {
   warmUp?(): Promise<void>;
   transcribe(input: SubtitleTranscriberInput): Promise<SubtitleTrackDraft>;
+  dispose?(): void;
 };
+
+export type SubtitleTranscriptionStatus =
+  | "loading-local-model"
+  | "requesting-external-asr"
+  | "transcribing";
 
 export type SubtitleStore = {
   load(recordingId: string): Promise<SubtitleTrack | null>;


### PR DESCRIPTION
## 关联

Refs #2（总控 issue，不在本 PR 中关闭）

## 改动点

- 新增 OpenAI-compatible 外部 ASR 配置与 `/audio/transcriptions` 请求转写器。
- 字幕生成优先请求外部 ASR，失败时自动回退本地 `whisper-tiny`。
- ASR 在字幕面板挂载后立即预热，并在生成过程中展示模型加载、外部请求、音频识别和 LLM 后处理状态。
- 补充 ASR 配置、外部转写、fallback 和字幕面板状态测试。

## 影响范围

- 影响回放页字幕面板的 ASR 生成入口、ASR 预热时机和状态文案。
- 外部 ASR API Key 仅存本机 localStorage，仅发往用户配置的转写 endpoint。
- 不改变 LLM 后处理契约；ASR 完成后仍先展示原始字幕，再由 LLM 二次刷新字幕和章节。

## GitNexus 影响分析摘要

- 风险等级: advisory（`npm run quality:predev` / `contract:local` 通过；开发中 `detect_changes` 曾标记字幕主链路为 critical）
- 关键骨架变更: 字幕生成主链路新增外部 ASR 优先与本地 ASR fallback；`SubtitlePanel` 新增 ASR 预热与状态展示
- GitNexus 影响面: ASR `transcribe` 流程、`SubtitlePanel` 主操作生成/后处理路径、外部配置读取路径
- 验证结果: `quality:precommit` 通过；`quality:local` 通过；Web 测试 843 passed；Playwright e2e 7 passed；本轮补跑 `npm run quality:predev` 通过

## AI 字幕验证记录

- `npm run subtitle:postprocess:evaluate`: `representativeOutputSource=postprocessor-runner`，`overallEvaluationDurationMs=1.6765`，代表样本通过率 1；该耗时为 fixture 输出校验耗时，不代表真实端到端 ASR + LLM 耗时。
- `npm run subtitle:postprocess:runtime-benchmark`: `postprocessClickToResultReadyDurationMs=37.802`，`postProcessTimeoutBudgetMs=60000`，`playbackProbeResponsiveDuringPostprocess=true`；该基准使用 jsdom mock postprocessor，覆盖点击到结果 ready 的 UI/worker 链路，不代表真实模型端到端耗时。

## 自检

- [x] 未修改 `docs/progress.json` 或 `docs/progress.md`
- [x] 已运行 `npm run quality:local`，或说明无法运行的原因
- [x] 涉及 AI 字幕时，已记录一次 `npm run subtitle:postprocess:evaluate` 的“纠错并生成章节”效果验证结果，包含 `representativeOutputSource`、`overallEvaluationDurationMs`，并区分输出校验耗时与真实端到端耗时
- [x] 涉及 AI 字幕点击链路、LLM worker、模型加载或性能时，已记录一次 `npm run subtitle:postprocess:runtime-benchmark` 结果，包含 `postprocessClickToResultReadyDurationMs`、`postProcessTimeoutBudgetMs` 和 `playbackProbeResponsiveDuringPostprocess`
- [x] 已说明改动点和影响范围
- [x] 如果改动关键骨架，已补充契约测试并填写 GitNexus 影响分析摘要
- [ ] 已等待 repo-guard、codex 和 Copilot 评论，并完成必要审查
